### PR TITLE
Run //tools/android/... in bazel-tests.

### DIFF
--- a/jenkins/jobs/BUILD
+++ b/jenkins/jobs/BUILD
@@ -177,6 +177,7 @@ bazel_github_job(
         "//scripts/...",
         "//src/...",
         "//third_party/ijar/...",
+        "//tools/android/...",
     ],
     windows_targets = [
         "//src:bazel",


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/continuous-integration/issues/69.

These are some small python and shell scripts for the tools that the Android rules invoke in SpawnActions.