### PR TITLE
Fixed gcloud project setting command

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -22,7 +22,7 @@ Gcloud:
 
     ```
     gcloud auth login
-    gcloud set project bazel-public
+    gcloud config set project bazel-public
     ```
 
 ## Pushing changes


### PR DESCRIPTION
`gcloud set project` has been moved to the `gcloud config` subcommand.