### PR TITLE
Add Global Dashboard to monitor.

### DIFF
--- a/jenkins/config/config.xml.tpl
+++ b/jenkins/config/config.xml.tpl
@@ -81,6 +81,24 @@
       <recurse>true</recurse>
       <statusFilter>true</statusFilter>
     </com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView>
+    <com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView>
+      <owner class="hudson" reference="../../.."/>
+      <name>Global Dashboard</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+      <jobNames/>
+      <jobFilters/>
+      <columns/>
+      <title>Bazel Tests</title>
+      <config>
+        <displayCommitters>false</displayCommitters>
+        <order class="com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ByStatus"/>
+      </config>
+      <includeRegex>Global/.*</includeRegex>
+      <recurse>true</recurse>
+      <statusFilter>true</statusFilter>
+    </com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView>
   </views>
   <primaryView>Projects</primaryView>
   <nodeProperties/>

--- a/jenkins/config/config.xml.tpl
+++ b/jenkins/config/config.xml.tpl
@@ -75,7 +75,7 @@
       <title>Bazel Tests</title>
       <config>
         <displayCommitters>false</displayCommitters>
-        <order class="com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ByName"/>
+        <order class="com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ByStatus"/>
       </config>
       <includeRegex>(bazel/nightly|bazel/release|(?!.*/).*)</includeRegex>
       <recurse>true</recurse>

--- a/jenkins/config/config.xml.tpl
+++ b/jenkins/config/config.xml.tpl
@@ -90,7 +90,7 @@
       <jobNames/>
       <jobFilters/>
       <columns/>
-      <title>Bazel Tests</title>
+      <title>Global Dashboard</title>
       <config>
         <displayCommitters>false</displayCommitters>
         <order class="com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ByStatus"/>


### PR DESCRIPTION
Helps the Bazel Sheriff monitor breakages caused by the nightlies and bazel built @ HEAD.