### PR TITLE
Add bazel-buildfarm to the list of projects.

### DIFF
--- a/jenkins/jobs/BUILD
+++ b/jenkins/jobs/BUILD
@@ -143,6 +143,7 @@ bazel_github_job(
 
 # Jobs from the bazelbuild org using the default configuration
 [bazel_github_job(name = n) for n in [
+    "bazel-buildfarm",
     "bazel-watcher",
     "migration-tooling",
     "rules_appengine",


### PR DESCRIPTION
Since bazel-buildfarm setup is simple, default config works
great for it.

Fixes bazelbuild/bazel-buildfarm#100