### PR TITLE
Remove excluded tests.

### DIFF
--- a/jenkins/jobs/configs/rules_webtesting.json
+++ b/jenkins/jobs/configs/rules_webtesting.json
@@ -10,9 +10,7 @@
             }
         ],
         "parameters": {
-            // Disable chrome55-win10 test until https://github.com/bazelbuild/rules_webtesting/issues/188
-            // is resolved.
-            "tests": ["tests(//...) - //go/launcher/webdriver:go_default_test_chrome55-win10"],
+            "tests": ["tests(//...)"],
         }
     }
 ]


### PR DESCRIPTION
Excluding tests this way makes it difficult to make changes.
In the future prefer to add "noci" tag to tests in the rules_webtesting
project.