### PR TITLE
Upgrade Android NDK version to 15c.

### DIFF
--- a/buildkite/install-android-sdk.sh
+++ b/buildkite/install-android-sdk.sh
@@ -16,7 +16,7 @@
 
 # Android NDK
 cd /opt
-curl -sSLo android-ndk.zip https://dl.google.com/android/repository/android-ndk-r14b-linux-x86_64.zip
+curl -sSLo android-ndk.zip https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip
 unzip android-ndk.zip > /dev/null
 rm android-ndk.zip
 

--- a/buildkite/install-buildkite-agent.sh
+++ b/buildkite/install-buildkite-agent.sh
@@ -45,7 +45,7 @@ cat > /etc/buildkite-agent/hooks/environment <<'EOF'
 set -eu
 
 export ANDROID_HOME="/opt/android-sdk-linux"
-export ANDROID_NDK_HOME="/opt/android-ndk-r14b"
+export ANDROID_NDK_HOME="/opt/android-ndk-r15c"
 export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="gs://bazel-buildkite-artifacts/$BUILDKITE_JOB_ID"
 export BUILDKITE_GS_ACL="publicRead"
 EOF

--- a/buildkite/setup-windows-manual.ps1
+++ b/buildkite/setup-windows-manual.ps1
@@ -190,15 +190,15 @@ New-Item "c:\bazel" -ItemType "directory" -Force
 $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";c:\bazel"
 [Environment]::SetEnvironmentVariable("PATH", $env:PATH, "Machine")
 
-## Download the Android NDK and install into C:\android-ndk-r14b.
-$android_ndk_url = "https://dl.google.com/android/repository/android-ndk-r14b-windows-x86_64.zip"
+## Download the Android NDK and install into C:\android-ndk-r15c.
+$android_ndk_url = "https://dl.google.com/android/repository/android-ndk-r15c-windows-x86_64.zip"
 $android_ndk_zip = "c:\temp\android_ndk.zip"
 $android_ndk_root = "c:\android_ndk"
 New-Item $android_ndk_root -ItemType "directory" -Force
 (New-Object Net.WebClient).DownloadFile($android_ndk_url, $android_ndk_zip)
 [System.IO.Compression.ZipFile]::ExtractToDirectory($android_ndk_zip, $android_ndk_root)
-Rename-Item "${android_ndk_root}\android-ndk-r14b" -NewName "r14b"
-[Environment]::SetEnvironmentVariable("ANDROID_NDK_HOME", "${android_ndk_root}\r14b", "Machine")
+Rename-Item "${android_ndk_root}\android-ndk-r15c" -NewName "r15c"
+[Environment]::SetEnvironmentVariable("ANDROID_NDK_HOME", "${android_ndk_root}\r15c", "Machine")
 $env:ANDROID_NDK_HOME = [Environment]::GetEnvironmentVariable("ANDROID_NDK_HOME", "Machine")
 Remove-Item $android_ndk_zip
 

--- a/buildkite/setup-windows.ps1
+++ b/buildkite/setup-windows.ps1
@@ -189,15 +189,15 @@ New-Item "c:\bazel" -ItemType "directory" -Force
 $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";c:\bazel"
 [Environment]::SetEnvironmentVariable("PATH", $env:PATH, "Machine")
 
-## Download the Android NDK and install into C:\android-ndk-r14b.
-$android_ndk_url = "https://dl.google.com/android/repository/android-ndk-r14b-windows-x86_64.zip"
+## Download the Android NDK and install into C:\android-ndk-r15c.
+$android_ndk_url = "https://dl.google.com/android/repository/android-ndk-r15c-windows-x86_64.zip"
 $android_ndk_zip = "c:\temp\android_ndk.zip"
 $android_ndk_root = "c:\android_ndk"
 New-Item $android_ndk_root -ItemType "directory" -Force
 (New-Object Net.WebClient).DownloadFile($android_ndk_url, $android_ndk_zip)
 [System.IO.Compression.ZipFile]::ExtractToDirectory($android_ndk_zip, $android_ndk_root)
-Rename-Item "${android_ndk_root}\android-ndk-r14b" -NewName "r14b"
-[Environment]::SetEnvironmentVariable("ANDROID_NDK_HOME", "${android_ndk_root}\r14b", "Machine")
+Rename-Item "${android_ndk_root}\android-ndk-r15c" -NewName "r15c"
+[Environment]::SetEnvironmentVariable("ANDROID_NDK_HOME", "${android_ndk_root}\r15c", "Machine")
 $env:ANDROID_NDK_HOME = [Environment]::GetEnvironmentVariable("ANDROID_NDK_HOME", "Machine")
 Remove-Item $android_ndk_zip
 


### PR DESCRIPTION
android_ndk_integration_test has been updated to pass with r15, and will fail with r14.

While the test is disabled due to https://github.com/bazelbuild/bazel/issues/4663, lets upgrade the NDK. I'm currently investigating the cause of failure when using remote caching.