### PR TITLE
Support subtractive patterns in build_targets and test_targets.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -671,7 +671,7 @@ def execute_bazel_build(bazel_binary, platform, flags, targets, bep_file):
         caching_flags = remote_caching_flags(platform)
     try:
         execute_command([bazel_binary, "build"] +
-                        common_flags + caching_flags + flags + targets)
+                        common_flags + caching_flags + flags + ["--"] + targets)
     except subprocess.CalledProcessError as e:
         raise BazelBuildFailedException(
             "bazel build failed with exit code {}".format(e.returncode))
@@ -689,7 +689,7 @@ def execute_bazel_test(bazel_binary, platform, flags, targets, bep_file):
         caching_flags = remote_caching_flags(platform)
     try:
         execute_command([bazel_binary, "test"] +
-                        common_flags + caching_flags + flags + targets)
+                        common_flags + caching_flags + flags + ["--"] + targets)
     except subprocess.CalledProcessError as e:
         raise BazelTestFailedException(
             "bazel test failed with exit code {}".format(e.returncode))


### PR DESCRIPTION
Wanted to skip some tests in https://github.com/bazelbuild/rules_rust/pull/61, figured it was better to support negation than manually expand it.

(I have no idea if this breaks anything downstream of the actual bazel invocations, feel free to reject or lmk if there are other issues)