### PR TITLE
Add config to test android_instrumentation_test samples

### DIFF
--- a/buildkite/install-android-sdk.sh
+++ b/buildkite/install-android-sdk.sh
@@ -38,6 +38,8 @@ expect {
 
 # This should be kept in sync with mac/mac-android.sh.
 tools/bin/sdkmanager \
+  "emulator" \
+  "system-images;android-23;default;x86" \
   "platform-tools" \
   "build-tools;27.0.3" \
   "platforms;android-24" \

--- a/buildkite/pipelines/android-testing-postsubmit.yml
+++ b/buildkite/pipelines/android-testing-postsubmit.yml
@@ -1,0 +1,17 @@
+# https://github.com/googlesamples/android-testing#experimental-bazel-support
+---
+platforms:
+  ubuntu1404:
+    build_targets:
+    - "//ui/..."
+    test_flags:
+    - "--spawn_strategy=local" # Required due to unified launcher bug
+    test_targets:
+    - "//ui/..."
+  ubuntu1604:
+    build_targets:
+    - "//ui/..."
+    test_flags:
+    - "--spawn_strategy=local" # Required due to unified launcher bug
+    test_targets:
+    - "//ui/..."

--- a/buildkite/setup-ubuntu.sh
+++ b/buildkite/setup-ubuntu.sh
@@ -70,5 +70,8 @@ packages=(
 
   # Required by our infrastructure.
   lvm2
+
+  # Required by Android projects using the Skylark maven_{jar, aar} rules
+  maven
 )
 apt-get -qqy install "${packages[@]}" > /dev/null


### PR DESCRIPTION
Now that KVM is enabled, we can finally run emulators on the CI. This also means that we can do e2e `android_instrumentation_test` runs. 

I'm using https://github.com/googlesamples/android-testing#experimental-bazel-support as the canonical examples, and have verified that they pass with Bazel on master on the Ubuntu test CI machines with the following additional configuration:

1) Installing `maven` for Skylark `maven_aar` rule
2) Installing `emulator` and `system-images;android-23;default;x86` in the SDK
3) Creating a `kvm` group, adding myself (`jingwen`) to `kvm` group, and `chown /dev/kvm` to `root:kvm`. The original chown-er was `root:root`.
4) Creating `/etc/udev/rules.d/65-kvm.rules` with content:

```
KERNEL=="kvm", NAME="%k", GROUP="kvm", MODE="0660"
```
5) Restarting the machine to use the new configuration.

I needed to run steps 3 to 5 because my user `jingwen` didn't have permissions to use KVM. I'm not sure if the CI user needs it, so I haven't added this to the configuration. @philwo, please advise?