### PR TITLE
Build Tensorflow's Android example for postsubmit

### DIFF
--- a/buildkite/pipelines/tensorflow-postsubmit.yml
+++ b/buildkite/pipelines/tensorflow-postsubmit.yml
@@ -5,16 +5,27 @@ platforms:
     - |-
       echo -e '
       import %workspace%/.bazelrc' >>bazel.bazelrc
+    - |-
+      echo -e '
+      android_sdk_repository(name = "androidsdk")
+      android_ndk_repository(name = "androidndk")' >>WORKSPACE
     - touch .bazelrc
     - "./tensorflow/tools/ci_build/builds/configured CPU"
     build_targets:
     - "//tensorflow/tools/pip_package:build_pip_package"
+    - "//tensorflow/examples/android:tensorflow_demo"
   ubuntu1604:
     shell_commands:
     - |-
       echo -e '
       import %workspace%/.bazelrc' >>bazel.bazelrc
+    - |- 
+      echo -e '
+      android_sdk_repository(name = "androidsdk")
+      android_ndk_repository(name = "androidndk")' >>WORKSPACE
     - touch .bazelrc
     - "./tensorflow/tools/ci_build/builds/configured CPU"
     build_targets:
     - "//tensorflow/tools/pip_package:build_pip_package"
+    - "//tensorflow/examples/android:tensorflow_demo"
+


### PR DESCRIPTION
This gives us a build_test that utilizes much of the NDK. Successfully built on test machine with the latest deployed image and Bazel 0.12.0rc1.