### PR TITLE
Remove `-e` flag from Tensorflow pipeline config

### DIFF
--- a/buildkite/pipelines/tensorflow-postsubmit.yml
+++ b/buildkite/pipelines/tensorflow-postsubmit.yml
@@ -3,10 +3,10 @@ platforms:
   ubuntu1404:
     shell_commands:
     - |-
-      echo -e '
+      echo '
       import %workspace%/.bazelrc' >>bazel.bazelrc
     - |-
-      echo -e '
+      echo '
       android_sdk_repository(name = "androidsdk")
       android_ndk_repository(name = "androidndk")' >>WORKSPACE
     - touch .bazelrc
@@ -17,10 +17,10 @@ platforms:
   ubuntu1604:
     shell_commands:
     - |-
-      echo -e '
+      echo '
       import %workspace%/.bazelrc' >>bazel.bazelrc
     - |- 
-      echo -e '
+      echo '
       android_sdk_repository(name = "androidsdk")
       android_ndk_repository(name = "androidndk")' >>WORKSPACE
     - touch .bazelrc


### PR DESCRIPTION
In pipeline yaml, `echo -e` actually echoes the string `-e` into the file, resulting in:

`bazel.bazelrc`:

```
-e 
import %workspace%/.bazelrc
```

and `WORKSPACE`:

```
...

new_http_archive(
    name = "speech_commands",
    build_file = "models.BUILD",
    sha256 = "c3ec4fea3158eb111f1d932336351edfe8bd515bb6e87aad4f25
dbad0a600d0c",
    urls = [
        "http://storage.googleapis.com/download.tensorflow.org/mod
els/speech_commands_v0.01.zip",
        "http://download.tensorflow.org/models/speech_commands_v0.
01.zip",
    ],
)
-e
android_sdk_repository(name = "androidsdk")
android_ndk_repository(name = "androidndk")
```

Turns out that `-e` was never parsed nor used in https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/pipelines/tensorflow-postsubmit.yml

This surfaced in https://buildkite.com/bazel/tensorflow/builds/175#d4739c3a-357a-43c8-a64f-524d0dd279ed