### PR TITLE
Install Android system images for APIs 19, 21 and 22.

### DIFF
--- a/buildkite/install-android-sdk.sh
+++ b/buildkite/install-android-sdk.sh
@@ -46,6 +46,9 @@ tools/bin/sdkmanager \
   "platforms;android-25" \
   "platforms;android-26" \
   "platforms;android-27" \
+  "system-images;android-19;default;x86" \
+  "system-images;android-21;default;x86" \
+  "system-images;android-22;default;x86" \
   "system-images;android-23;default;x86" \
   > /dev/null
 chown -R root:root /opt/android*


### PR DESCRIPTION
This is for testing against multiple emulator API levels in
the Android Testing project.

https://buildkite.com/bazel/android-testing/builds/10#6c9f1d2b-bb05-424d-9aea-b810adb9bd10