### PR TITLE
Remove Android Testing from downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -79,10 +79,11 @@ def eprint(*args, **kwargs):
 
 def downstream_projects():
     return {
-        "Android Testing": {
-            "git_repository": "https://github.com/googlesamples/android-testing.git",
-            "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/pipelines/android-testing-postsubmit.yml"
-        },
+        # Removed until issues in https://github.com/bazelbuild/bazel/issues/4979 is fully resolved
+        # "Android Testing": {
+        #    "git_repository": "https://github.com/googlesamples/android-testing.git",
+        #    "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/pipelines/android-testing-postsubmit.yml"
+        # },
         "Bazel Remote Execution": {
             "git_repository": "https://github.com/bazelbuild/bazel.git",
             "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/pipelines/bazel-remote-execution-postsubmit.yml"


### PR DESCRIPTION
Blocked on issues in https://github.com/bazelbuild/bazel/issues/4979