### PR TITLE
Remove Maven from install script

### DIFF
--- a/buildkite/setup-ubuntu.sh
+++ b/buildkite/setup-ubuntu.sh
@@ -129,7 +129,7 @@ esac
     # Required by our infrastructure.
     lvm2
 
-    # Required by Android projects that launches the Android emulator headlessly
+    # Required by Android projects that launche the Android emulator headlessly
     # (see https://github.com/bazelbuild/continuous-integration/pull/246)
     cpu-checker
     qemu-system-x86

--- a/buildkite/setup-ubuntu.sh
+++ b/buildkite/setup-ubuntu.sh
@@ -129,10 +129,9 @@ esac
     # Required by our infrastructure.
     lvm2
 
-    # Required by Android projects using the Skylark maven_{jar, aar} rules.
+    # Required by Android projects that launches the Android emulator headlessly
     # (see https://github.com/bazelbuild/continuous-integration/pull/246)
     cpu-checker
-    maven
     qemu-system-x86
     unzip
     xvfb

--- a/buildkite/setup-ubuntu.sh
+++ b/buildkite/setup-ubuntu.sh
@@ -129,7 +129,7 @@ esac
     # Required by our infrastructure.
     lvm2
 
-    # Required by Android projects that launche the Android emulator headlessly
+    # Required by Android projects that launch the Android emulator headlessly
     # (see https://github.com/bazelbuild/continuous-integration/pull/246)
     cpu-checker
     qemu-system-x86


### PR DESCRIPTION
Maven is no longer needed to download AARs/JARs.