### PR TITLE
Fix TF config

### DIFF
--- a/buildkite/pipelines/tensorflow-postsubmit.yml
+++ b/buildkite/pipelines/tensorflow-postsubmit.yml
@@ -32,7 +32,6 @@ platforms:
     batch_commands:
     - "echo.| python ./configure.py"
     build_flags:
-    - "-c opt"
     - "--copt=-w"
     - "--host_copt=-w"
     - "--define=override_eigen_strong_inline=true"


### PR DESCRIPTION
It's causing the failure of https://buildkite.com/bazel/tensorflow/builds/564#90e67c1b-c30c-4aad-bad2-6b4519aa00fc

It's fine to remove it because `-c opt` already exists in `tensorflow/tools/bazel.rc`