### PR TITLE
bazelci.py: remove deprecated (no-op) flag

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -666,13 +666,11 @@ def remote_caching_flags(platform):
                         "--tls_enabled",
                         "--project_id=bazel-public",
                         "--remote_instance_name=projects/bazel-public",
-                        "--experimental_remote_spawn_cache",
                         "--remote_timeout=10",
                         "--remote_cache=remotebuildexecution.googleapis.com",
                         "--experimental_remote_platform_override=properties:{name:\"platform\" value:\"" + platform + "\"}"]
     else:
         common_flags = ["--remote_timeout=10",
-                        "--experimental_remote_spawn_cache",
                         "--experimental_remote_platform_override=properties:{name:\"platform\" value:\"" + platform + "\"}",
                         "--remote_http_cache=https://storage.googleapis.com/bazel-buildkite-cache"]
     if platform in ["ubuntu1404", "ubuntu1604", "macos", "windows"]:


### PR DESCRIPTION
Remove --experimental_remote_spawn_cache from
bazelci.py, because it is a no-op and it's
deprecated since commit cdf118a6 [1], and Bazel
gives a warning about it in every CI run.

[1] https://github.com/bazelbuild/bazel/commit/cdf118a607ab179807cd39d0cafdb551859d1cd1