### PR TITLE
TensorFlow pipeline: fix --copt flag value

### DIFF
--- a/buildkite/pipelines/tensorflow-postsubmit.yml
+++ b/buildkite/pipelines/tensorflow-postsubmit.yml
@@ -12,10 +12,10 @@ platforms:
     - touch .bazelrc
     - "./tensorflow/tools/ci_build/builds/configured CPU"
     build_flags:
-    # TODO(laszlocsomor): remove "--cxxopt='--std=c++11'" after cr/200219133
+    # TODO(laszlocsomor): remove "--cxxopt=--std=c++11" after cr/200219133
     # is merged to upstream TensorFlow, it's a temporary workaround for
     # https://github.com/bazelbuild/bazel/issues/5365.
-    - "--cxxopt='--std=c++11'"
+    - "--cxxopt=--std=c++11"
     build_targets:
     - "//tensorflow/tools/pip_package:build_pip_package"
     - "//tensorflow/examples/android:tensorflow_demo"
@@ -31,10 +31,10 @@ platforms:
     - touch .bazelrc
     - "./tensorflow/tools/ci_build/builds/configured CPU"
     build_flags:
-    # TODO(laszlocsomor): remove "--cxxopt='--std=c++11'" after cr/200219133
+    # TODO(laszlocsomor): remove "--cxxopt=--std=c++11" after cr/200219133
     # is merged to upstream TensorFlow, it's a temporary workaround for
     # https://github.com/bazelbuild/bazel/issues/5365.
-    - "--cxxopt='--std=c++11'"
+    - "--cxxopt=--std=c++11"
     build_targets:
     - "//tensorflow/tools/pip_package:build_pip_package"
     - "//tensorflow/examples/android:tensorflow_demo"
@@ -45,9 +45,9 @@ platforms:
     - "--copt=-w"
     - "--host_copt=-w"
     - "--define=override_eigen_strong_inline=true"
-    # TODO(laszlocsomor): remove "--cxxopt='--std=c++11'" after cr/200219133
+    # TODO(laszlocsomor): remove "--cxxopt=--std=c++11" after cr/200219133
     # is merged to upstream TensorFlow, it's a temporary workaround for
     # https://github.com/bazelbuild/bazel/issues/5365.
-    - "--cxxopt='--std=c++11'"
+    - "--cxxopt=--std=c++11"
     build_targets:
     - "//tensorflow/tools/pip_package:build_pip_package"


### PR DESCRIPTION
The TensorFlow pipeline is failing because of a
bad `--copt` flag value that https://github.com/bazelbuild/continuous-integration/commit/269c686c0f2633ea9f02da89b3374bc1074748a2
added.