### PR TITLE
Disable --reference on macOS temporarily.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -627,10 +627,11 @@ def clone_git_repository(git_repository, platform):
             execute_command(
                 ["git", "clone", "--recurse-submodules", "--reference",
                  "/var/lib/bazelbuild", git_repository, clone_path])
-        elif platform in ["macos"]:
-            execute_command(
-                ["git", "clone", "--recurse-submodules", "--reference",
-                 "/usr/local/var/bazelbuild", git_repository, clone_path])
+        # TODO(philwo): Re-enable this once issue #293 is fixed.
+        # elif platform in ["macos"]:
+        #     execute_command(
+        #         ["git", "clone", "--recurse-submodules", "--reference",
+        #          "/usr/local/var/bazelbuild", git_repository, clone_path])
         elif platform in ["windows"]:
             execute_command(
                 ["git", "clone", "--recurse-submodules", "--reference",


### PR DESCRIPTION
We'll need to add the Git reference directory to the machines for this to work, but currently don't have SSH access.

I'll setup the reference directory once SSH access works again and then re-enable this feature on macOS.

Updates #293.