### PR TITLE
Don't test Gerrit on Ubuntu 14.04

### DIFF
--- a/buildkite/pipelines/gerrit-postsubmit.yml
+++ b/buildkite/pipelines/gerrit-postsubmit.yml
@@ -1,12 +1,5 @@
 ---
 platforms:
-  ubuntu1404:
-    build_targets:
-    - "//:release"
-    test_flags:
-    - "--test_tag_filters=-slow"
-    test_targets:
-    - "..."
   ubuntu1604:
     build_targets:
     - "//:release"


### PR DESCRIPTION
It's broken, because it requires Git 2.2, which is not available on that version of Ubuntu: https://github.com/bazelbuild/bazel/issues/5712