### PR TITLE
Don't restart Windows VMs on failure.

### DIFF
--- a/buildkite/create_instances.py
+++ b/buildkite/create_instances.py
@@ -88,6 +88,7 @@ INSTANCE_GROUPS = {
         'image_family': 'buildkite-worker-windows-java8',
         'local_ssd': 'interface=scsi',
         'metadata_from_file': 'windows-startup-script-ps1=startup-windows.ps1',
+        'restart-on-failure': false,
     },
 }
 


### PR DESCRIPTION
This should fix #311, because it prevents the VMs from getting into an unsupported state where the local SSD loses its data, but the persistent disk is still there and has registry entries pointing to (now no longer existing) directories on the local SSD.

The instance group should automatically create a new VM in case one is terminated, so this doesn't impact availability of our CI workers.