### PR TITLE
Update CI_HOME to use home directory.

### DIFF
--- a/gce/freebsd-ci-homedir.sh
+++ b/gce/freebsd-ci-homedir.sh
@@ -14,7 +14,7 @@
 
 # Setup the required file structure in the ci's home directory
 
-CI_HOME="$(echo ~ci)"
+CI_HOME="$(echo ~/ci)"
 PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
 BAZEL_VERSION="$(pkg query '%v' bazel)"
 destination="${CI_HOME}/.bazel/${BAZEL_VERSION}"


### PR DESCRIPTION
Current output for CI_HOME:
```
$ echo ~ci
~ci
```

Expected output for CI_HOME:
```
$ echo ~/ci
/root/ci
```