### PR TITLE
Add platforms;android-28 and build-tools;28.0.2 to the Android SDK

### DIFF
--- a/buildkite/setup-ubuntu.sh
+++ b/buildkite/setup-ubuntu.sh
@@ -438,8 +438,10 @@ expect {
 '
 
   # This should be kept in sync with mac/mac-android.sh.
+  # build-tools 28.0.1 introduces the new dexer, d8.jar
   tools/bin/sdkmanager \
     "build-tools;27.0.3" \
+    "build-tools;28.0.1" \
     "emulator" \
     "extras;android;m2repository" \
     "platform-tools" \

--- a/buildkite/setup-ubuntu.sh
+++ b/buildkite/setup-ubuntu.sh
@@ -441,7 +441,7 @@ expect {
   # build-tools 28.0.1 introduces the new dexer, d8.jar
   tools/bin/sdkmanager \
     "build-tools;27.0.3" \
-    "build-tools;28.0.1" \
+    "build-tools;28.0.2" \
     "emulator" \
     "extras;android;m2repository" \
     "platform-tools" \
@@ -449,6 +449,7 @@ expect {
     "platforms;android-25" \
     "platforms;android-26" \
     "platforms;android-27" \
+    "platforms;android-28" \
     "system-images;android-19;default;x86" \
     "system-images;android-21;default;x86" \
     "system-images;android-22;default;x86" \

--- a/buildkite/setup-windows.ps1
+++ b/buildkite/setup-windows.ps1
@@ -226,11 +226,12 @@ Remove-Item "${android_sdk_root}\tools.old" -Force -Recurse
 ## build-tools 28.0.1 introduces the new dexer, d8.jar
 & "${android_sdk_root}\tools\bin\sdkmanager.bat" "platform-tools"
 & "${android_sdk_root}\tools\bin\sdkmanager.bat" "build-tools;27.0.3"
-& "${android_sdk_root}\tools\bin\sdkmanager.bat" "build-tools;28.0.1"
+& "${android_sdk_root}\tools\bin\sdkmanager.bat" "build-tools;28.0.2"
 & "${android_sdk_root}\tools\bin\sdkmanager.bat" "platforms;android-24"
 & "${android_sdk_root}\tools\bin\sdkmanager.bat" "platforms;android-25"
 & "${android_sdk_root}\tools\bin\sdkmanager.bat" "platforms;android-26"
 & "${android_sdk_root}\tools\bin\sdkmanager.bat" "platforms;android-27"
+& "${android_sdk_root}\tools\bin\sdkmanager.bat" "platforms;android-28"
 & "${android_sdk_root}\tools\bin\sdkmanager.bat" "extras;android;m2repository"
 
 ## Download and install the Buildkite agent.

--- a/buildkite/setup-windows.ps1
+++ b/buildkite/setup-windows.ps1
@@ -223,8 +223,10 @@ Rename-Item "${android_sdk_root}\tools" "${android_sdk_root}\tools.old"
 Remove-Item "${android_sdk_root}\tools.old" -Force -Recurse
 
 ## Install all required Android SDK components.
+## build-tools 28.0.1 introduces the new dexer, d8.jar
 & "${android_sdk_root}\tools\bin\sdkmanager.bat" "platform-tools"
 & "${android_sdk_root}\tools\bin\sdkmanager.bat" "build-tools;27.0.3"
+& "${android_sdk_root}\tools\bin\sdkmanager.bat" "build-tools;28.0.1"
 & "${android_sdk_root}\tools\bin\sdkmanager.bat" "platforms;android-24"
 & "${android_sdk_root}\tools\bin\sdkmanager.bat" "platforms;android-25"
 & "${android_sdk_root}\tools\bin\sdkmanager.bat" "platforms;android-26"

--- a/mac/mac-android.sh
+++ b/mac/mac-android.sh
@@ -46,9 +46,11 @@ expect {
 '
 
 # This should be kept in sync with gce/install-android-sdk.sh
+# build-tools 28.0.1 introduces the new dexer, d8.jar
 tools/bin/sdkmanager \
   "platform-tools" \
   "build-tools;27.0.3" \
+  "build-tools;28.0.1" \
   "platforms;android-24" \
   "platforms;android-25" \
   "platforms;android-26" \

--- a/mac/mac-android.sh
+++ b/mac/mac-android.sh
@@ -50,9 +50,10 @@ expect {
 tools/bin/sdkmanager \
   "platform-tools" \
   "build-tools;27.0.3" \
-  "build-tools;28.0.1" \
+  "build-tools;28.0.2" \
   "platforms;android-24" \
   "platforms;android-25" \
   "platforms;android-26" \
   "platforms;android-27" \
+  "platforms;android-28" \
   "extras;android;m2repository"


### PR DESCRIPTION
The Android testing pipeline is now using these tools and APIs.

Fixes https://github.com/googlesamples/android-testing/issues/199

cc @brettchabot @mhlopko 