### PR TITLE
Disable bazel-toolchains from downstream job

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -57,10 +57,11 @@ DOWNSTREAM_PROJECTS = {
         "git_repository": "https://github.com/bazelbuild/BUILD_file_generator.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/BUILD_file_generator/master/.bazelci/presubmit.yml"
     },
-    "bazel-toolchains": {
-        "git_repository": "https://github.com/bazelbuild/bazel-toolchains.git",
-        "http_config": "https://raw.githubusercontent.com/bazelbuild/bazel-toolchains/master/.bazelci/presubmit.yml"
-    },
+    # TODO(bazel): enable once https://github.com/bazelbuild/bazel-toolchains/issues/198 is fixed
+    # "bazel-toolchains": {
+    #     "git_repository": "https://github.com/bazelbuild/bazel-toolchains.git",
+    #     "http_config": "https://raw.githubusercontent.com/bazelbuild/bazel-toolchains/master/.bazelci/presubmit.yml"
+    # },
     "bazel-skylib": {
         "git_repository": "https://github.com/bazelbuild/bazel-skylib.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/bazel-skylib/master/.bazelci/presubmit.yml"


### PR DESCRIPTION
bazel-toolchains need to adapt incompatible changes and fix their bug.
See https://github.com/bazelbuild/bazel-toolchains/issues/198
@philwo @mhlopko