### PR TITLE
Remove test step from publish_bazel_binaries job

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1132,16 +1132,12 @@ def print_bazel_publish_binaries_pipeline(configs, http_config, file_config):
     if set(configs) != set(name for name, platform in PLATFORMS.items() if platform["publish_binary"]):
         raise BuildkiteException("Bazel publish binaries pipeline needs to build Bazel for every commit on all publish_binary-enabled platforms.")
 
-    # Build and Test Bazel
+    # Build Bazel
     pipeline_steps = []
 
     for platform in configs:
         pipeline_steps.append(bazel_build_step(
             platform, "Bazel", http_config, file_config, build_only=True))
-
-    for platform in configs:
-        pipeline_steps.append(bazel_build_step(
-            platform, "Bazel", http_config, file_config, test_only=True))
 
     pipeline_steps.append("wait")
 


### PR DESCRIPTION
To fix https://buildkite.com/bazel/publish-bazel-binaries/builds/1284#_

Related https://github.com/bazelbuild/continuous-integration/issues/353