### PR TITLE
Disable Android Testing from Downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -48,6 +48,7 @@ DOWNSTREAM_PROJECTS = {
         "git_repository": "https://github.com/googlesamples/android-testing.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/pipelines/android-testing-postsubmit.yml",
         "pipeline_slug": "android-testing",
+        "disabled_reason": "https://github.com/googlesamples/android-testing/issues/224: reenable once fixed"
     },
     "Bazel Remote Execution": {
         "git_repository": "https://github.com/bazelbuild/bazel.git",


### PR DESCRIPTION
Related: https://github.com/bazelbuild/continuous-integration/pull/394