### PR TITLE
Remove hardcoded Bazel version from Windows setup

### DIFF
--- a/buildkite/setup-windows.ps1
+++ b/buildkite/setup-windows.ps1
@@ -206,13 +206,12 @@ Write-Host "Installing Sauce Connect Proxy..."
 $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine")
 
 ## Get the latest release version number of Bazel.
-# Write-Host "Grabbing latest Bazel version number from GitHub..."
-# $url = "https://github.com/bazelbuild/bazel/releases/latest"
-# $req = [system.Net.HttpWebRequest]::Create($url)
-# $res = $req.getresponse()
-# $res.Close()
-# $bazel_version = $res.ResponseUri.AbsolutePath.TrimStart("/bazelbuild/bazel/releases/tag/")
-$bazel_version = "0.19.0"
+Write-Host "Grabbing latest Bazel version number from GitHub..."
+$url = "https://github.com/bazelbuild/bazel/releases/latest"
+$req = [system.Net.HttpWebRequest]::Create($url)
+$res = $req.getresponse()
+$res.Close()
+$bazel_version = $res.ResponseUri.AbsolutePath.TrimStart("/bazelbuild/bazel/releases/tag/")
 
 ## Download the latest Bazel.
 Write-Host "Downloading Bazel ${bazel_version}..."


### PR DESCRIPTION
0.20.0 was recently released, which means that the hack is no longer required.