### PR TITLE
Remove hardcoded Bazel version from Ubuntu setup

### DIFF
--- a/buildkite/setup-ubuntu.sh
+++ b/buildkite/setup-ubuntu.sh
@@ -197,8 +197,7 @@ fi
 
 ### Install Bazel.
 {
-  # bazel_version=$(curl -sSI https://github.com/bazelbuild/bazel/releases/latest | grep '^Location: ' | sed 's|.*/||' | sed $'s/\r//')
-  bazel_version="0.19.0"
+  bazel_version=$(curl -sSI https://github.com/bazelbuild/bazel/releases/latest | grep '^Location: ' | sed 's|.*/||' | sed $'s/\r//')
   curl -sSLo install.sh "https://releases.bazel.build/${bazel_version}/release/bazel-${bazel_version}-installer-linux-x86_64.sh"
   bash install.sh > /dev/null
   rm -f install.sh


### PR DESCRIPTION
0.20.0 was recently released, which means that the hack is no longer required.