### PR TITLE
don't test bazel on downstream projects

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1326,12 +1326,6 @@ def print_bazel_downstream_pipeline(configs, http_config, file_config, test_inco
 
     pipeline_steps.append("wait")
 
-    for platform, config in configs.items():
-        if not "test_targets" in config:
-            continue
-        pipeline_steps.append(
-            bazel_build_step(platform, "Bazel", http_config, file_config, test_only=True))
-
     incompatible_flags = None
     if test_incompatible_flags:
         incompatible_flags = os.environ.get("INCOMPATIBLE_FLAGS", "").split()


### PR DESCRIPTION
There's no benefit to testing bazel in the downstream pipeline since we already have a postsubmit pipeline for Bazel. This change should drastically reduce resource requirements and e2e times for a downstream project build.

Discussed this change offline with @meteorcloudy 