### PR TITLE
Remove --incompatible_package_name_is_a_function from Android Testing

### DIFF
--- a/buildkite/pipelines/android-testing-postsubmit.yml
+++ b/buildkite/pipelines/android-testing-postsubmit.yml
@@ -2,15 +2,12 @@
 ---
 platforms:
   ubuntu1404:
-    build_flags:
-    - "--incompatible_package_name_is_a_function=false" # Remove when android/android-test is updated to use updated protobuf https://github.com/protocolbuffers/protobuf/pull/4650
     build_targets:
     - "//ui/..."
     test_flags:
     - "--local_test_jobs=8" # Run at most 8 tests (= emulators) in parallel
     - "--flaky_test_attempts=3" # Flakes.
     - "--spawn_strategy=standalone" # Reduce flakes.
-    - "--incompatible_package_name_is_a_function=false" # Remove when android/android-test is updated to use updated protobuf https://github.com/protocolbuffers/protobuf/pull/4650
     test_targets:
     - "//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_23_x86"
     - "//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_23_x86"
@@ -19,15 +16,12 @@ platforms:
     - "//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest_23_x86"
     - "//ui/espresso/BasicSample:BasicSampleInstrumentationTest_23_x86"
   ubuntu1604:
-    build_flags:
-    - "--incompatible_package_name_is_a_function=false" # Remove when android/android-test is updated to use updated protobuf https://github.com/protocolbuffers/protobuf/pull/4650
     build_targets:
     - "//ui/..."
     test_flags:
     - "--local_test_jobs=8" # Run at most 8 tests (= emulators) in parallel
     - "--flaky_test_attempts=3" # Flakes.
     - "--spawn_strategy=standalone" # Reduce flakes.
-    - "--incompatible_package_name_is_a_function=false" # Remove when android/android-test is updated to use updated protobuf https://github.com/protocolbuffers/protobuf/pull/4650
     test_targets:
     - "//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_23_x86"
     - "//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_23_x86"
@@ -36,15 +30,12 @@ platforms:
     - "//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest_23_x86"
     - "//ui/espresso/BasicSample:BasicSampleInstrumentationTest_23_x86"
   ubuntu1804:
-    build_flags:
-    - "--incompatible_package_name_is_a_function=false" # Remove when android/android-test is updated to use updated protobuf https://github.com/protocolbuffers/protobuf/pull/4650
     build_targets:
     - "//ui/..."
     test_flags:
     - "--local_test_jobs=8" # Run at most 8 tests (= emulators) in parallel
     - "--flaky_test_attempts=3" # Flakes.
     - "--spawn_strategy=standalone" # Reduce flakes.
-    - "--incompatible_package_name_is_a_function=false" # Remove when android/android-test is updated to use updated protobuf https://github.com/protocolbuffers/protobuf/pull/4650
     test_targets:
     - "//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_23_x86"
     - "//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_23_x86"
@@ -54,8 +45,6 @@ platforms:
     - "//ui/espresso/BasicSample:BasicSampleInstrumentationTest_23_x86"
   macos:
     # Testing does not work for macos and windows yet
-    build_flags:
-    - "--incompatible_package_name_is_a_function=false" # Remove when android/android-test is updated to use updated protobuf https://github.com/protocolbuffers/protobuf/pull/4650
     build_targets: # Results of `bazel query 'kind(android_binary, //...)'
       - "//ui/uiautomator/BasicSample:BasicSampleTest"
       - "//ui/uiautomator/BasicSample:BasicSample"


### PR DESCRIPTION
The flag has been removed; these tests are now expected to fail with the PACKAGE_NAME failure from upstream protobuf 3.4.1. 

The workaround is to update [android/android-test to protobuf 3.6.1.2 ](https://github.com/android/android-test/blob/9e991e0f503c50154d87df293c038f984e2c4fe6/repo.bzl#L274) when it is released, and update googlesamples/android-testing to use the updated android/android-test.

ref: https://github.com/bazelbuild/bazel/issues/5827

cc @laurentlb 