### PR TITLE
Increase number of bk-worker-ubuntu1404-java8 VMs

### DIFF
--- a/buildkite/instances.yml
+++ b/buildkite/instances.yml
@@ -36,7 +36,7 @@ instance_groups:
     metadata_from_file: startup-script=startup-ubuntu.sh
     service_account: bazel-release-process@bazel-public.iam.gserviceaccount.com
   - name: bk-worker-ubuntu1404-java8
-    count: 8
+    count: 12
     image_family: bk-worker-ubuntu1404-java8
     local_ssd: interface=nvme
     metadata_from_file: startup-script=startup-ubuntu.sh


### PR DESCRIPTION
Let's go from 8 to 12 in order to deal with bottlenecks.