### PR TITLE
Windows: Don't convert the line endings when cloning a repository

### DIFF
--- a/buildkite/setup-windows.ps1
+++ b/buildkite/setup-windows.ps1
@@ -84,6 +84,8 @@ Write-Host "Installing Git for Windows..."
 # FYI: choco adds "C:\Program Files\Git\cmd" to global PATH.
 & choco install git --params "'/GitOnlyOnPath'"
 $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine")
+# Don't convert the line endings when cloning the repository because that could break some tests
+& git config --global core.autocrlf false
 
 ## Install MSYS2
 Write-Host "Installing MSYS2..."


### PR DESCRIPTION
I recently enabled protobuf test on Windows at https://github.com/bazelbuild/continuous-integration/pull/427

But it is failing on CI while succeeded on my local machine: https://buildkite.com/bazel/protobuf/builds/1947#b3bb6708-ef5d-4d36-a5d6-a52e45d78e51
```
FAIL: testPrintAllFields (__main__.OnlyWorksWithProto2RightNowTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "\\?\D:\temp\Bazel.runfiles_mia7_q7b\runfiles\com_google_protobuf\python\google\protobuf\internal\text_format_test.py", line 791, in testPrintAllFields
    'text_format_unittest_data_oneof_implemented.txt')
  File "\\?\D:\temp\Bazel.runfiles_mia7_q7b\runfiles\com_google_protobuf\python\google\protobuf\internal\text_format_test.py", line 89, in CompareToGoldenFile
    self.assertMultiLineEqual(text, ''.join(golden_lines))
AssertionError: 'optional_int32: 101\noptional_int64: 102\noptional_uint32: 10[2493 chars]4"\n' != 'optional_int32: 101\r\noptional_int64: 102\r\noptional_uint32[2751 chars]\r\n'
Diff is 8320 characters long. Set self.maxDiff to None to see it.
```

It turned out it's the line endings of some [test data files](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/testdata/map_test_data.txt) are automatically transformed to `\r\n` when cloning with Git on Windows (I'm using git in msys on my machine, so it doesn't).

Thus, we need to turn off the auto-translation to allow the test to pass.