### PR TITLE
bazelci.py: Add back fetch_buildkite_token function

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -588,7 +588,8 @@ def fetch_saucelabs_token():
         os.remove("saucelabs-access-key.enc")
 
 
-def fetch_buildkite_token():	
+def fetch_buildkite_token():
+    """This function is used in buildkite/incompatible_flag_verbose_failures.py"""
     global __buildkite_token__	
     if __buildkite_token__:	
         return __buildkite_token__	


### PR DESCRIPTION
639c0455e26f50098eecef031dc635b40fc5f2f5 broke https://buildkite.com/bazel/bazel-at-release-plus-incompatible-flags/builds/54#4ae15dd6-90cc-449f-aa61-40b15527d15b, because we need to access buildkite API to get the status of the jobs in order to rerun the failed ones.