### PR TITLE
Windows: Move Git snapshot download from startup script to setup script

### DIFF
--- a/buildkite/setup-windows.ps1
+++ b/buildkite/setup-windows.ps1
@@ -271,6 +271,16 @@ if ($java -ne "no") {
     & "${android_sdk_root}\tools\bin\sdkmanager.bat" "extras;android;m2repository"
 }
 
+## Download and unpack our Git snapshot.
+Write-Host "Downloading Git snapshot..."
+$bazelbuild_url = "https://storage.googleapis.com/bazel-git-mirror/bazelbuild.zip"
+$bazelbuild_zip = "c:\temp\bazelbuild.zip"
+$bazelbuild_root = "c:\buildkite"
+(New-Object Net.WebClient).DownloadFile($bazelbuild_url, $bazelbuild_zip)
+Write-Host "Unpacking Git snapshot..."
+Expand-Archive -LiteralPath $bazelbuild_zip -DestinationPath $bazelbuild_root -Force
+Remove-Item $bazelbuild_zip
+
 ## Download and install the Buildkite agent.
 Write-Host "Grabbing latest Buildkite Agent version number from GitHub..."
 $url = "https://github.com/buildkite/agent/releases/latest"

--- a/buildkite/startup-windows.ps1
+++ b/buildkite/startup-windows.ps1
@@ -47,16 +47,6 @@ Write-Host "Decrypting Buildkite Agent token using KMS..."
 $buildkite_agent_token = & gcloud kms decrypt --location global --keyring buildkite --key buildkite-agent-token --ciphertext-file $buildkite_agent_token_file --plaintext-file -
 Remove-Item $buildkite_agent_token_file
 
-## Download and unpack our Git snapshot.
-Write-Host "Downloading Git snapshot..."
-$bazelbuild_url = "https://storage.googleapis.com/bazel-git-mirror/bazelbuild.zip"
-$bazelbuild_zip = "c:\temp\bazelbuild.zip"
-$bazelbuild_root = "c:\buildkite"
-(New-Object Net.WebClient).DownloadFile($bazelbuild_url, $bazelbuild_zip)
-Write-Host "Unpacking Git snapshot..."
-Expand-Archive -LiteralPath $bazelbuild_zip -DestinationPath $bazelbuild_root -Force
-Remove-Item $bazelbuild_zip
-
 ## Configure the Buildkite agent.
 Write-Host "Configuring Buildkite Agent..."
 $buildkite_agent_root = "c:\buildkite"


### PR DESCRIPTION
So that we don't wait for 5 mins every time we restart the Windows slave.