### PR TITLE
bazelci.py no longer crashes when the BUILDKITE_ORGANIZATION_SLUG env…

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -43,7 +43,7 @@ random.seed()
 
 CLOUD_PROJECT = (
     "bazel-public"
-    if os.environ["BUILDKITE_ORGANIZATION_SLUG"] == "bazel-trusted"
+    if os.environ.get("BUILDKITE_ORGANIZATION_SLUG") == "bazel-trusted"
     else "bazel-untrusted"
 )
 


### PR DESCRIPTION
… variable is missing.

This change allows us to test the script locally without setting any variables, exactly as it used to be.