### PR TITLE
Change the pipeline configuration from platforms to tasks

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -154,6 +154,7 @@ There are more advanced mechanisms for configuring individual tasks:
   Simply add the `batch_commands` (Windows) or `shell_commands` field (all other platforms).
 - The `run_targets` field contains a list of Bazel targets that should be run before building.
 - The `build_flags` and `test_flags` fields contain lists of flags that should be used when building or testing (respectively).
+- You can specify a display name in the `name` field. The resulting job will display this value and an emoji that represents the platform.
 
 ```yaml
 ---
@@ -172,6 +173,7 @@ tasks:
     test_targets:
     - ":clwb_tests"
   windows:
+    name: "some :emoji:"
     batch_commands:
     - powershell -Command "..."
     build_targets:

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1893,7 +1893,7 @@ def main(argv=None):
                     )
                 )
 
-            platform = get_platform_for_task(args.task, task_config.get)
+            platform = get_platform_for_task(args.task, task_config)
             if not platform:
                 raise BuildkiteException(
                     "Configuration for task '{}' misses required field 'platform'.".format(

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -454,6 +454,7 @@ def transform_legacy_platform(platform, platform_config):
     # Legacy mode means that there is exactly one config per platform type (e.g. Ubuntu1604_nojdk), which means that we can use the same value for id and type.
     platform_config["id"] = platform
     platform_config["type"] = platform
+    platform_config["display_name"] = ""
     return platform_config
 
 
@@ -1191,6 +1192,7 @@ def print_project_pipeline(
         step = runner_step(
             platform_config["id"],
             platform_config["type"],
+            platform_config.get("display_name", ""),
             project_name,
             http_config,
             file_config,
@@ -1238,6 +1240,7 @@ def print_project_pipeline(
 def runner_step(
     platform_id,
     platform_type,
+    platform_display_name,
     project_name=None,
     http_config=None,
     file_config=None,
@@ -1263,7 +1266,7 @@ def runner_step(
         command += " --use_but"
     for flag in incompatible_flags or []:
         command += " --incompatible_flag=" + flag
-    label = create_label(platform_id, platform_type, project_name)
+    label = create_label(platform_type, project_name, platform_details=platform_display_name)
     return create_step(
         label=label, commands=[fetch_bazelcipy_command(), command], platform=platform_type
     )
@@ -1302,10 +1305,10 @@ def upload_project_pipeline_step(
     )
 
 
-def create_label(platform_id, platform_type, project_name, build_only=False, test_only=False):
+def create_label(platform, project_name, build_only=False, test_only=False, platform_details=""):
     if build_only and test_only:
         raise BuildkiteException("build_only and test_only cannot be true at the same time")
-    emoji_name = PLATFORMS[platform_type]["emoji-name"]
+    emoji_name = PLATFORMS[platform]["emoji-name"]
 
     if build_only:
         label = "Build "
@@ -1314,7 +1317,7 @@ def create_label(platform_id, platform_type, project_name, build_only=False, tes
     else:
         label = ""
 
-    platform_label = ("{0} on {1}".format(platform_id, emoji_name) if platform_id != platform_type else emoji_name)
+    platform_label = ("{0} on {1}".format(platform_details, emoji_name) if platform_details else emoji_name)
 
     if project_name:
         label += "{0} ({1})".format(project_name, platform_label)

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1850,7 +1850,7 @@ def main(argv=None):
             )
         elif args.subparsers_name == "runner":
             configs = fetch_configs(args.http_config, args.file_config)
-            platform_configs = [p for p in configs.get("platforms", []) if p["id"] == args.platform]
+            platform_configs = [p for p in configs.get("platforms", []) if p.get("id") == args.platform]
             config = platform_configs[0] if platform_configs else None
             platform = config.get("type") if config else None
             execute_commands(

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1851,9 +1851,11 @@ def main(argv=None):
         elif args.subparsers_name == "runner":
             configs = fetch_configs(args.http_config, args.file_config)
             platform_configs = [p for p in configs.get("platforms", []) if p["id"] == args.platform]
+            config = platform_configs[0] if platform_configs else None
+            platform = config.get("type") if config else None
             execute_commands(
-                config=platform_configs[0] if platform_configs else None,
-                platform=args.platform,
+                config=config,
+                platform=platform or args.platform,
                 git_repository=args.git_repository,
                 git_commit=args.git_commit,
                 git_repo_location=args.git_repo_location,

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1314,12 +1314,12 @@ def create_label(platform_id, platform_type, project_name, build_only=False, tes
     else:
         label = ""
 
-    platform_label = ("{0} on {1}".format(platform_id, platform_type) if platform_id != platform_type else platform_id)
+    platform_label = ("{0} on {1}".format(platform_id, emoji_name) if platform_id != platform_type else emoji_name)
 
     if project_name:
         label += "{0} ({1})".format(project_name, platform_label)
     else:
-        label += emoji_name
+        label += platform_label
 
     return label
 


### PR DESCRIPTION
This commit changes the configuration format slightly by requiring a "tasks" dictionary instead of the old "platforms" dictionary.

Unlike platforms, tasks
- may have arbitrary, but unique IDs (= dictionary keys),
- can have an optional display name and
- usually have an explicit "platform" field [*].

This commit allows us to run multiple tasks on the same platform.
It is fully backwards compatible since the CI script still accepts configurations with a "platforms" dictionary.

[*] For ease of use, tasks may omit the "platform" field if there is exactly one task per platform. In this case the task ID must be the platform name.