### PR TITLE
Allow users to specify the Bazel version in the pipeline config

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -221,7 +221,7 @@ tasks:
 
 The CI script still supports the legacy format, too.
 
-## Using a specific version of Bazel
+### Using a specific version of Bazel
 
 The CI uses [Bazelisk](https://github.com/philwo/bazelisk) to support older versions of Bazel, too. You can specify a Bazel version for each pipeline (or even for individual platforms) in the pipeline Yaml configuration:
 

--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -221,6 +221,28 @@ tasks:
 
 The CI script still supports the legacy format, too.
 
+## Using a specific version of Bazel
+
+The CI uses [Bazelisk](https://github.com/philwo/bazelisk) to support older versions of Bazel, too. You can specify a Bazel version for each pipeline (or even for individual platforms) in the pipeline Yaml configuration:
+
+```yaml
+---
+bazel: 0.20.0
+platforms:
+  windows:
+    build_targets:
+    - "..."
+  macos:
+    build_targets:
+    - "..."
+  ubuntu1404:
+    bazel: 0.18.0
+    build_targets:
+    - "..."
+[...]
+```
+In this example the jobs on Windows and MacOS would use 0.20.0, wherease the job on Ubuntu would run 0.18.0.
+Please see the [Bazelisk documentation](https://github.com/philwo/bazelisk/blob/master/README.md#how-does-bazelisk-know-which-version-to-run) for a list of all supported version values.
 
 ### Running Buildifier on CI
 

--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -241,7 +241,7 @@ platforms:
     - "..."
 [...]
 ```
-In this example the jobs on Windows and MacOS would use 0.20.0, wherease the job on Ubuntu would run 0.18.0.
+In this example the jobs on Windows and MacOS would use 0.20.0, whereas the job on Ubuntu would run 0.18.0.
 Please see the [Bazelisk documentation](https://github.com/philwo/bazelisk/blob/master/README.md#how-does-bazelisk-know-which-version-to-run) for a list of all supported version values.
 
 ### Running Buildifier on CI

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -473,7 +473,7 @@ def execute_commands(
     test_only,
     monitor_flaky_tests,
     incompatible_flags,
-    bazel_version=None
+    bazel_version=None,
 ):
     build_only = build_only or "test_targets" not in task_config
     test_only = test_only or "build_targets" not in task_config
@@ -1935,7 +1935,7 @@ def main(argv=None):
                 test_only=args.test_only,
                 monitor_flaky_tests=args.monitor_flaky_tests,
                 incompatible_flags=args.incompatible_flag,
-                bazel_version = task_config.get("bazel") or configs.get("bazel")
+                bazel_version=task_config.get("bazel") or configs.get("bazel"),
             )
         elif args.subparsers_name == "publish_binaries":
             publish_binaries()

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -338,7 +338,8 @@ EDql
 
 BAZELISK_VERSION_ENV_VAR = "USE_BAZEL_VERSION"
 
-BUILD_LABEL_PATTERN = re.compile(r'^Build label: (\S)$', re.MULTILINE)
+BUILD_LABEL_PATTERN = re.compile(r"^Build label: (\S+)$", re.MULTILINE)
+
 
 class BuildkiteException(Exception):
     """
@@ -474,7 +475,7 @@ def execute_commands(
     test_only,
     monitor_flaky_tests,
     incompatible_flags,
-    bazel_version=None
+    bazel_version=None,
 ):
     build_only = build_only or "test_targets" not in config
     test_only = test_only or "build_targets" not in config
@@ -487,7 +488,9 @@ def execute_commands(
     bazel_version = config.get("bazel") or bazel_version
     if bazel_version:
         if use_bazel_at_commit or use_but:
-            raise BuildkiteException("Cannot specify an explicit Bazel version when either use_bazel_at_commit or use_but is set.")
+            raise BuildkiteException(
+                "Cannot specify an explicit Bazel version when either use_bazel_at_commit or use_but is set."
+            )
 
         os.environ[BAZELISK_VERSION_ENV_VAR] = bazel_version
 
@@ -999,7 +1002,9 @@ def execute_bazel_clean(bazel_binary, platform):
         raise BuildkiteException("bazel clean failed with exit code {}".format(e.returncode))
 
 
-def execute_bazel_build(bazel_version, bazel_binary, platform, flags, targets, bep_file, incompatible_flags):
+def execute_bazel_build(
+    bazel_version, bazel_binary, platform, flags, targets, bep_file, incompatible_flags
+):
     print_expanded_group(":bazel: Build ({})".format(bazel_version))
 
     aggregated_flags = compute_flags(
@@ -1014,7 +1019,14 @@ def execute_bazel_build(bazel_version, bazel_binary, platform, flags, targets, b
 
 
 def execute_bazel_test(
-    bazel_version, bazel_binary, platform, flags, targets, bep_file, monitor_flaky_tests, incompatible_flags
+    bazel_version,
+    bazel_binary,
+    platform,
+    flags,
+    targets,
+    bep_file,
+    monitor_flaky_tests,
+    incompatible_flags,
 ):
     print_expanded_group(":bazel: Test ({})".format(bazel_version))
 
@@ -1115,8 +1127,11 @@ def test_logs_for_status(bep_file, status):
 
 def execute_command(args, shell=False, fail_if_nonzero=True):
     eprint(" ".join(args))
-    process = subprocess.run(args, shell=shell, check=fail_if_nonzero, env=os.environ, stdout=subprocess.PIPE)
+    process = subprocess.run(
+        args, shell=shell, check=fail_if_nonzero, env=os.environ, stdout=subprocess.PIPE
+    )
     return process.stdout.decode("utf-8")
+
 
 def execute_command_background(args):
     eprint(" ".join(args))
@@ -1921,7 +1936,7 @@ def main(argv=None):
                 test_only=args.test_only,
                 monitor_flaky_tests=args.monitor_flaky_tests,
                 incompatible_flags=args.incompatible_flag,
-                bazel_version=configs.get("bazel")
+                bazel_version=configs.get("bazel"),
             )
         elif args.subparsers_name == "publish_binaries":
             publish_binaries()

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -336,6 +336,8 @@ CiQAry63sOlZtTNtuOT5DAOLkum0rGof+DOweppZY1aOWbat8zwSTQAL7Hu+rgHSOr6P4S1cu4YG
 EDql
 """.strip()
 
+BAZELISK_VERSION_ENV_VAR = "USE_BAZEL_VERSION"
+
 
 class BuildkiteException(Exception):
     """
@@ -471,6 +473,7 @@ def execute_commands(
     test_only,
     monitor_flaky_tests,
     incompatible_flags,
+    bazel_version=None
 ):
     build_only = build_only or "test_targets" not in config
     test_only = test_only or "build_targets" not in config
@@ -479,6 +482,13 @@ def execute_commands(
 
     if use_bazel_at_commit and use_but:
         raise BuildkiteException("use_bazel_at_commit cannot be set when use_but is true")
+
+    bazel_version = config.get("bazel") or bazel_version
+    if bazel_version:
+        if use_bazel_at_commit or use_but:
+            raise BuildkiteException("Cannot specify an explicit Bazel version when either use_bazel_at_commit or use_but is set.")
+
+        os.environ[BAZELISK_VERSION_ENV_VAR] = bazel_version
 
     tmpdir = tempfile.mkdtemp()
     sc_process = None
@@ -1905,6 +1915,7 @@ def main(argv=None):
                 test_only=args.test_only,
                 monitor_flaky_tests=args.monitor_flaky_tests,
                 incompatible_flags=args.incompatible_flag,
+                bazel_version=configs.get("bazel")
             )
         elif args.subparsers_name == "publish_binaries":
             publish_binaries()


### PR DESCRIPTION
The Bazel version can be specified for each platform individually, or for all platforms at once.

This commit only works once Bazelisk is the default bazel binary on all platforms.