### PR TITLE
Migrate incompatible flags script from --platform to --task

### DIFF
--- a/buildkite/incompatible_flag_verbose_failures.py
+++ b/buildkite/incompatible_flag_verbose_failures.py
@@ -92,11 +92,12 @@ def get_failing_jobs(build_info):
             # Recover the platform name from job command
             platform = None
             for s in command.split(" "):
-                if s.startswith("--platform="):
-                    platform = s[len("--platform="):]
+                # TODO(fweikert): Fix this once we use arbitrary task names.
+                if s.startswith("--task="):
+                    platform = s[len("--task="):]
 
             if not platform:
-                raise BuildkiteException("Cannot recongnize platform from job command: %s" % command)
+                raise BuildkiteException("Cannot recognize platform from job command: %s" % command)
 
             failing_jobs.append(
                 {


### PR DESCRIPTION
https://github.com/bazelbuild/continuous-integration/pull/463 changed the --platform flag to --task. We're still using platform names as task names, hence this PR should fix the current breakage. However, more work might be needed once we actually use arbitrary task names.