### PR TITLE
Remove bazel-toolchains from gitsync.

### DIFF
--- a/gitsync/gitsync.sh
+++ b/gitsync/gitsync.sh
@@ -23,7 +23,6 @@
 #   direction can be ==> or <=>
 REPOSITORIES=(
     "https://bazel.googlesource.com/bazel ==> git@github.com:bazelbuild/bazel.git bazel"
-    "https://bazel.googlesource.com/bazel-toolchains <=> git@github.com:bazelbuild/bazel-toolchains.git bazel-toolchains"
     "https://bazel.googlesource.com/java_tools ==> git@github.com:bazelbuild/java_tools.git java_tools"
     "https://bazel.googlesource.com/rules_cc ==> git@github.com:bazelbuild/rules_cc.git rules_cc"
     "https://bazel.googlesource.com/tulsi ==> git@github.com:bazelbuild/tulsi.git tulsi"


### PR DESCRIPTION
Its source of truth is now in GitHub and changes are merged there via PRs, so there's no point in mirroring it to / from GoB.