### PR TITLE
Re-enable remote caching on Windows

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -890,7 +890,7 @@ def remote_caching_flags(platform):
         "ubuntu1804_java10",
         "ubuntu1804_java11",
         "macos",
-        # "windows",
+        "windows",
     ]:
         return []
 


### PR DESCRIPTION
Bug fixes for remote caching on Windows have been released in 0.22.0