### PR TITLE
Remove obsolete code

### DIFF
--- a/buildkite/incompatible_flag_verbose_failures.py
+++ b/buildkite/incompatible_flag_verbose_failures.py
@@ -124,12 +124,7 @@ def get_failing_jobs(build_info):
                 )
 
             # Shortcut: Users can skip the "platform" field if its value equals the task name.
-            platform = task_config.get("platform", task)
-            if not platform:
-                raise BuildkiteException(
-                    "Cannot determine platform based on job command: %s" % command
-                )
-
+            platform = task_config.get("platform") or task
             failing_jobs.append(
                 {
                     "name": job["name"],


### PR DESCRIPTION
The change to how we retrieve the platform field means that the "platform" variable will never be None, thus making the exception obsolete.