### PR TITLE
Pass required Bazelisk env vars to test step

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -640,8 +640,8 @@ def execute_commands(
             # Otherwise any integration test that invokes Bazel (=Bazelisk in this case) will fail.
             if pass_bazelisk_env_vars_to_test:
                 test_flags += [
-                    "--test_env=HOME={}".format(os.environ.get("HOME")),
-                    "--test_env=USE_BAZEL_VERSION={}".format(bazel_version),
+                    create_test_env_flag("HOME"),
+                    create_test_env_flag("USE_BAZEL_VERSION"),
                 ]
 
             test_bep_file = os.path.join(tmpdir, "test_bep.json")
@@ -684,6 +684,10 @@ def execute_commands(
                 sc_process.kill()
         if tmpdir:
             shutil.rmtree(tmpdir)
+
+
+def create_test_env_flag(env_var_name):
+    return "--test_env={}={}".format(env_var_name, os.environ.get(env_var_name)),
 
 
 def tests_with_status(bep_file, status):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -687,7 +687,7 @@ def execute_commands(
 
 
 def create_test_env_flag(env_var_name):
-    return "--test_env={}={}".format(env_var_name, os.environ.get(env_var_name)),
+    return "--test_env={}".format(env_var_name),
 
 
 def tests_with_status(bep_file, status):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -548,7 +548,7 @@ def execute_commands(
     tmpdir = tempfile.mkdtemp()
     sc_process = None
     try:
-        pass_bazelisk_env_vars = False
+        pass_bazelisk_env_vars_to_test = False
         if git_repo_location:
             os.chdir(git_repo_location)
         elif git_repository:

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -548,7 +548,9 @@ def execute_commands(
     tmpdir = tempfile.mkdtemp()
     sc_process = None
     try:
-        test_env_vars = []
+        # If the CI worker runs Bazelisk, we need to forward all required env variables to the test.
+        # Otherwise any integration test that invokes Bazel (=Bazelisk in this case) will fail.
+        test_env_vars = ["HOME"]
         if git_repo_location:
             os.chdir(git_repo_location)
         elif git_repository:
@@ -568,9 +570,7 @@ def execute_commands(
                 # This will only work if the bazel binary in $PATH is actually a bazelisk binary
                 # (https://github.com/philwo/bazelisk).
                 os.environ["USE_BAZEL_VERSION"] = bazel_version
-                # If the CI worker runs Bazelisk, we need to forward all required env variables to the test.
-                # Otherwise any integration test that invokes Bazel (=Bazelisk in this case) will fail.
-                test_env_vars = ["HOME", "USE_BAZEL_VERSION"]
+                test_env_vars.append("USE_BAZEL_VERSION")
 
         os.environ.update(task_config.get("environment", {}))
 


### PR DESCRIPTION
Bazelisk replaces /usr/bin/bazel. As a consequence, any integration test that runs on a machine with Bazelisk and that invokes Bazel actually calls Bazelisk, but without access to the required environment variables (due to how "bazel test" works). Consequently, the invocation fails.

This commit fixes the problem by passing the required environment variable ($HOME) to the test. For consistency, it also passes $USE_BAZEL_VERSION so that the test doesn't use a different version of Bazel.

Fixes https://github.com/bazelbuild/continuous-integration/issues/485