### PR TITLE
Add rules_dotnet to downstream pipeline.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -198,6 +198,11 @@ DOWNSTREAM_PROJECTS = {
         "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_docker/master/.bazelci/presubmit.yml",
         "pipeline_slug": "rules-docker-docker",
     },
+    "rules_dotnet": {
+        "git_repository": "https://github.com/bazelbuild/rules_dotnet.git",
+        "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_dotnet/master/.bazelci/presubmit.yml",
+        "pipeline_slug": "rules-dotnet-edge",
+    },
     "rules_foreign_cc": {
         "git_repository": "https://github.com/bazelbuild/rules_foreign_cc.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_foreign_cc/master/.bazelci/config.yaml",


### PR DESCRIPTION
However, we should wait before submitting this fix: The rules_dotnet pipeline has been stale for several months, and a manual build failed on all platforms (https://buildkite.com/bazel/rules-dotnet-edge/builds/6).
The team should properly set up the GitHub webhook and then fix their tests.

Fixes https://github.com/bazelbuild/continuous-integration/issues/312.