### PR TITLE
Set default Bazel version on CI to 0.22.0.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -536,6 +536,10 @@ def execute_commands(
     incompatible_flags,
     bazel_version=None,
 ):
+    # TODO(https://github.com/bazelbuild/bazel/issues/7555): remove this hack once the
+    # latest Bazel release is no longer broken.
+    bazel_version = bazel_version or "0.22.0"
+
     build_only = build_only or "test_targets" not in task_config
     test_only = test_only or "build_targets" not in task_config
     if build_only and test_only:


### PR DESCRIPTION
This commit unblocks CI by avoiding the bad release 0.23.0: 
https://github.com/bazelbuild/bazel/issues/7555