### PR TITLE
Allow CI to run Bazel-built-at-current-commit.

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -225,7 +225,7 @@ The CI script still supports the legacy format, too.
 
 ### Using a specific version of Bazel
 
-The CI uses [Bazelisk](https://github.com/philwo/bazelisk) to support different versions of Bazel, too. You can specify a Bazel version for each pipeline (or even for individual platforms) in the pipeline Yaml configuration:
+The CI uses [Bazelisk](https://github.com/philwo/bazelisk) to support different versions of Bazel. You can specify a Bazel version for each pipeline (or even for individual platforms) in the pipeline Yaml configuration:
 
 ```yaml
 ---
@@ -248,7 +248,7 @@ In this example the jobs on Windows and MacOS would use 0.20.0, whereas the job 
 You can also use unreleased versions of Bazel:
 
 - `last_green` refers to the Bazel binary built at the latest green commit in the [Bazel pipeline](https://buildkite.com/bazel/bazel-bazel).
-- `commit` tells the pipeline to build a new Bazel binary at the current commit and to use that binary for all builds and tests.
+- `commit` tells the pipeline to build a new Bazel binary at the current commit and to use that binary for all other Bazel-related steps (clean, run, build and test).
 
 Please see the [Bazelisk documentation](https://github.com/philwo/bazelisk/blob/master/README.md#how-does-bazelisk-know-which-version-to-run) for a list of all supported version values.
 

--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -225,7 +225,7 @@ The CI script still supports the legacy format, too.
 
 ### Using a specific version of Bazel
 
-The CI uses [Bazelisk](https://github.com/philwo/bazelisk) to support older versions of Bazel, too. You can specify a Bazel version for each pipeline (or even for individual platforms) in the pipeline Yaml configuration:
+The CI uses [Bazelisk](https://github.com/philwo/bazelisk) to support different versions of Bazel, too. You can specify a Bazel version for each pipeline (or even for individual platforms) in the pipeline Yaml configuration:
 
 ```yaml
 ---
@@ -244,6 +244,12 @@ platforms:
 [...]
 ```
 In this example the jobs on Windows and MacOS would use 0.20.0, whereas the job on Ubuntu would run 0.18.0.
+
+You can also use unreleased versions of Bazel:
+
+- `last_green` refers to the Bazel binary built at the latest green commit in the [Bazel pipeline](https://buildkite.com/bazel/bazel-bazel).
+- `commit` tells the pipeline to build a new Bazel binary at the current commit and to use that binary for all builds and tests.
+
 Please see the [Bazelisk documentation](https://github.com/philwo/bazelisk/blob/master/README.md#how-does-bazelisk-know-which-version-to-run) for a list of all supported version values.
 
 ### Running Buildifier on CI

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -629,7 +629,7 @@ def execute_commands(
             raise BuildkiteException("working_directory refers to a path outside the workspace")
         os.chdir(requested_working_dir)
 
-        # Resolved given versions such as "latest" to an actual version number like 0.22.0.
+        # Resolve the specified version (e.g. "latest") to an actual version number (e.g. 0.22.0).
         # If the binary is not a release (candidate), the result will be "unreleased binary".
         resolved_bazel_version = print_bazel_version_info(bazel_binary, platform)
         if bazel_version == "commit":


### PR DESCRIPTION
This feature allows "regular" (=non-downstream) pipelines to build
a Bazel binary at the current commit, which will be used for all other
Bazel-related steps in that pipeline (clean, run, build, test).
It can be activated via the existing "bazel" field in the respective
Yaml configuration file.