### PR TITLE
Run buildkite-agent directly

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1746,7 +1746,7 @@ def print_bazel_downstream_pipeline(
                         fetch_bazelcipy_command(),
                         fetch_aggregate_incompatible_flags_test_result_command(),
                         python_binary()
-                        + " aggregate_incompatible_flags_test_result.py --build_number=%s | buildkite-agent pipeline upload"
+                        + " aggregate_incompatible_flags_test_result.py --build_number=%s"
                         % current_build_number,
                     ],
                 )


### PR DESCRIPTION
This will resolve "argument list too long" error at https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/15#f956c4e3-9d1a-4104-a0fb-8ef088ee4c0e

@laurentlb 