### PR TITLE
Add mechanism for handling CI-wide emergencies

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1700,6 +1700,7 @@ def print_pipeline_steps(pipeline_steps):
 
 def add_outage_announcement_step_if_necessary(pipeline_steps):
     style = "error"
+    message, issue_url, last_good_bazel = None, None, None
     try:
         outage = load_remote_yaml_file(OUTAGE_FILE_URL)
         message = outage.get("message")
@@ -2424,10 +2425,6 @@ def str_presenter(dumper, data):
     if len(data.splitlines()) > 1:  # check for multiline string
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)
-
-
-def show_outage_annotation(message, issue_url, good_bazel):
-    pass
 
 
 def main(argv=None):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1655,7 +1655,7 @@ def print_project_pipeline(
     if "validate_config" in configs:
         pipeline_steps += create_config_validation_steps()
 
-    print(yaml.dump({"steps": pipeline_steps}))
+    print_pipeline_steps(pipeline_steps)
 
 
 def get_platform_for_task(task, task_config):
@@ -1688,6 +1688,16 @@ def create_config_validation_steps():
         )
         for f in config_files
     ]
+
+
+def print_pipeline_steps(pipeline_steps):
+    outage_step = create_outage_announcement_step_if_necessary()
+    if outage_step:
+        pipeline_steps.insert(0, outage_step)
+
+    print(yaml.dump({"steps": pipeline_steps}))
+
+
 def add_outage_announcement_step_if_necessary(pipeline_steps):
     style = "error"
     try:
@@ -1712,11 +1722,10 @@ def add_outage_announcement_step_if_necessary(pipeline_steps):
             last_good_bazel
         )
 
-    step = create_step(
+    return create_step(
         label=":rotating_light: Outage :rotating_light:",
         commands=['buildkite-agent annotate --append --style={} "{}"'.format(style, text)],
     )
-    return [step] + pipeline_steps
 
 
 def runner_step(
@@ -1953,7 +1962,7 @@ def print_bazel_publish_binaries_pipeline(task_configs, http_config, file_config
         )
     )
 
-    print(yaml.dump({"steps": pipeline_steps}))
+    print_pipeline_steps(pipeline_steps)
 
 
 def should_publish_binaries_for_platform(platform):
@@ -2152,7 +2161,7 @@ def print_bazel_downstream_pipeline(
             )
         )
 
-    print(yaml.dump({"steps": pipeline_steps}))
+    print_pipeline_steps(pipeline_steps)
 
 
 def bazelci_builds_download_url(platform, git_commit):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1719,7 +1719,7 @@ def create_emergency_announcement_step_if_necessary():
     if issue_url:
         text += '- Please check this <a href="{}">issue</a> for more details.\n'.format(issue_url)
     if last_good_bazel:
-        text += "- Default Bazel version is *{}*, unless the pipeline configuration explicitly specifies a version.".format(
+        text += "- Default Bazel version is *{}*, unless the pipeline configuration specifies an explicit version.".format(
             last_good_bazel
         )
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1708,7 +1708,9 @@ def add_outage_announcement_step_if_necessary(pipeline_steps):
     if issue_url:
         text += '- Please check this <a href="{}">issue</a> for more details.\n'.format(issue_url)
     if last_good_bazel:
-        text += "- Default Bazel version is {}".format(last_good_bazel)
+        text += "- Default Bazel version is *{}*, unless the pipeline configuration explicitly specifies a version.".format(
+            last_good_bazel
+        )
 
     step = create_step(
         label=":rotating_light: Outage :rotating_light:",

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1719,9 +1719,10 @@ def create_emergency_announcement_step_if_necessary():
     if issue_url:
         text += '- Please check this <a href="{}">issue</a> for more details.\n'.format(issue_url)
     if last_good_bazel:
-        text += "- Default Bazel version is *{}*, unless the pipeline configuration specifies an explicit version.".format(
-            last_good_bazel
-        )
+        text += (
+            "- Default Bazel version is *{}*, "
+            "unless the pipeline configuration specifies an explicit version."
+        ).format(last_good_bazel)
 
     return create_step(
         label=":rotating_light: Emergency :rotating_light:",

--- a/buildkite/emergency.yml
+++ b/buildkite/emergency.yml
@@ -1,4 +1,4 @@
-# This file allows Bazel team member to mitigate outages by
+# This file allows Bazel team member to handle emergencies by
 # - Setting a warning message (and a link to a GitHub issue) that is displayed
 #   for every CI build
 # - Specifying a known good version of Bazel that will be used for

--- a/buildkite/emergency.yml
+++ b/buildkite/emergency.yml
@@ -17,6 +17,6 @@
 # Please do not clear or delete this file when an incident is over.
 # Instead, simply replace all values with empty strings ("").
 ---
-message: "We had to disable Bazel 0.23.0 due to a problem with remote caching."
-issue_url: "https://github.com/bazelbuild/bazel/issues/7555"
-last_good_bazel: "0.22.0"
+message: ""
+issue_url: ""
+last_good_bazel: ""

--- a/buildkite/outage.yml
+++ b/buildkite/outage.yml
@@ -1,0 +1,22 @@
+# This file allows Bazel team member to mitigate outages by
+# - Setting a warning message (and a link to a GitHub issue) that is displayed
+#   for every CI build
+# - Specifying a known good version of Bazel that will be used for
+#   every pipeline and task that hasn't specified an explicit version in
+#   the respective pipeline configuration.
+#
+# Example:
+#
+# ---
+# message: "Bazel 0.20.0 is broken"
+# issue_url: "https://github.com/bazelbuild/bazel/issues/123"
+# last_good_bazel: "0.19.0"
+#
+#
+# ATTENTION:
+# Please do not clear or delete this file when an incident is over.
+# Instead, simply replace all values with empty strings ("").
+---
+message: "We had to disable Bazel 0.23.0 due to a problem with remote caching."
+issue_url: "https://github.com/bazelbuild/bazel/issues/7555"
+last_good_bazel: "0.22.0"


### PR DESCRIPTION
emergency.yml provides a single location where the following settings can
be configured in the case of an emergency:
- A message that will be displayed on top of every build on CI,
- A link to a GitHub issue that will be displayed with the message,
- A known last good version of Bazel that will be used to run all
  pipelines and tasks that do not explicitly specify a version of Bazel
  in the pipeline configuration.

Examples:
- https://buildkite.com/bazel/fwe-test/builds/47: Run with an emergency (note Bazel version 0.22.0 in the test logs)
- https://buildkite.com/bazel/fwe-test/builds/48: Run without an emergency