### PR TITLE
Update Bazelisk on Linux workers to 0.0.2.

### DIFF
--- a/buildkite/docker/Dockerfile
+++ b/buildkite/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN mkdir -p /opt/android-sdk-linux && \
     chown -R root:root /opt/android-sdk-linux
 
 FROM builder AS bazelisk
-RUN curl -Lo /usr/local/bin/bazel https://github.com/philwo/bazelisk/releases/download/v0.0.1/bazelisk-linux-amd64 && \
+RUN curl -Lo /usr/local/bin/bazel https://github.com/philwo/bazelisk/releases/download/v0.0.2/bazelisk-linux-amd64 && \
     chown root:root /usr/local/bin/bazel && \
     chmod 0755 /usr/local/bin/bazel
 

--- a/buildkite/setup-docker.sh
+++ b/buildkite/setup-docker.sh
@@ -98,7 +98,7 @@ EOF
 # TODO: We can remove this, once we run the "Setup" step inside a Docker container, too.
 # TODO: Automatically fetch the latest release.
 {
-  curl -Lo /usr/local/bin/bazel https://github.com/philwo/bazelisk/releases/download/v0.0.1/bazelisk-linux-amd64
+  curl -Lo /usr/local/bin/bazel https://github.com/philwo/bazelisk/releases/download/v0.0.2/bazelisk-linux-amd64
   chown root:root /usr/local/bin/bazel
   chmod 0755 /usr/local/bin/bazel
 }


### PR DESCRIPTION
This PR is a part of the solution to https://github.com/bazelbuild/continuous-integration/issues/525.