### PR TITLE
Update Buildifier to 0.22.0

### DIFF
--- a/buildifier/Dockerfile
+++ b/buildifier/Dockerfile
@@ -2,7 +2,7 @@ FROM python:alpine
 
 # Latest release from: https://github.com/bazelbuild/buildtools/releases
 RUN apk add curl && \
-    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.20.0/buildifier && \
+    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.22.0/buildifier && \
     chown root:root /usr/local/bin/buildifier && \
     chmod 0755 /usr/local/bin/buildifier
 


### PR DESCRIPTION
I'm seeing some weird errors while testing formatting support (https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/1916#1a0b4746-ced0-472c-8ac1-19bf4b6c09e8) and cannot reproduce them locally with the latest Buildifier version 0.22.0.
CI has been using 0.20.0, which might be an explanation. Irregardless of this specific issue using the latest version is a good idea.

(https://github.com/bazelbuild/continuous-integration/issues/506)