### PR TITLE
Improve Bazelisk + Incompatible flags pipeline

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -914,6 +914,14 @@ def execute_shell_commands(commands):
     execute_command([shell_command], shell=True)
 
 
+def handle_bazel_failure(exception, action):
+    msg = "bazel {0} failed with exit code {1}".format(action, exception.returncode)
+    if use_bazelisk_migrate():
+        print_collapsed_group(msg)
+    else:
+        raise BuildkiteException(msg)
+
+
 def execute_bazel_run(bazel_binary, platform, targets, incompatible_flags):
     if not targets:
         return
@@ -933,11 +941,7 @@ def execute_bazel_run(bazel_binary, platform, targets, incompatible_flags):
                 + [target]
             )
         except subprocess.CalledProcessError as e:
-            msg = "bazel run failed with exit code {}".format(e.returncode)
-            if use_bazelisk_migrate():
-                print_collapsed_group(msg)
-            else:
-                raise BuildkiteException(msg)
+            handle_bazel_failure(e, "run")
 
 
 def remote_caching_flags(platform):
@@ -1146,11 +1150,7 @@ def execute_bazel_build(
             [bazel_binary] + bazelisk_flags() + common_startup_flags(platform) + ["build"] + aggregated_flags + targets
         )
     except subprocess.CalledProcessError as e:
-        msg = "bazel build failed with exit code {}".format(e.returncode)
-        if use_bazelisk_migrate():
-            print_collapsed_group(msg)
-        else:
-            raise BuildkiteException(msg)
+        handle_bazel_failure(e, "build")
 
 
 def execute_bazel_test(
@@ -1188,11 +1188,7 @@ def execute_bazel_test(
             [bazel_binary] + bazelisk_flags() + common_startup_flags(platform) + ["test"] + aggregated_flags + targets
         )
     except subprocess.CalledProcessError as e:
-        msg = "bazel test failed with exit code {}".format(e.returncode)
-        if use_bazelisk_migrate():
-            print_collapsed_group(msg)
-        else:
-            raise BuildkiteException(msg)
+        handle_bazel_failure(e, "test")
 
 
 def upload_test_logs(bep_file, tmpdir):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -922,15 +922,22 @@ def execute_bazel_run(bazel_binary, platform, targets, incompatible_flags):
     # incompatible flags set by "INCOMPATIBLE_FLAGS" env var will be ignored.
     incompatible_flags_to_use = [] if (use_bazelisk_migrate() or not incompatible_flags) else incompatible_flags
     for target in targets:
-        execute_command(
-            [bazel_binary]
-            + bazelisk_flags()
-            + common_startup_flags(platform)
-            + ["run"]
-            + common_build_flags(None, platform)
-            + incompatible_flags_to_use
-            + [target]
-        )
+        try:
+            execute_command(
+                [bazel_binary]
+                + bazelisk_flags()
+                + common_startup_flags(platform)
+                + ["run"]
+                + common_build_flags(None, platform)
+                + incompatible_flags_to_use
+                + [target]
+            )
+        except subprocess.CalledProcessError as e:
+            msg = "bazel run failed with exit code {}".format(e.returncode)
+            if use_bazelisk_migrate():
+                print_collapsed_group(msg)
+            else:
+                raise BuildkiteException(msg)
 
 
 def remote_caching_flags(platform):
@@ -1139,7 +1146,11 @@ def execute_bazel_build(
             [bazel_binary] + bazelisk_flags() + common_startup_flags(platform) + ["build"] + aggregated_flags + targets
         )
     except subprocess.CalledProcessError as e:
-        raise BuildkiteException("bazel build failed with exit code {}".format(e.returncode))
+        msg = "bazel build failed with exit code {}".format(e.returncode)
+        if use_bazelisk_migrate():
+            print_collapsed_group(msg)
+        else:
+            raise BuildkiteException(msg)
 
 
 def execute_bazel_test(
@@ -1177,7 +1188,11 @@ def execute_bazel_test(
             [bazel_binary] + bazelisk_flags() + common_startup_flags(platform) + ["test"] + aggregated_flags + targets
         )
     except subprocess.CalledProcessError as e:
-        raise BuildkiteException("bazel test failed with exit code {}".format(e.returncode))
+        msg = "bazel test failed with exit code {}".format(e.returncode)
+        if use_bazelisk_migrate():
+            print_collapsed_group(msg)
+        else:
+            raise BuildkiteException(msg)
 
 
 def upload_test_logs(bep_file, tmpdir):


### PR DESCRIPTION
1. The job will continue to finish all run/build/test steps if Bazelisk --migrate detects incompatible flags that need migration (in this cause, it returns 1, which will immediately fail the job currently).

2. We parse all "+++ Result" sections from the log

FYI @laurentlb @hlopko 