### PR TITLE
Read Buildifier version from env variables.

### DIFF
--- a/buildifier/buildifier.py
+++ b/buildifier/buildifier.py
@@ -231,7 +231,7 @@ def main(argv=None):
         output = create_heading("format", len(unformatted_files))
         display_version = " {}".format(version) if version else ""
         output += (
-            "Please download <a href=\'{}\'>buildifier{}</a> and run the following "
+            "Please download <a href=\"{}\">buildifier{}</a> and run the following "
             "command in your workspace:<br/><pre><code>buildifier {}</code></pre>"
             "\n".format(display_url, display_version, " ".join(unformatted_files))
         )

--- a/buildifier/buildifier.py
+++ b/buildifier/buildifier.py
@@ -136,7 +136,9 @@ def get_releases():
 
 
 def get_release_urls(release):
-    buildifier_assets = [a for a in release["assets"] if a["name"] in ("buildifier", "buildifier.linux")]
+    buildifier_assets = [
+        a for a in release["assets"] if a["name"] in ("buildifier", "buildifier.linux")
+    ]
     if not buildifier_assets:
         raise Exception("There is no Buildifier binary for release {}".format(release["tag_name"]))
 
@@ -144,8 +146,7 @@ def get_release_urls(release):
 
 
 def download_buildifier(url):
-    tmpdir = tempfile.mkdtemp()
-    path = os.path.join(tmpdir, "buildifier")
+    path = os.path.join(tempfile.mkdtemp(), "buildifier")
     with closing(urlopen(url)) as response:
         with open(path, "wb") as out_file:
             shutil.copyfileobj(response, out_file)
@@ -230,7 +231,7 @@ def main(argv=None):
         output = create_heading("format", len(unformatted_files))
         display_version = " {}".format(version) if version else ""
         output += (
-            'Please download <a href="{}">buildifier{}</a> and run the following '
+            "Please download <a href=\'{}\'>buildifier{}</a> and run the following "
             "command in your workspace:<br/><pre><code>buildifier {}</code></pre>"
             "\n".format(display_url, display_version, " ".join(unformatted_files))
         )

--- a/buildifier/buildifier.py
+++ b/buildifier/buildifier.py
@@ -230,7 +230,7 @@ def main(argv=None):
         output = create_heading("format", len(unformatted_files))
         display_version = " {}".format(version) if version else ""
         output += (
-            'Please download <a href="{}">buildifier</a>{} and run the following '
+            'Please download <a href="{}">buildifier{}</a> and run the following '
             "command in your workspace:<br/><pre><code>buildifier {}</code></pre>"
             "\n".format(display_url, display_version, " ".join(unformatted_files))
         )


### PR DESCRIPTION
buildifier.py will download and use the version of Buildifier that is
specified in the BUILDIFIER_VERSION environment variable.
If this variable is not set, the script continues to use the
Buildifier binary that is part of the Docker image.

This PR doesn't have any effect on CI yet since we don't set BUILDIFIER_VERSION in bazel.ci.py (which will happen in a future PR).

https://github.com/bazelbuild/continuous-integration/issues/530