### PR TITLE
Read Buildifier version from presubmit config.

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -252,11 +252,12 @@ For each pipeline you can enable [Buildifier](https://github.com/bazelbuild/buil
 
 ```yaml
 ---
-buildifier: true
+buildifier: latest
 [...]
 ```
 
 As a consequence, every future build for this pipeline will contain an additional "Buildifier" step that runs the latest version of Buildifier both in "lint" and "check" mode.
+Alternatively you can specify a particular Buildifier version such as "0.20.0".
 
 ### Using multiple Workspaces in a single Pipeline
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -399,6 +399,8 @@ EDql
 
 BUILD_LABEL_PATTERN = re.compile(r"^Build label: (\S+)$", re.MULTILINE)
 
+BUILDIFIER_VERSION_ENV_VAR = "BUILDIFIER_VERSION"
+
 
 class BuildkiteException(Exception):
     """
@@ -928,7 +930,9 @@ def execute_bazel_run(bazel_binary, platform, targets, incompatible_flags):
     print_collapsed_group("Setup (Run Targets)")
     # When using bazelisk --migrate to test incompatible flags,
     # incompatible flags set by "INCOMPATIBLE_FLAGS" env var will be ignored.
-    incompatible_flags_to_use = [] if (use_bazelisk_migrate() or not incompatible_flags) else incompatible_flags
+    incompatible_flags_to_use = (
+        [] if (use_bazelisk_migrate() or not incompatible_flags) else incompatible_flags
+    )
     for target in targets:
         try:
             execute_command(
@@ -1143,11 +1147,16 @@ def execute_bazel_build(
         # incompatible flags set by "INCOMPATIBLE_FLAGS" env var will be ignored.
         [] if (use_bazelisk_migrate() or not incompatible_flags) else incompatible_flags,
         bep_file,
-        enable_remote_cache=True
+        enable_remote_cache=True,
     )
     try:
         execute_command(
-            [bazel_binary] + bazelisk_flags() + common_startup_flags(platform) + ["build"] + aggregated_flags + targets
+            [bazel_binary]
+            + bazelisk_flags()
+            + common_startup_flags(platform)
+            + ["build"]
+            + aggregated_flags
+            + targets
         )
     except subprocess.CalledProcessError as e:
         handle_bazel_failure(e, "build")
@@ -1180,12 +1189,17 @@ def execute_bazel_test(
         # incompatible flags set by "INCOMPATIBLE_FLAGS" env var will be ignored.
         [] if (use_bazelisk_migrate() or not incompatible_flags) else incompatible_flags,
         bep_file,
-        enable_remote_cache=not monitor_flaky_tests
+        enable_remote_cache=not monitor_flaky_tests,
     )
 
     try:
         execute_command(
-            [bazel_binary] + bazelisk_flags() + common_startup_flags(platform) + ["test"] + aggregated_flags + targets
+            [bazel_binary]
+            + bazelisk_flags()
+            + common_startup_flags(platform)
+            + ["test"]
+            + aggregated_flags
+            + targets
         )
     except subprocess.CalledProcessError as e:
         handle_bazel_failure(e, "test")
@@ -1310,7 +1324,11 @@ def create_step(label, commands, platform=DEFAULT_PLATFORM):
         }
 
 
-def create_docker_step(label, image, commands=None):
+def create_docker_step(label, image, commands=None, additional_env_vars=None):
+    env = ["BUILDKITE_ARTIFACT_UPLOAD_DESTINATION", "BUILDKITE_GS_ACL"]
+    if additional_env_vars:
+        env += ["{}={}".format(k, v) for k, v in additional_env_vars.items()]
+
     step = {
         "label": label,
         "command": commands,
@@ -1319,7 +1337,7 @@ def create_docker_step(label, image, commands=None):
             "philwo/docker": {
                 "always-pull": True,
                 "debug": True,
-                "environment": ["BUILDKITE_ARTIFACT_UPLOAD_DESTINATION", "BUILDKITE_GS_ACL"],
+                "environment": env,
                 "image": image,
                 "network": "host",
                 "privileged": True,
@@ -1358,8 +1376,15 @@ def print_project_pipeline(
     is_downstream_project = (use_but or incompatible_flags) and git_repository and project_name
 
     # Skip Buildifier when we test downstream projects.
-    if not is_downstream_project and configs.get("buildifier"):
-        pipeline_steps.append(create_docker_step("Buildifier", image=BUILDIFIER_DOCKER_IMAGE))
+    buildifier_version = configs.get("buildifier")
+    if not is_downstream_project and buildifier_version:
+        pipeline_steps.append(
+            create_docker_step(
+                "Buildifier",
+                image=BUILDIFIER_DOCKER_IMAGE,
+                additional_env_vars={BUILDIFIER_VERSION_ENV_VAR: buildifier_version},
+            )
+        )
 
     # In Bazel Downstream Project pipelines, we should test the project at the last green commit.
     git_commit = None


### PR DESCRIPTION
Users can now specify a particular version of Buildifier (or "latest") in the presubmit configuration.

Merging this commit won't have any effect until I merge https://github.com/bazelbuild/continuous-integration/pull/541 and create a new Docker image.

https://github.com/bazelbuild/continuous-integration/issues/530