### PR TITLE
Refactor Buildkite API calls.

### DIFF
--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -22,7 +22,7 @@ import bazelci
 
 INCOMPATIBLE_FLAGS = bazelci.fetch_incompatible_flags()
 
-ORG = "bazel"
+BUILDKITE_ORG = "bazel"
 
 PIPELINE = "bazelisk-plus-incompatible-flags"
 
@@ -158,7 +158,7 @@ def main(argv=None):
     args = parser.parse_args(argv)
     try:
         if args.build_number:
-            client = bazelci.BuildkiteClient(org=ORG, pipeline=PIPELINE)
+            client = bazelci.BuildkiteClient(org=BUILDKITE_ORG, pipeline=PIPELINE)
             print_result_info(args.build_number, client)
         else:
             parser.print_help()

--- a/buildkite/incompatible_flag_verbose_failures.py
+++ b/buildkite/incompatible_flag_verbose_failures.py
@@ -26,7 +26,7 @@ from bazelci import BuildkiteException
 # under.
 BUILDKITE_MAX_JOBS_LIMIT = 1500
 
-ORG = "bazel"
+BUILDKITE_ORG = "bazel"
 
 PIPELINE = "bazel-at-release-plus-incompatible-flags"
 
@@ -133,7 +133,7 @@ def main(argv=None):
     args = parser.parse_args(argv)
     try:
         if args.build_number:
-            client = bazelci.BuildkiteClient(org=ORG, pipeline=PIPELINE)
+            client = bazelci.BuildkiteClient(org=BUILDKITE_ORG, pipeline=PIPELINE)
             build_info = client.get_build_info(args.build_number)
             print_steps_for_failing_jobs(build_info)
         else:


### PR DESCRIPTION
This commit merges the almost-identical code for calling the Buildkite API from incompatible_flag_verbose_failures and aggregate_incompatible_flags_test_result into a single class in bazelci.
While this seems like a good idea from a clean-code-point of view,
it also helps us with https://github.com/bazelbuild/continuous-integration/issues/543 since we will need this functionality in bazelci anyway [*].
Moreover, this commit fixes some lint warnings.

[*] The last green commit for a pipeline is only updated if all previous steps for a given build have finished successfully. However, this means that a failing Buildifier step prevents us from updating the last green commit, even if all tests have passed. Buildkite doesn't offer an easy solution since there is no way to say "only execute this step until *some* of the previous ones have succeeded". Putting the Buildifier step to the end of the pipeline doesn't make sense either since that step would never run if there was a test failure. Consequently, the solution is to wait for all jobs to finish, then always run the "try update last green commit" step (even if previous steps failed), but use the newly-added Buildkite client class to check whether all steps except for Buildifier have succeeded, and then update the commit (or not, depending on the step results).