### PR TITLE
Fix a bug in aggregate_incompatible_flags_test_result.py

### DIFF
--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -54,7 +54,7 @@ def process_build_log(failed_jobs_per_flag, already_failing_jobs, log, job):
         lines = log[index_failure:].split("\n")
         for line in lines:
             line = line.strip()
-            if line.startswith("--incompatible_") and line in failed_jobs_per_flag:
+            if line.startswith("--incompatible_") and line in INCOMPATIBLE_FLAGS:
                 failed_jobs_per_flag[line][job["id"]] = job
         log = log[0: log.rfind("+++ Result")]
 


### PR DESCRIPTION
After https://github.com/bazelbuild/continuous-integration/pull/545/files, `failed_jobs_per_flag` is not initialized anymore. We should decide if a flag should be added by checking INCOMPATIBLE_FLAGS instead of `failed_jobs_per_flag`