### PR TITLE
Handle "wait" step when updating the last green.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1968,11 +1968,10 @@ def try_update_last_green_commit():
 
     # Find any failing steps other than Buildifier and "try update last green".
     def HasFailed(job):
-        # Some irrelevant job doesn't have "state" field.
-        if "state" not in job:
-            return True
+        state = job.get("state")
+        # Ignore steps that don't have a state (like "wait").
         return (
-            job["state"] != "passed"
+            state != None and state != "passed"
             and job["id"] != current_job_id
             and job["name"] != BUILDIFIER_STEP_NAME
         )

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1971,7 +1971,7 @@ def try_update_last_green_commit():
         state = job.get("state")
         # Ignore steps that don't have a state (like "wait").
         return (
-            state != None and state != "passed"
+            state is not None and state != "passed"
             and job["id"] != current_job_id
             and job["name"] != BUILDIFIER_STEP_NAME
         )


### PR DESCRIPTION
This step has no state and name, and thus crashed the CI script.

Fixes https://github.com/bazelbuild/continuous-integration/issues/552