### PR TITLE
Show flags ready to flip again

### DIFF
--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -69,8 +69,8 @@ def get_html_link_text(content, link):
 
 def construct_success_info(failed_jobs_per_flag):
     info_text = ["#### The following flags didn't break any passing jobs"]
-    for flag, jobs in failed_jobs_per_flag.items():
-        if not jobs:
+    for flag in INCOMPATIBLE_FLAGS:
+        if flag not in failed_jobs_per_flag:
             github_url = INCOMPATIBLE_FLAGS[flag]
             info_text.append(f"* **{flag}** " + get_html_link_text(":github:", github_url))
     if len(info_text) == 1:


### PR DESCRIPTION
https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/36 was not showing up incompatible flags that're ready to flip.


Flags that's not breaking any jobs were not added into `failed_jobs_per_flag` anymore, we should check all flags from `INCOMPATIBLE_FLAGS`