### PR TITLE
Display all jobs of a pipeline in the same line.

### DIFF
--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -106,7 +106,7 @@ def merge_and_format_jobs(jobs, line_prefix):
     #   pipeline (platform3)
     # with line_prefix ">> " becomes
     #   >> pipeline: platform1, platform2, platform3
-    jobs_per_pipeline = collections.defaultdict([])
+    jobs_per_pipeline = collections.defaultdict(list)
     for job in jobs:
         pipeline, platform = get_pipeline_and_platform(job)
         jobs_per_pipeline[pipeline].append(get_html_link_text(platform, job["web_url"]))

--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -111,7 +111,7 @@ def merge_and_format_jobs(jobs, line_prefix):
         pipeline, platform = get_pipeline_and_platform(job)
         jobs_per_pipeline[pipeline].append(get_html_link_text(platform, job["web_url"]))
 
-    return ["{}{}: {}".format(line_prefix, pipeline, ", ".join(platforms)) for pipeline, platforms in jobs_per_pipeline.items()]
+    return ["{}**{}**: {}".format(line_prefix, pipeline, ", ".join(platforms)) for pipeline, platforms in jobs_per_pipeline.items()]
 
 
 def get_pipeline_and_platform(job):


### PR DESCRIPTION
This commit changes the output from
- pipeline (platform1)
- pipeline (platform2)
- ...
- pipeline (platformN)

to

- pipeline: platform1, platform2, ..., platformN

Before: https://buildkite.com/bazel/pcloudy-test/builds/19
After: https://buildkite.com/bazel/pcloudy-test/builds/21