### PR TITLE
Revert "disable android testing"

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -58,7 +58,6 @@ DOWNSTREAM_PROJECTS = {
         "git_repository": "https://github.com/googlesamples/android-testing.git",
         "http_config": "https://raw.githubusercontent.com/googlesamples/android-testing/master/bazelci/buildkite-pipeline.yml",
         "pipeline_slug": "android-testing",
-        "disabled_reason": "https://github.com/googlesamples/android-testing/issues/250",
     },
     "Bazel": {
         "git_repository": "https://github.com/bazelbuild/bazel.git",


### PR DESCRIPTION
This reverts commit c0bcaafacc276527d3eeb1e05251974f1df4025c.

Android testing now passes with HEAD on Linux and macOS https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/855#_

Windows pipeline has been disabled upstream in https://github.com/googlesamples/android-testing/pull/251

https://github.com/googlesamples/android-testing/blob/fbb1f7e9fdf1cf8135326393e358d4fda13b82fe/bazelci/buildkite-pipeline.yml#L52