### PR TITLE
Display failing projects with style "error"

### DIFF
--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -120,7 +120,7 @@ def print_projects_need_to_migrate(failed_jobs_per_flag):
             "annotate",
             "--append",
             f"--context=projects_need_migration",
-            f"--style=warning",
+            f"--style=error",
             f"\n{info_str}\n",
         ]
     )


### PR DESCRIPTION
For consistency it makes sense that both newly failing projects and jobs have style "error", while pre-existing failures have style "warning".