### PR TITLE
Publish last green commit of downstream pipeline.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1901,8 +1901,9 @@ def print_bazel_downstream_pipeline(
                     ],
                 )
             )
-    else:
-        # Only update the last green downstream commit in the regular Bazel@HEAD + Downstream pipeline (i.e. without incompatible flags).
+
+    if not test_disabled_projects and not test_incompatible_flags:
+        # Only update the last green downstream commit in the regular Bazel@HEAD + Downstream pipeline.
         pipeline_steps.append("wait")
         pipeline_steps.append(
             create_step(

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1483,7 +1483,9 @@ def print_project_pipeline(
     # In Bazel Downstream Project pipelines, we should test the project at the last green commit.
     git_commit = None
     if is_downstream_project:
-        last_green_commit_url = bazelci_last_green_commit_url(git_repository, DOWNSTREAM_PROJECTS[project_name]["pipeline_slug"])
+        last_green_commit_url = bazelci_last_green_commit_url(
+            git_repository, DOWNSTREAM_PROJECTS[project_name]["pipeline_slug"]
+        )
         git_commit = get_last_green_commit(last_green_commit_url)
 
     for task, task_config in task_configs.items():
@@ -1969,7 +1971,8 @@ def try_update_last_green_commit():
         state = job.get("state")
         # Ignore steps that don't have a state (like "wait").
         return (
-            state is not None and state != "passed"
+            state is not None
+            and state != "passed"
             and job["id"] != current_job_id
             and job["name"] != BUILDIFIER_STEP_NAME
         )
@@ -2004,14 +2007,7 @@ def update_last_green_commit_if_newer(last_green_commit_url):
     # commits, otherwise the output should be empty.
     if not last_green_commit or result:
         execute_command(
-            [
-                "echo %s | %s cp - %s"
-                % (
-                    current_commit,
-                    gsutil_command(),
-                    last_green_commit_url,
-                )
-            ],
+            ["echo %s | %s cp - %s" % (current_commit, gsutil_command(), last_green_commit_url)],
             shell=True,
         )
     else:

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1483,9 +1483,8 @@ def print_project_pipeline(
     # In Bazel Downstream Project pipelines, we should test the project at the last green commit.
     git_commit = None
     if is_downstream_project:
-        git_commit = get_last_green_commit(
-            git_repository, DOWNSTREAM_PROJECTS[project_name]["pipeline_slug"]
-        )
+        last_green_commit_url = bazelci_last_green_commit_url(git_repository, DOWNSTREAM_PROJECTS[project_name]["pipeline_slug"])
+        git_commit = get_last_green_commit(last_green_commit_url)
 
     for task, task_config in task_configs.items():
         step = runner_step(
@@ -1900,6 +1899,18 @@ def print_bazel_downstream_pipeline(
                     ],
                 )
             )
+    else:
+        # Only update the last green downstream commit in the regular Bazel@HEAD + Downstream pipeline (i.e. without incompatible flags).
+        pipeline_steps.append("wait")
+        pipeline_steps.append(
+            create_step(
+                label="Try Update Last Green Downstream Commit",
+                commands=[
+                    fetch_bazelcipy_command(),
+                    python_binary() + " bazelci.py try_update_last_green_downstream_commit",
+                ],
+            )
+        )
 
     print(yaml.dump({"steps": pipeline_steps}))
 
@@ -1926,8 +1937,12 @@ def bazelci_last_green_commit_url(git_repository, pipeline_slug):
     )
 
 
-def get_last_green_commit(git_repository, pipeline_slug):
-    last_green_commit_url = bazelci_last_green_commit_url(git_repository, pipeline_slug)
+def bazelci_last_green_downstream_commit_url():
+    # Downstream pipeline runs in the unstrusted org
+    return "gs://bazel-untrusted-builds/last_green_commit/downstream_pipeline"
+
+
+def get_last_green_commit(last_green_commit_url):
     try:
         return (
             subprocess.check_output(
@@ -1968,7 +1983,12 @@ def try_update_last_green_commit():
         )
 
     git_repository = os.getenv("BUILDKITE_REPO")
-    last_green_commit = get_last_green_commit(git_repository, pipeline_slug)
+    last_green_commit_url = bazelci_last_green_commit_url(git_repository, pipeline_slug)
+    update_last_green_commit_if_newer(last_green_commit_url)
+
+
+def update_last_green_commit_if_newer(last_green_commit_url):
+    last_green_commit = get_last_green_commit(last_green_commit_url)
     current_commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf-8").strip()
     if last_green_commit:
         execute_command(["git", "fetch", "-v", "origin", last_green_commit])
@@ -1989,7 +2009,7 @@ def try_update_last_green_commit():
                 % (
                     current_commit,
                     gsutil_command(),
-                    bazelci_last_green_commit_url(git_repository, pipeline_slug),
+                    last_green_commit_url,
                 )
             ],
             shell=True,
@@ -1999,6 +2019,11 @@ def try_update_last_green_commit():
             "Updating abandoned: last green commit (%s) is not older than current commit (%s)."
             % (last_green_commit, current_commit)
         )
+
+
+def try_update_last_green_downstream_commit():
+    last_green_commit_url = bazelci_last_green_downstream_commit_url()
+    update_last_green_commit_if_newer(last_green_commit_url)
 
 
 def latest_generation_and_build_number():
@@ -2203,6 +2228,7 @@ def main(argv=None):
     runner = subparsers.add_parser("publish_binaries")
 
     runner = subparsers.add_parser("try_update_last_green_commit")
+    runner = subparsers.add_parser("try_update_last_green_downstream_commit")
 
     args = parser.parse_args(argv)
 
@@ -2267,7 +2293,11 @@ def main(argv=None):
         elif args.subparsers_name == "publish_binaries":
             publish_binaries()
         elif args.subparsers_name == "try_update_last_green_commit":
+            # Update the last green commit of a project pipeline
             try_update_last_green_commit()
+        elif args.subparsers_name == "try_update_last_green_downstream_commit":
+            # Update the last green commit of the downstream pipeline
+            try_update_last_green_downstream_commit()
         else:
             parser.print_help()
             return 2


### PR DESCRIPTION
As a result the most recent commit that passes the regular
Bazel@head downstream pipeline will be published to GCS, so that it can
be used by Bazelisk (and other tools).

Part of https://github.com/bazelbuild/continuous-integration/issues/583