### PR TITLE
Print information about successful GCE operations.

### DIFF
--- a/buildkite/create_instances.py
+++ b/buildkite/create_instances.py
@@ -73,8 +73,11 @@ def worker():
                     template_name, project=project).returncode == 0:
                 print("Deleted existing VM template: {}".format(template_name))
 
+            print("Creating a new template and then a new instance group for project {}".format(project))
+
             gcloud.create_instance_template(
                 template_name, project=project, **item)
+            print("Created instance template {}}".format(template_name))
 
             kwargs = {
                 "project": project,
@@ -87,6 +90,7 @@ def worker():
             elif region is not None:
                 kwargs["region"] = region
             gcloud.create_instance_group(instance_group_name, **kwargs)
+            print("Created instance group {}}".format(instance_group_name))
         finally:
             WORK_QUEUE.task_done()
 


### PR DESCRIPTION
Running create_instances has been very irritating since it used to only
print messages about the deletion of VM resources, but not about their
creation.