### PR TITLE
Re-enable TensorFlow in downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -293,7 +293,6 @@ DOWNSTREAM_PROJECTS = {
         "git_repository": "https://github.com/tensorflow/tensorflow.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/pipelines/tensorflow-postsubmit.yml",
         "pipeline_slug": "tensorflow",
-        "disabled_reason": "https://github.com/tensorflow/tensorflow/issues/26388",
     },
     "Tulsi": {
         "git_repository": "https://github.com/bazelbuild/tulsi.git",


### PR DESCRIPTION
TensorFlow is finally green with Bazel@HEAD again:
https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/148