### PR TITLE
Allow pipeline tasks to be skipped.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1777,7 +1777,7 @@ def print_skip_task_annotations(annotations, pipeline_steps):
         for s, t in annotations
     ]
     pipeline_steps.append(
-        create_step(label=":pipeline: Print information about skipped tasks.", commands=commands)
+        create_step(label=":pipeline: Print information about skipped tasks", commands=commands)
     )
 
 


### PR DESCRIPTION
Presubmit requests can list individual tasks that should be skipped. In this case the Buildkite UI will show a message notifying the user which tasks have been skipped.