### PR TITLE
Do not print message if there are no skip_tasks

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1736,7 +1736,6 @@ def bazel_build_step(
 def filter_tasks_that_should_be_skipped(task_configs, pipeline_steps):
     skip_tasks = get_skip_tasks()
     if not skip_tasks:
-        eprint("No tasks to skip.")
         return task_configs
 
     actually_skipped = []


### PR DESCRIPTION
The output should only contain the yaml pipeline configuration without any unstructured text.