### PR TITLE
Implement sharding of build and test targets

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1291,7 +1291,7 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
             "tests(set({}))".format(" ".join("'{}'".format(t) for t in test_targets if t != "--")),
         ]
     )
-    return sorted(output.split("\n"))
+    return [t for t in output.split("\n") if t]
 
 
 def get_test_targets_for_shard(test_targets, shard_id, shard_count):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1251,9 +1251,6 @@ def execute_bazel_build(
 ):
     print_expanded_group(":bazel: Build ({})".format(bazel_version))
 
-    # TODO(fweikert): remove
-    return
-
     aggregated_flags = compute_flags(
         platform,
         flags,
@@ -1332,10 +1329,6 @@ def execute_bazel_test(
     incompatible_flags,
 ):
     print_expanded_group(":bazel: Test ({})".format(bazel_version))
-
-    # TODO(fweikert): remove
-    eprint(targets)
-    raise BuildkiteException("sharded")
 
     aggregated_flags = [
         "--flaky_test_attempts=3",

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -515,7 +515,8 @@ def bazelcipy_url():
     """
     URL to the latest version of this script.
     """
-    return "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?{}".format(
+    # TODO(fweikert): change this
+    return "https://raw.githubusercontent.com/fweikert/continuous-integration/shard/buildkite/bazelci.py?{}".format(
         int(time.time())
     )
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -514,7 +514,8 @@ def bazelcipy_url():
     """
     URL to the latest version of this script.
     """
-    return "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?{}".format(
+    # TODO: https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py
+    return "https://raw.githubusercontent.com/fweikert/continuous-integration/shard/buildkite/bazelci.py?{}".format(
         int(time.time())
     )
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1297,29 +1297,8 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
 
 def get_targets_for_shard(build_targets, test_targets, shard_id, shard_count):
     # TODO(fweikert): implement a more sophisticated algorithm
-    all_targets = [("build", t) for t in sorted(build_targets)] + [
-        ("test", t) for t in sorted(test_targets)
-    ]
-    targets_for_this_shard = []
-    index = shard_id
-    target_count = len(all_targets)
-    while index < target_count:
-        targets_for_this_shard.append(all_targets[index])
-        index += shard_count
-
-    eprint(
-        "Actions for shard {} of {}:\n\t{}".format(
-            shard_id + 1,
-            shard_count,
-            "\n\t".join("{} {}".format(a, t) for a, t in targets_for_this_shard),
-        )
-    )
-
-    build_targets_for_this_shard = []
-    test_targets_for_this_shard = []
-    for a, t in targets_for_this_shard:
-        dest = build_targets_for_this_shard if a == "build" else test_targets_for_this_shard
-        dest.append(t)
+    build_targets_for_this_shard = sorted(build_targets)[shard_id::shard_count]
+    test_targets_for_this_shard = sorted(test_targets)[shard_id::shard_count]
 
     return build_targets_for_this_shard, test_targets_for_this_shard
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1289,7 +1289,7 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
         ],
         print_output=False,
     )
-    return [t for t in output.split("\n") if t.startswith('//')]
+    return [t for t in output.split("\n") if t.startswith("//")]
 
 
 def get_targets_for_shard(build_targets, test_targets, shard_id, shard_count):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -515,8 +515,7 @@ def bazelcipy_url():
     """
     URL to the latest version of this script.
     """
-    # TODO(fweikert): change this
-    return "https://raw.githubusercontent.com/fweikert/continuous-integration/shard/buildkite/bazelci.py?{}".format(
+    return "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?{}".format(
         int(time.time())
     )
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1302,13 +1302,13 @@ def get_targets_for_shard(build_targets, test_targets, shard_id, shard_count):
     all_targets = [("build", t) for t in sorted(build_targets)] + [
         ("test", t) for t in sorted(test_targets)
     ]
+    targets_for_this_shard = []
+    index = shard_id
     target_count = len(all_targets)
-    targets_per_shard = math.ceil(target_count / shard_count)
-    start_index = shard_id * targets_per_shard
+    while index < target_count:
+        targets_for_this_shard.append(all_targets[index])
+        index += shard_count
 
-    build_targets_for_this_shard = []
-    test_targets_for_this_shard = []
-    targets_for_this_shard = all_targets[start_index : start_index + targets_per_shard]
     eprint(
         "Actions for shard {} of {}:\n\t{}".format(
             shard_id + 1,
@@ -1316,6 +1316,9 @@ def get_targets_for_shard(build_targets, test_targets, shard_id, shard_count):
             "\n\t".join("{} {}".format(a, t) for a, t in targets_for_this_shard),
         )
     )
+
+    build_targets_for_this_shard = []
+    test_targets_for_this_shard = []
     for a, t in targets_for_this_shard:
         dest = build_targets_for_this_shard if a == "build" else test_targets_for_this_shard
         dest.append(t)

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1289,7 +1289,7 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
         ],
         print_output=False,
     )
-    return [t for t in output.split("\n") if t]
+    return [t for t in output.split("\n") if t.startswith('//')]
 
 
 def get_targets_for_shard(build_targets, test_targets, shard_id, shard_count):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1282,9 +1282,6 @@ def calculate_targets(task_config, platform, bazel_binary, build_only, test_only
 
 
 def expand_test_target_patterns(bazel_binary, platform, test_targets):
-    if not any(t for t in test_targets if t.endswith(":all") or t.endswith("...")):
-        return test_targets
-
     included_targets, excluded_targets = partition_test_targets(test_targets)
     excluded_string = (
         " except tests(set({}))".format(" ".join("'{}'".format(t) for t in excluded_targets))

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -514,8 +514,7 @@ def bazelcipy_url():
     """
     URL to the latest version of this script.
     """
-    # TODO: https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py
-    return "https://raw.githubusercontent.com/fweikert/continuous-integration/shard/buildkite/bazelci.py?{}".format(
+    return "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?{}".format(
         int(time.time())
     )
 
@@ -1268,9 +1267,6 @@ def calculate_targets(task_config, platform, bazel_binary, build_only, test_only
 
     shard_id = int(os.getenv("BUILDKITE_PARALLEL_JOB", "-1"))
     shard_count = int(os.getenv("BUILDKITE_PARALLEL_JOB_COUNT", "-1"))
-
-    print_collapsed_group("SHARD {} of {}".format(shard_id, shard_count))
-
     if shard_id > -1 and shard_count > -1:
         print_collapsed_group(
             ":female-detective: Calculating targets for shard {}/{}".format(

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1288,7 +1288,7 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
             "--nomaster_bazelrc",
             "--bazelrc=/dev/null",
             "query",
-            "tests(set({}))".format(" ".join("'{}'".format(t) for t in test_targets)),
+            "tests(set({}))".format(" ".join("'{}'".format(t) for t in test_targets if t != "--")),
         ]
     )
     return sorted(output.split("\n"))

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1267,6 +1267,9 @@ def calculate_targets(task_config, platform, bazel_binary, build_only, test_only
 
     shard_id = int(os.getenv("BUILDKITE_PARALLEL_JOB", "-1"))
     shard_count = int(os.getenv("BUILDKITE_PARALLEL_JOB_COUNT", "-1"))
+
+    print_collapsed_group("SHARD {} of {}".format(shard_id, shard_count))
+
     if shard_id > -1 and shard_count > -1:
         print_collapsed_group(
             ":female-detective: Calculating targets for shard {}/{}".format(
@@ -1287,7 +1290,7 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
 
     included_targets, excluded_targets = partition_test_targets(test_targets)
     excluded_string = (
-        " except set({})".format(" ".join("'{}'".format(t) for t in excluded_targets))
+        " except tests(set({}))".format(" ".join("'{}'".format(t) for t in excluded_targets))
         if excluded_targets
         else ""
     )

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -743,6 +743,11 @@ def execute_commands(
         shard_id = int(os.getenv("BUILDKITE_PARALLEL_JOB", "-1"))
         shard_count = int(os.getenv("BUILDKITE_PARALLEL_JOB_COUNT", "-1"))
         if shard_id > -1 and shard_count > -1:
+            print_collapsed_group(
+                ":female-detective: Calculating targets for shard {}/{}".format(
+                    shard_id + 1, shard_count
+                )
+            )
             expanded_test_targets = expand_test_target_patterns(
                 bazel_binary, platform, test_targets
             )
@@ -1277,7 +1282,7 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
     if not any(t for t in test_targets if t.endswith(":all") or t.endswith("...")):
         return test_targets
 
-    print_collapsed_group(":female-detective: Resolving test targets via bazel query")
+    eprint("Resolving test targets via bazel query")
     output = execute_command_and_get_output(
         [bazel_binary]
         + common_startup_flags(platform)

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1289,7 +1289,8 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
             "--bazelrc=/dev/null",
             "query",
             "tests(set({}))".format(" ".join("'{}'".format(t) for t in test_targets if t != "--")),
-        ]
+        ],
+        print_output=False,
     )
     return [t for t in output.split("\n") if t]
 
@@ -1442,7 +1443,7 @@ def test_logs_for_status(bep_file, status):
     return targets
 
 
-def execute_command_and_get_output(args, shell=False, fail_if_nonzero=True):
+def execute_command_and_get_output(args, shell=False, fail_if_nonzero=True, print_output=True):
     eprint(" ".join(args))
     process = subprocess.run(
         args,
@@ -1454,7 +1455,9 @@ def execute_command_and_get_output(args, shell=False, fail_if_nonzero=True):
         errors="replace",
         universal_newlines=True,
     )
-    eprint(process.stdout)
+    if print_output:
+        eprint(process.stdout)
+
     return process.stdout
 
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1308,7 +1308,7 @@ def get_targets_for_shard(build_targets, test_targets, shard_id, shard_count):
     targets_for_this_shard = all_targets[start_index : start_index + targets_per_shard]
     eprint(
         "Actions for shard {} of {}:\n\t{}".format(
-            shard_id,
+            shard_id + 1,
             shard_count,
             "\n\t".join("{} {}".format(a, t) for a, t in targets_for_this_shard),
         )

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1288,7 +1288,7 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
             "--nomaster_bazelrc",
             "--bazelrc=/dev/null",
             "query",
-            "'tests(set({}))'".format(" ".join(test_targets)),
+            "tests(set({}))".format(" ".join("'{}'".format(t) for t in test_targets)),
         ]
     )
     return sorted(output.split("\n"))

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1302,8 +1302,9 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
             ),
         ],
         print_output=False,
+        capture_stderr=False,
     )
-    return [t for t in output.split("\n") if t.startswith("//")]
+    return output.split("\n")
 
 
 def partition_test_targets(test_targets):
@@ -1445,7 +1446,9 @@ def test_logs_for_status(bep_file, status):
     return targets
 
 
-def execute_command_and_get_output(args, shell=False, fail_if_nonzero=True, print_output=True):
+def execute_command_and_get_output(
+    args, shell=False, fail_if_nonzero=True, print_output=True, capture_stderr=True
+):
     eprint(" ".join(args))
     process = subprocess.run(
         args,
@@ -1453,7 +1456,7 @@ def execute_command_and_get_output(args, shell=False, fail_if_nonzero=True, prin
         check=fail_if_nonzero,
         env=os.environ,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.STDOUT if capture_stderr else None,
         errors="replace",
         universal_newlines=True,
     )

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -20,7 +20,6 @@ import codecs
 import datetime
 import hashlib
 import json
-import math
 import multiprocessing
 import os
 import os.path

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -772,8 +772,12 @@ def execute_commands(
             shard_id = int(os.getenv("BUILDKITE_PARALLEL_JOB", "-1"))
             shard_count = int(os.getenv("BUILDKITE_PARALLEL_JOB_COUNT", "-1"))
             if shard_id > -1 and shard_count > -1:
-                expanded_test_targets = expand_test_target_patterns(bazel_binary, platform, test_targets)
-                test_targets = get_test_targets_for_shard(expanded_test_targets, shard_id, shard_count)
+                expanded_test_targets = expand_test_target_patterns(
+                    bazel_binary, platform, test_targets
+                )
+                test_targets = get_test_targets_for_shard(
+                    expanded_test_targets, shard_id, shard_count
+                )
                 if not test_targets:
                     return
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1261,6 +1261,26 @@ def execute_bazel_build(
         handle_bazel_failure(e, "build")
 
 
+def calculate_targets(task_config, platform, bazel_binary, build_only, test_only):
+    build_targets = [] if test_only else task_config.get("build_targets", [])
+    test_targets = [] if build_only else task_config.get("test_targets", [])
+
+    shard_id = int(os.getenv("BUILDKITE_PARALLEL_JOB", "-1"))
+    shard_count = int(os.getenv("BUILDKITE_PARALLEL_JOB_COUNT", "-1"))
+    if shard_id > -1 and shard_count > -1:
+        print_collapsed_group(
+            ":female-detective: Calculating targets for shard {}/{}".format(
+                shard_id + 1, shard_count
+            )
+        )
+        expanded_test_targets = expand_test_target_patterns(bazel_binary, platform, test_targets)
+        build_targets, test_targets = get_targets_for_shard(
+            build_targets, expanded_test_targets, shard_id, shard_count
+        )
+
+    return build_targets, test_targets
+
+
 def expand_test_target_patterns(bazel_binary, platform, test_targets):
     if not any(t for t in test_targets if t.endswith(":all") or t.endswith("...")):
         return test_targets
@@ -1300,26 +1320,6 @@ def partition_test_targets(test_targets):
             included_targets.append(target)
 
     return included_targets, excluded_targets
-
-
-def calculate_targets(task_config, platform, bazel_binary, build_only, test_only):
-    build_targets = [] if test_only else task_config.get("build_targets", [])
-    test_targets = [] if build_only else task_config.get("test_targets", [])
-
-    shard_id = int(os.getenv("BUILDKITE_PARALLEL_JOB", "-1"))
-    shard_count = int(os.getenv("BUILDKITE_PARALLEL_JOB_COUNT", "-1"))
-    if shard_id > -1 and shard_count > -1:
-        print_collapsed_group(
-            ":female-detective: Calculating targets for shard {}/{}".format(
-                shard_id + 1, shard_count
-            )
-        )
-        expanded_test_targets = expand_test_target_patterns(bazel_binary, platform, test_targets)
-        build_targets, test_targets = get_targets_for_shard(
-            build_targets, expanded_test_targets, shard_id, shard_count
-        )
-
-    return build_targets, test_targets
 
 
 def get_targets_for_shard(build_targets, test_targets, shard_id, shard_count):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1250,6 +1250,9 @@ def execute_bazel_build(
 ):
     print_expanded_group(":bazel: Build ({})".format(bazel_version))
 
+    # TODO(fweikert): remove
+    return
+
     aggregated_flags = compute_flags(
         platform,
         flags,
@@ -1309,6 +1312,10 @@ def execute_bazel_test(
     incompatible_flags,
 ):
     print_expanded_group(":bazel: Test ({})".format(bazel_version))
+
+    # TODO(fweikert): remove
+    eprint(targets)
+    raise BuildkiteException("sharded")
 
     aggregated_flags = [
         "--flaky_test_attempts=3",


### PR DESCRIPTION
This PR implements optional sharding. The algorithm resolves all test target patterns, then uses a list of build and test targets to distribute all targets across shards. Currently the sharding protocol assigns every N-th target (starting at offset I) to a shard, with N being the number of shards and I being the shard ID.

Example run: https://buildkite.com/bazel/fwe-test/builds/44 (with debug output)

The distribution of shell tests is not yet ideal, hence the distribution of test times is quite uneven.

This feature is still experimental, hence it's not mentioned in the documentation.