### PR TITLE
Don't test Gerrit on ubuntu1804_java9.

### DIFF
--- a/buildkite/pipelines/gerrit-postsubmit.yml
+++ b/buildkite/pipelines/gerrit-postsubmit.yml
@@ -7,18 +7,6 @@ platforms:
     - "--test_tag_filters=-slow,-flaky,-docker"
     test_targets:
     - "//..."
-  ubuntu1804_java9:
-    build_flags:
-    - "--host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java9"
-    - "--java_toolchain=@bazel_tools//tools/jdk:toolchain_java9"
-    build_targets:
-    - "//:release"
-    test_flags:
-    - "--test_tag_filters=-slow,-flaky,-docker"
-    - "--host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java9"
-    - "--java_toolchain=@bazel_tools//tools/jdk:toolchain_java9"
-    test_targets:
-    - "//..."
   ubuntu1804_java11:
     build_flags:
     - "--define=ABSOLUTE_JAVABASE=/usr/lib/jvm/zulu-11-amd64"


### PR DESCRIPTION
@davido Would it be OK to not test Gerrit on ubuntu1804_java9, considering that we have test coverage for Ubuntu 16.04 (OpenJDK 8) and Ubuntu 18.04 (OpenJDK 11)?

I'm trying to remove the platform from our CI, because OpenJDK 9 is EOL.