### PR TITLE
Implement validation of configuration changes.

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -329,3 +329,19 @@ tasks:
     test_targets:
     - //...
 ```
+
+### Validating changes to pipeline configuration files
+
+You can set the top-level `validate_config` option to ensure that changes to pipeline configuration files in the `.bazelci` directory will be validated.
+With this option, every build for a commit that touches a configuration file will contain an additional validation step for each modified configuration file.
+
+Example usage:
+
+```yaml
+---
+validate_config: 1
+tasks:
+  macos:
+    build_targets:
+    - "..."
+```

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1592,7 +1592,7 @@ def print_project_pipeline(
         for f in config_files:
             pipeline_steps.append(
                 create_step(
-                    label="Validate {}".format(f),
+                    label=":cop: Validate {}".format(f),
                     commands=[
                         fetch_bazelcipy_command(),
                         "{} bazelci.py project_pipeline --file_config={}".format(

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -397,8 +397,6 @@ BUILDIFIER_STEP_NAME = "Buildifier"
 
 SKIP_TASKS_ENV_VAR = "CI_SKIP_TASKS"
 
-VALIDATE_CONFIG_OPTION = "validate_config"
-
 CONFIG_FILE_EXTENSIONS = set([".yml", ".yaml"])
 
 
@@ -1572,7 +1570,7 @@ def print_project_pipeline(
             )
         )
 
-    if VALIDATE_CONFIG_OPTION in configs:
+    if "validate_config" in configs:
         output = execute_command_and_get_output(
             [
                 "git",


### PR DESCRIPTION
If the "validate_config" option is set in the pipeline configuration, all changes to pipeline configuration files in the .bazelci folder will be validated. Currently this means that CI tries to print a project pipeline using that configuration.

Examples:
- https://buildkite.com/bazel/fwe-test/builds/35: No validation step since no configs were modified.
- https://buildkite.com/bazel/fwe-test/builds/36: Successful validation of a commit that changed two configuration files correctly.
- https://buildkite.com/bazel/fwe-test/builds/38: Validation failed due to  bug in the configuration.