### PR TITLE
Add option to include JSON profile in builds

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -382,3 +382,26 @@ tasks:
     build_targets:
     - "..."
 ```
+
+### Exporting JSON profiles of builds and tests
+
+[JSON Profile](https://docs.bazel.build/versions/master/skylark/performance.html#json-profile) is a useful tool to investigate the performance of Bazel. You can configure your pipeline to export these JSON profiles on builds and tests using the `include_json_profile` option.
+
+Example usage:
+
+```yaml
+---
+platforms:
+  ubuntu1604:
+    include_json_profile:
+    - build
+    - test
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+```
+
+When `include_json_profile` is specified with `build`, the builds will be carried out with the extra JSON profile flags. Similarly for `test`. Other values will be ignored.
+
+The exported JSON profiles are available as artifacts after each run.

--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -385,7 +385,7 @@ tasks:
 
 ### Exporting JSON profiles of builds and tests
 
-[JSON Profile](https://docs.bazel.build/versions/master/skylark/performance.html#json-profile) is a useful tool to investigate the performance of Bazel. You can configure your pipeline to export these JSON profiles on builds and tests using the `include_json_profile` option.
+[Bazel's JSON Profile](https://docs.bazel.build/versions/master/skylark/performance.html#json-profile) is a useful tool to investigate the performance of Bazel. You can configure your pipeline to export these JSON profiles on builds and tests using the `include_json_profile` option.
 
 Example usage:
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -766,17 +766,31 @@ def execute_commands(
             raise BuildkiteException("There are neither build nor test targets")
 
         if build_targets:
-            execute_bazel_build(
-                bazel_version,
-                bazel_binary,
-                platform,
-                task_config.get("build_flags", []),
-                build_targets,
-                None,
-                incompatible_flags,
-            )
-            if save_but:
-                upload_bazel_binary(platform)
+            json_profile_flags = []
+            include_json_profile = task_config.get("include_json_profile", False)
+
+            if include_json_profile:
+                json_profile_temp_out = os.path.join(tmpdir, "build.profile")
+                json_profile_flags = [
+                    "--experimental_generate_json_trace_profile",
+                    "--experimental_profile_cpu_usage",
+                    "--profile={}".format(json_profile_temp_out)
+                ]
+            try:
+                execute_bazel_build(
+                    bazel_version,
+                    bazel_binary,
+                    platform,
+                    task_config.get("build_flags", []) + json_profile_flags,
+                    build_targets,
+                    None,
+                    incompatible_flags,
+                )
+                if save_but:
+                    upload_bazel_binary(platform)
+            finally:
+                if include_json_profile:
+                  upload_json_profile(json_profile_temp_out, tmpdir)
 
         if test_targets:
             test_flags = task_config.get("test_flags", [])
@@ -1396,6 +1410,15 @@ def upload_test_logs(bep_file, tmpdir):
             os.chdir(cwd)
 
 
+def upload_json_profile(json_profile_path, tmpdir):
+    if not os.path.exists(json_profile_path):
+        return
+    print_collapsed_group(":gcloud: Uploading JSON Profile")
+    execute_command(
+        ["buildkite-agent", "artifact", "upload", json_profile_path],
+        cwd=tmpdir)
+
+
 def test_logs_to_upload(bep_file, tmpdir):
     failed = test_logs_for_status(bep_file, status="FAILED")
     timed_out = test_logs_for_status(bep_file, status="TIMEOUT")
@@ -1475,9 +1498,9 @@ def execute_command_and_get_output(
     return process.stdout
 
 
-def execute_command(args, shell=False, fail_if_nonzero=True):
+def execute_command(args, shell=False, fail_if_nonzero=True, cwd=None):
     eprint(" ".join(args))
-    return subprocess.run(args, shell=shell, check=fail_if_nonzero, env=os.environ).returncode
+    return subprocess.run(args, shell=shell, check=fail_if_nonzero, env=os.environ, cwd=cwd).returncode
 
 
 def execute_command_background(args):


### PR DESCRIPTION
This PR introduces a new attribute in `.bazelci` config yml files: `include_json_profile`.
Example:

```yaml
platforms:
  ubuntu1604:
    include_json_profile:
    - build
    - test
    build_targets:
    - "..."
    test_targets:
    - "..."
```
When `include_json_profile` is specified with `build`, the builds will be carried out with the extra JSON profile flags. Similarly for `test`. Other values will be ignored.

The resulting JSON profile is uploaded as an artifact, accessible via BuildKite's web interface.