### PR TITLE
Use tasks instead of platforms in README example

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -391,7 +391,7 @@ Example usage:
 
 ```yaml
 ---
-platforms:
+tasks:
   ubuntu1604:
     include_json_profile:
     - build


### PR DESCRIPTION
`platforms` is deprecated.