### PR TITLE
Switch Ubuntu 14.04 step back to ubuntu1404

### DIFF
--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -42,7 +42,7 @@ steps:
           - ANDROID_HOME
           - ANDROID_NDK_HOME
           - BUILDKITE_ARTIFACT_UPLOAD_DESTINATION
-        image: gcr.io/bazel-public/ubuntu1804:java11
+        image: gcr.io/bazel-public/ubuntu1404:java8
         network: host
         privileged: true
         propagate-environment: true
@@ -140,7 +140,7 @@ steps:
           - ANDROID_HOME
           - ANDROID_NDK_HOME
           - BUILDKITE_ARTIFACT_UPLOAD_DESTINATION
-        image: gcr.io/bazel-public/ubuntu1804:java11
+        image: gcr.io/bazel-public/ubuntu1404:java8
         network: host
         privileged: true
         propagate-environment: true


### PR DESCRIPTION
It accidentally used ubuntu1804, which means we built a version no longer compatible with Ubuntu 14.04: https://github.com/bazelbuild/bazel/issues/7499#issuecomment-494295522

Note that Bazel 0.26 will be the last version built on Ubuntu 14.04, though, as was previously announced here: https://groups.google.com/forum/#!searchin/bazel-discuss/ubuntu$2014.04%7Csort:date/bazel-discuss/dPomOEOPseA/Jp849gJvBwAJ