### PR TITLE
Fix culprit_finder.py

### DIFF
--- a/buildkite/culprit_finder.py
+++ b/buildkite/culprit_finder.py
@@ -137,7 +137,7 @@ def print_culprit_finder_pipeline(
     command = (
         '%s culprit_finder.py runner --project_name="%s" --task_name=%s --good_bazel_commit=%s --bad_bazel_commit=%s %s %s'
         % (
-            bazelci.python_binary(platform_name),
+            bazelci.PLATFORMS[platform_name]["python"],
             project_name,
             task_name,
             good_bazel_commit,


### PR DESCRIPTION
Due to https://github.com/bazelbuild/continuous-integration/commit/57b32683c8dc11eb6cfb82b31ac1e916fdca5c96#diff-9ca62ea3191ff346e911994ded260c87