### PR TITLE
Link to the authoritative source of our release policy

### DIFF
--- a/docs/release-playbook.md
+++ b/docs/release-playbook.md
@@ -179,7 +179,8 @@ Create candidates with the release.sh script.
 
 ## Push a release
 
-1.  Verify that the following conditions **all apply**:
+1.  Verify that the [conditions outlined in our policy](https://bazel.build/support.html#policy) **all apply**. As of
+    May 2019 those were the following, but _double check_ that they have not changed since then.
     1.  at least **1 weeks passed since you pushed RC1**, and
     1.  at least **2 business days passed since you pushed the last RC**, and
     1.  there are **no open ["Release blocking" Bazel bugs](https://github.com/bazelbuild/bazel/labels/Release%20blocker)** on GitHub.


### PR DESCRIPTION
We currently have two copies of our release policy an "end-user friendly"[1] one,
and one that is followed when doing releases. To avoid them falling apart, add a link
in the release playbook to the apparently authoritative one, advising the release manager
to check for changes.

[1] https://github.com/bazelbuild/bazel-website/pull/188#discussion_r284670042