### PR TITLE
Remove --keep_going

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1134,7 +1134,6 @@ def common_build_flags(bep_file, platform):
         "--curses=yes",
         "--color=yes",
         "--verbose_failures",
-        "--keep_going",
         "--jobs=" + concurrent_jobs(platform),
         "--announce_rc",
         "--experimental_multi_threaded_digest",


### PR DESCRIPTION
Until https://github.com/bazelbuild/bazel/issues/7674 is resolved, it should not be used as a default flag in the CI.