### PR TITLE
Remove rules_cc from gitsync

### DIFF
--- a/gitsync/gitsync.sh
+++ b/gitsync/gitsync.sh
@@ -24,7 +24,6 @@
 REPOSITORIES=(
     "https://bazel.googlesource.com/bazel ==> git@github.com:bazelbuild/bazel.git bazel"
     "https://bazel.googlesource.com/java_tools ==> git@github.com:bazelbuild/java_tools.git java_tools"
-    "https://bazel.googlesource.com/rules_cc ==> git@github.com:bazelbuild/rules_cc.git rules_cc"
     "https://bazel.googlesource.com/tulsi ==> git@github.com:bazelbuild/tulsi.git tulsi"
 )
 


### PR DESCRIPTION
Copybara will sync rules_cc between GoB and GitHub, so we don't need to use gitsync for it any longer.