### PR TITLE
Install future pip package in docker for TensorFlow

### DIFF
--- a/buildkite/docker/Dockerfile
+++ b/buildkite/docker/Dockerfile
@@ -168,8 +168,8 @@ RUN dpkg --add-architecture i386 && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install Python packages required by Tensorflow.
-RUN pip install keras_applications keras_preprocessing && \
-    pip3 install keras_applications keras_preprocessing
+RUN pip install keras_applications keras_preprocessing future && \
+    pip3 install keras_applications keras_preprocessing future
 
 ### Install Google Cloud SDK.
 ### https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
@@ -265,8 +265,8 @@ RUN dpkg --add-architecture i386 && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install Python packages required by Tensorflow.
-RUN pip install keras_applications keras_preprocessing && \
-    pip3 install keras_applications keras_preprocessing
+RUN pip install keras_applications keras_preprocessing future && \
+    pip3 install keras_applications keras_preprocessing future
 
 ### Install Google Cloud SDK.
 ### https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu


### PR DESCRIPTION
To fix the failure on Ubuntu 18.04
https://buildkite.com/bazel/tensorflow/builds/2847#6602bbdf-d832-4301-ab6b-8540398c1f90
```
Git Configuration Error: Traceback (most recent call last):
--
  | File "/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/external/org_tensorflow/tensorflow/tools/git/gen_git_source.py", line 29, in <module>
  | from builtins import bytes  # pylint: disable=redefined-builtin
  | ImportError: No module named builtins


```