### PR TITLE
Add support for a testing environment

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -50,33 +50,33 @@ THIS_IS_SPARTA = True
 CLOUD_PROJECT = "bazel-public" if THIS_IS_TRUSTED else "bazel-untrusted"
 
 SCRIPT_URL = {
-    "bazel-public": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py",
-    "bazel-untrusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py",
     "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py",
+    "bazel-trusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py",
+    "bazel": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py",
 }[BUILDKITE_ORG] + "?{}".format(int(time.time()))
 
 INCOMPATIBLE_FLAG_VERBOSE_FAILURES_URL = {
-    "bazel-public": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/incompatible_flag_verbose_failures.py",
-    "bazel-untrusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/incompatible_flag_verbose_failures.py",
     "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/incompatible_flag_verbose_failures.py",
+    "bazel-trusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/incompatible_flag_verbose_failures.py",
+    "bazel": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/incompatible_flag_verbose_failures.py",
 }[BUILDKITE_ORG] + "?{}".format(int(time.time()))
 
 AGGREGATE_INCOMPATIBLE_TEST_RESULT_URL = {
-    "bazel-public": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/aggregate_incompatible_flags_test_result.py",
-    "bazel-untrusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/aggregate_incompatible_flags_test_result.py",
     "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/aggregate_incompatible_flags_test_result.py",
+    "bazel-trusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/aggregate_incompatible_flags_test_result.py",
+    "bazel": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/aggregate_incompatible_flags_test_result.py",
 }[BUILDKITE_ORG] + "?{}".format(int(time.time()))
 
 EMERGENCY_FILE_URL = {
-    "bazel-public": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/emergency.yml",
-    "bazel-untrusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/emergency.yml",
     "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/emergency.yml",
+    "bazel-trusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/emergency.yml",
+    "bazel": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/emergency.yml",
 }[BUILDKITE_ORG] + "?{}".format(int(time.time()))
 
 FLAKY_TESTS_BUCKET = {
-    "bazel-public": "gs://bazel-buildkite-stats/flaky-tests-bep/",
-    "bazel-untrusted": "gs://bazel-buildkite-stats/flaky-tests-bep/",
     "bazel-testing": "gs://bazel-testing-buildkite-stats/flaky-tests-bep/",
+    "bazel-trusted": "gs://bazel-buildkite-stats/flaky-tests-bep/",
+    "bazel": "gs://bazel-buildkite-stats/flaky-tests-bep/",
 }[BUILDKITE_ORG]
 
 DOWNSTREAM_PROJECTS_PRODUCTION = {
@@ -375,9 +375,9 @@ DOWNSTREAM_PROJECTS_TESTING = {
 }
 
 DOWNSTREAM_PROJECTS = {
-    "bazel-public": {},
-    "bazel-untrusted": DOWNSTREAM_PROJECTS_PRODUCTION,
     "bazel-testing": DOWNSTREAM_PROJECTS_TESTING,
+    "bazel-trusted": {},
+    "bazel": DOWNSTREAM_PROJECTS_PRODUCTION,
 }[BUILDKITE_ORG]
 
 # A map containing all supported platform names as keys, with the values being

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -680,36 +680,8 @@ def execute_commands(
     tmpdir = tempfile.mkdtemp()
     sc_process = None
     try:
-        # Activate the correct Xcode version on macOS machines.
         if platform == "macos":
-            # Get the Xcode version from the config.
-            xcode_version = task_config.get("xcode_version", DEFAULT_XCODE_VERSION)
-            print_collapsed_group("Activating Xcode {}...".format(xcode_version))
-
-            # Ensure it's a valid version number.
-            if not isinstance(xcode_version, str):
-                raise BuildkiteException(
-                    "Version number '{}' is not a string. Did you forget to put it in quotes?".format(
-                        xcode_version
-                    )
-                )
-            if not XCODE_VERSION_REGEX.match(xcode_version):
-                raise BuildkiteException(
-                    "Invalid Xcode version format '{}', must match the format X.Y[.Z].".format(
-                        xcode_version
-                    )
-                )
-
-            # Check that the selected Xcode version is actually installed on the host.
-            xcode_path = "/Applications/Xcode{}.app".format(xcode_version)
-            if not os.path.exists(xcode_path):
-                raise BuildkiteException("Xcode not found at '{}'.".format(xcode_path))
-
-            # Now activate the specified Xcode version and let it install its required components.
-            # The CI machines have a sudoers config that allows the 'buildkite' user to run exactly
-            # these two commands, so don't change them without also modifying the file there.
-            execute_command(["/usr/bin/sudo", "/usr/bin/xcode-select", "--switch", xcode_path])
-            execute_command(["/usr/bin/sudo", "/usr/bin/xcodebuild", "-runFirstLaunch"])
+            activate_xcode(task_config)
 
         # If the CI worker runs Bazelisk, we need to forward all required env variables to the test.
         # Otherwise any integration test that invokes Bazel (=Bazelisk in this case) will fail.
@@ -765,26 +737,8 @@ def execute_commands(
             bazel_binary, platform, task_config.get("run_targets", None), incompatible_flags
         )
 
-        if task_config.get("sauce", None):
-            print_collapsed_group(":saucelabs: Starting Sauce Connect Proxy")
-            os.environ["SAUCE_USERNAME"] = "bazel_rules_webtesting"
-            os.environ["SAUCE_ACCESS_KEY"] = saucelabs_token()
-            os.environ["TUNNEL_IDENTIFIER"] = str(uuid.uuid4())
-            os.environ["BUILD_TAG"] = str(uuid.uuid4())
-            readyfile = os.path.join(tmpdir, "sc_is_ready")
-            if platform == "windows":
-                cmd = ["sauce-connect.exe", "/i", os.environ["TUNNEL_IDENTIFIER"], "/f", readyfile]
-            else:
-                cmd = ["sc", "-i", os.environ["TUNNEL_IDENTIFIER"], "-f", readyfile]
-            sc_process = execute_command_background(cmd)
-            wait_start = time.time()
-            while not os.path.exists(readyfile):
-                if time.time() - wait_start > 30:
-                    raise BuildkiteException(
-                        "Sauce Connect Proxy is still not ready after 30 seconds, aborting!"
-                    )
-                time.sleep(1)
-            print("Sauce Connect Proxy is ready, continuing...")
+        if task_config.get("sauce"):
+            sc_process = start_sauce_connect_proxy(platform, tmpdir)
 
         if needs_clean:
             execute_bazel_clean(bazel_binary, platform)
@@ -853,19 +807,8 @@ def execute_commands(
                     monitor_flaky_tests,
                     incompatible_flags,
                 )
-                if has_flaky_tests(test_bep_file):
-                    if monitor_flaky_tests:
-                        # Upload the BEP logs from Bazel builds for later analysis on flaky tests
-                        build_number = os.getenv("BUILDKITE_BUILD_NUMBER")
-                        pipeline_slug = os.getenv("BUILDKITE_PIPELINE_SLUG")
-                        execute_command(
-                            [
-                                gsutil_command(),
-                                "cp",
-                                test_bep_file,
-                                FLAKY_TESTS_BUCKET + pipeline_slug + "/" + build_number + ".json",
-                            ]
-                        )
+                if monitor_flaky_tests:
+                    upload_bep_logs_for_flaky_tests(test_bep_file)
             finally:
                 upload_test_logs(test_bep_file, tmpdir)
                 if include_json_profile_test:
@@ -881,6 +824,37 @@ def execute_commands(
             shutil.rmtree(tmpdir)
 
 
+def activate_xcode(task_config):
+    # Get the Xcode version from the config.
+    xcode_version = task_config.get("xcode_version", DEFAULT_XCODE_VERSION)
+    print_collapsed_group("Activating Xcode {}...".format(xcode_version))
+
+    # Ensure it's a valid version number.
+    if not isinstance(xcode_version, str):
+        raise BuildkiteException(
+            "Version number '{}' is not a string. Did you forget to put it in quotes?".format(
+                xcode_version
+            )
+        )
+    if not XCODE_VERSION_REGEX.match(xcode_version):
+        raise BuildkiteException(
+            "Invalid Xcode version format '{}', must match the format X.Y[.Z].".format(
+                xcode_version
+            )
+        )
+
+    # Check that the selected Xcode version is actually installed on the host.
+    xcode_path = "/Applications/Xcode{}.app".format(xcode_version)
+    if not os.path.exists(xcode_path):
+        raise BuildkiteException("Xcode not found at '{}'.".format(xcode_path))
+
+    # Now activate the specified Xcode version and let it install its required components.
+    # The CI machines have a sudoers config that allows the 'buildkite' user to run exactly
+    # these two commands, so don't change them without also modifying the file there.
+    execute_command(["/usr/bin/sudo", "/usr/bin/xcode-select", "--switch", xcode_path])
+    execute_command(["/usr/bin/sudo", "/usr/bin/xcodebuild", "-runFirstLaunch"])
+
+
 def get_bazelisk_cache_directory(platform):
     # The path relies on the behavior of Go's os.UserCacheDir()
     # and of the Go version of Bazelisk.
@@ -890,6 +864,29 @@ def get_bazelisk_cache_directory(platform):
 
 def tests_with_status(bep_file, status):
     return set(label for label, _ in test_logs_for_status(bep_file, status=status))
+
+
+def start_sauce_connect_proxy(platform, tmpdir):
+    print_collapsed_group(":saucelabs: Starting Sauce Connect Proxy")
+    os.environ["SAUCE_USERNAME"] = "bazel_rules_webtesting"
+    os.environ["SAUCE_ACCESS_KEY"] = saucelabs_token()
+    os.environ["TUNNEL_IDENTIFIER"] = str(uuid.uuid4())
+    os.environ["BUILD_TAG"] = str(uuid.uuid4())
+    readyfile = os.path.join(tmpdir, "sc_is_ready")
+    if platform == "windows":
+        cmd = ["sauce-connect.exe", "/i", os.environ["TUNNEL_IDENTIFIER"], "/f", readyfile]
+    else:
+        cmd = ["sc", "-i", os.environ["TUNNEL_IDENTIFIER"], "-f", readyfile]
+    sc_process = execute_command_background(cmd)
+    wait_start = time.time()
+    while not os.path.exists(readyfile):
+        if time.time() - wait_start > 30:
+            raise BuildkiteException(
+                "Sauce Connect Proxy is still not ready after 30 seconds, aborting!"
+            )
+        time.sleep(1)
+    print("Sauce Connect Proxy is ready, continuing...")
+    return sc_process
 
 
 def saucelabs_token():
@@ -1437,6 +1434,20 @@ def get_json_profile_flags(out_file):
         "--experimental_json_trace_compression",
         "--profile={}".format(out_file),
     ]
+
+
+def upload_bep_logs_for_flaky_tests(test_bep_file):
+    if has_flaky_tests(test_bep_file):
+        build_number = os.getenv("BUILDKITE_BUILD_NUMBER")
+        pipeline_slug = os.getenv("BUILDKITE_PIPELINE_SLUG")
+        execute_command(
+            [
+                gsutil_command(),
+                "cp",
+                test_bep_file,
+                FLAKY_TESTS_BUCKET + pipeline_slug + "/" + build_number + ".json",
+            ]
+        )
 
 
 def upload_test_logs(bep_file, tmpdir):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -49,29 +49,25 @@ THIS_IS_SPARTA = True
 
 CLOUD_PROJECT = "bazel-public" if THIS_IS_TRUSTED else "bazel-untrusted"
 
-SCRIPT_URL = {
-    "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py",
-    "bazel-trusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py",
-    "bazel": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py",
-}[BUILDKITE_ORG] + "?{}".format(int(time.time()))
+GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "testing"}[
+    BUILDKITE_ORG
+]
 
-INCOMPATIBLE_FLAG_VERBOSE_FAILURES_URL = {
-    "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/incompatible_flag_verbose_failures.py",
-    "bazel-trusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/incompatible_flag_verbose_failures.py",
-    "bazel": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/incompatible_flag_verbose_failures.py",
-}[BUILDKITE_ORG] + "?{}".format(int(time.time()))
+SCRIPT_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/bazelci.py?{}".format(
+    GITHUB_BRANCH, int(time.time())
+)
 
-AGGREGATE_INCOMPATIBLE_TEST_RESULT_URL = {
-    "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/aggregate_incompatible_flags_test_result.py",
-    "bazel-trusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/aggregate_incompatible_flags_test_result.py",
-    "bazel": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/aggregate_incompatible_flags_test_result.py",
-}[BUILDKITE_ORG] + "?{}".format(int(time.time()))
+INCOMPATIBLE_FLAG_VERBOSE_FAILURES_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/incompatible_flag_verbose_failures.py?{}".format(
+    GITHUB_BRANCH, int(time.time())
+)
 
-EMERGENCY_FILE_URL = {
-    "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/emergency.yml",
-    "bazel-trusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/emergency.yml",
-    "bazel": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/emergency.yml",
-}[BUILDKITE_ORG] + "?{}".format(int(time.time()))
+AGGREGATE_INCOMPATIBLE_TEST_RESULT_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/aggregate_incompatible_flags_test_result.py?{}".format(
+    GITHUB_BRANCH, int(time.time())
+)
+
+EMERGENCY_FILE_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/emergency.yml?{}".format(
+    GITHUB_BRANCH, int(time.time())
+)
 
 FLAKY_TESTS_BUCKET = {
     "bazel-testing": "gs://bazel-testing-buildkite-stats/flaky-tests-bep/",

--- a/buildkite/culprit_finder.py
+++ b/buildkite/culprit_finder.py
@@ -27,9 +27,9 @@ BAZEL_REPO_DIR = os.getcwd()
 BUILDKITE_ORG = os.environ["BUILDKITE_ORGANIZATION_SLUG"]
 
 SCRIPT_URL = {
-    "bazel-public": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/culprit_finder.py",
-    "bazel-untrusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/culprit_finder.py",
     "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/culprit_finder.py",
+    "bazel-trusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/culprit_finder.py",
+    "bazel": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/culprit_finder.py",
 }[BUILDKITE_ORG] + "?{}".format(int(time.time()))
 
 

--- a/buildkite/culprit_finder.py
+++ b/buildkite/culprit_finder.py
@@ -24,18 +24,17 @@ import bazelci
 
 BAZEL_REPO_DIR = os.getcwd()
 
+BUILDKITE_ORG = os.environ["BUILDKITE_ORGANIZATION_SLUG"]
 
-def bazel_culprit_finder_py_url():
-    """
-    URL to the latest version of this script.
-    """
-    return "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/culprit_finder.py?{}".format(
-        int(time.time())
-    )
+SCRIPT_URL = {
+    "bazel-public": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/culprit_finder.py",
+    "bazel-untrusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/culprit_finder.py",
+    "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/culprit_finder.py",
+}[BUILDKITE_ORG] + "?{}".format(int(time.time()))
 
 
 def fetch_culprit_finder_py_command():
-    return "curl -s {0} -o culprit_finder.py".format(bazel_culprit_finder_py_url())
+    return "curl -s {0} -o culprit_finder.py".format(SCRIPT_URL)
 
 
 def get_bazel_commits_between(first_commit, second_commit):

--- a/buildkite/incompatible_flag_verbose_failures.py
+++ b/buildkite/incompatible_flag_verbose_failures.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import os
 import sys
 import yaml
 
@@ -26,7 +27,7 @@ from bazelci import BuildkiteException
 # under.
 BUILDKITE_MAX_JOBS_LIMIT = 1500
 
-BUILDKITE_ORG = "bazel"
+BUILDKITE_ORG = os.environ["BUILDKITE_ORGANIZATION_SLUG"]
 
 PIPELINE = "bazel-at-release-plus-incompatible-flags"
 

--- a/buildkite/startup-docker.sh
+++ b/buildkite/startup-docker.sh
@@ -67,13 +67,14 @@ case $(hostname -f) in
         gcloud kms decrypt --project bazel-public --location global --keyring buildkite --key buildkite-trusted-agent-token --ciphertext-file - --plaintext-file -)
     ;;
   *.bazel-untrusted.*)
-    ARTIFACT_BUCKET="bazel-untrusted-buildkite-artifacts"
     case $(hostname -f) in
       *-testing-*)
-        BUILDKITE_TOKEN=$(gsutil cat "gs://bazel-untrusted-encrypted-secrets/buildkite-testing-agent-token.enc" | \
+        ARTIFACT_BUCKET="bazel-testing-buildkite-artifacts"
+        BUILDKITE_TOKEN=$(gsutil cat "gs://bazel-testing-encrypted-secrets/buildkite-testing-agent-token.enc" | \
             gcloud kms decrypt --project bazel-untrusted --location global --keyring buildkite --key buildkite-testing-agent-token --ciphertext-file - --plaintext-file -)
         ;;
       *)
+        ARTIFACT_BUCKET="bazel-untrusted-buildkite-artifacts"
         BUILDKITE_TOKEN=$(gsutil cat "gs://bazel-untrusted-encrypted-secrets/buildkite-untrusted-agent-token.enc" | \
             gcloud kms decrypt --project bazel-untrusted --location global --keyring buildkite --key buildkite-untrusted-agent-token --ciphertext-file - --plaintext-file -)
         ;;


### PR DESCRIPTION
This parametrizes things like GCS buckets, script URLs, ... and let's the bazelci.py script pick the correct one for the current Buildkite organization.

That allows us to setup a mirror of our normal Buildkite organization with the same pipelines as a testing environment, which will then use the bazelci.py script from the testing branch and a separate GCP service account, GCS buckets, ... so that it cannot accidentally disturb the production environment.