### PR TITLE
Make Culprit Finder smarter

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -100,9 +100,9 @@ If a project is green with release Bazel but red with Bazel nightly, it means so
 Create "New Build" in the [Culprit Finder](https://buildkite.com/bazel/culprit-finder) project with the following environment variable:
 
 - PROJECT_NAME (The project name must exist in DOWNSTREAM_PROJECTS in [bazelci.py](https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazelci.py))
-- TASK_NAME (The task name must exist in the project's config file, eg. [macos_latest](https://github.com/bazelbuild/rules_apple/blob/master/.bazelci/presubmit.yml#L3)). For old config syntax where platform name is essentially the task name, you can also set PLATFORM_NAME instead of TASK_NAME.
-- GOOD_BAZEL_COMMIT (A full Bazel commit, Bazel built at this commit still works for this project)
-- BAD_BAZEL_COMMIT (A full Bazel commit, Bazel built at this commit fails with this project)
+- (Optional) TASK_NAME (The task name must exist in the project's config file, eg. [macos_latest](https://github.com/bazelbuild/rules_apple/blob/master/.bazelci/presubmit.yml#L3)). For old config syntax where platform name is essentially the task name, you can also set PLATFORM_NAME instead of TASK_NAME. If not set, culprit finder will bisect for all tasks of the specified project.
+- (Optional) GOOD_BAZEL_COMMIT (A full Bazel commit, Bazel built at this commit still works for this project). If not set, culprit finder will use the last green bazel commit in downstream pipeline as the good bazel commit.
+- (Optional) BAD_BAZEL_COMMIT (A full Bazel commit, Bazel built at this commit fails with this project). If not set, culprit finder will use the lastest Bazel commit as the bad bazel commit.
 - (Optional) NEEDS_CLEAN (Set NEEDS_CLEAN to `true` to run `bazel clean --expunge` before each build, this will help reduce flakiness)
 - (Optional) REPEAT_TIMES (Set REPEAT_TIMES to run the build multiple times to detect flaky build failure, if at least one build fails we consider the commit as bad)
 

--- a/buildkite/culprit_finder.py
+++ b/buildkite/culprit_finder.py
@@ -185,21 +185,20 @@ def main(argv=None):
             project_name = os.environ["PROJECT_NAME"]
 
             # For old config file, we can still set PLATFORM_NAME as task name.
-            if "PLATFORM_NAME" in os.environ or "TASK_NAME" in os.environ:
-                tasks = [os.environ.get("PLATFORM_NAME") or os.environ["TASK_NAME"]]
+            task = os.environ.get("PLATFORM_NAME") or os.environ.get("TASK_NAME")
+            if task:
+                tasks = [task]
             else:
                 tasks = get_tasks(project_name)
 
-            if "GOOD_BAZEL_COMMIT" in os.environ:
-                good_bazel_commit = os.environ["GOOD_BAZEL_COMMIT"]
-            else:
+            good_bazel_commit = os.environ.get("GOOD_BAZEL_COMMIT")
+            if not good_bazel_commit:
                 # If GOOD_BAZEL_COMMIT is not set, use recorded last bazel green commit for downstream project
                 last_green_commit_url = bazelci.bazelci_last_green_downstream_commit_url()
                 good_bazel_commit = bazelci.get_last_green_commit(last_green_commit_url)
 
-            if "BAD_BAZEL_COMMIT" in os.environ:
-                bad_bazel_commit = os.environ["BAD_BAZEL_COMMIT"]
-            else:
+            bad_bazel_commit = os.environ.get("BAD_BAZEL_COMMIT")
+            if not bad_bazel_commit:
                 # If BAD_BAZEL_COMMIT is not set, use HEAD commit.
                 bad_bazel_commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf-8").strip()
         except KeyError as e:

--- a/buildkite/culprit_finder.py
+++ b/buildkite/culprit_finder.py
@@ -70,7 +70,7 @@ def get_platform(project_name, task_name):
 
 def get_tasks(project_name):
     configs = get_configs(project_name)
-    return configs.keys()
+    return configs["tasks"].keys()
 
 def test_with_bazel_at_commit(
     project_name, task_name, git_repo_location, bazel_commit, needs_clean, repeat_times
@@ -184,7 +184,7 @@ def main(argv=None):
             project_name = os.environ["PROJECT_NAME"]
 
             # For old config file, we can still set PLATFORM_NAME as task name.
-            if "PLATFORMS_NAME" in os.environ or "TASK_NAME" in os.environ:
+            if "PLATFORM_NAME" in os.environ or "TASK_NAME" in os.environ:
                 tasks = [os.environ.get("PLATFORM_NAME") or os.environ["TASK_NAME"]]
             else:
                 tasks = get_tasks(project_name)


### PR DESCRIPTION
Culprit finder can now find out what default value to use, if some environment variables are not set.
- `TASK_NAME` or `PLATFORM_NAME`: If not set, bisect for all tasks of the specified project
- `GOOD_BAZEL_COMMIT`: If not set, use the last green bazel commit in downstream pipeline
- `BAD_BAZEL_COMMIT`: If not set, use the latest Bazel commit

After this, to do a bisect, you only have to set `PROJECT_NAME`

FYI @hlopko @vladmos @buchgr 