### PR TITLE
[bazel-bench Nightly] Add a new flag --bazel_bench_options

### DIFF
--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -108,9 +108,6 @@ def ci_step_for_platform_and_commits(bazel_commits, platform, project):
     An object: the result of applying bazelci.create_step to wrap the
       command to be executed by buildkite-agent.
   """
-  # Get Bazel commits during the day
-  bazel_commits = get_bazel_commits(datetime.date.today())
-
   # Download the binaries already built.
   # Bazel-bench won"t try to build these binaries again, since they exist.
   for bazel_commit in bazel_commits:

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +18,13 @@ Runs bazel-bench on the defined projects, on every platforms the project runs
 on.
 """
 
+import argparse
 import bazelci
 import datetime
+import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import yaml
 
@@ -70,8 +74,9 @@ def get_bazel_commits(day):
       "--until='%s'" % day_plus_one.strftime("%Y-%m-%d 00:00"),
       "--reverse"
   ]
-  command = subprocess.Popen(args, shell=True, stdoud=subprocess.PIPE)
-  return [line.strip() for line in command.stdout]
+  command = subprocess.Popen(args, stdout=subprocess.PIPE)
+  return [
+      line.decode("utf-8").rstrip("\n").strip("'") for line in command.stdout]
 
 
 def get_platforms(project_name):
@@ -112,7 +117,7 @@ def ci_step_for_platform_and_commits(bazel_commits, platform, project):
     bazelci.download_bazel_binary_at_commit(
         BAZEL_BINARY_BASE_PATH + bazel_commit,
         platform,
-        commit
+        bazel_commit
     )
   project_mirror_path = bazelci.get_mirror_path(
       project["git_repository"], platform)
@@ -139,11 +144,18 @@ def ci_step_for_platform_and_commits(bazel_commits, platform, project):
   return bazelci.create_step(label, " ".join(args), platform)
 
 
-def main(argv):
-  if len(argv) > 1:
-    raise app.UsageError("Too many command-line arguments.")
+def main(argv=None):
+  if agrv is None:
+    argv = sys.argv[1:]
+
+  parser = argparse.ArgumentParser(description="Bazel Bench CI Pipeline")
+  parser.add_argument("--day", type=str)
+  args = parser.parse_args(argv)
 
   bazel_bench_ci_steps = []
+  day = (datetime.datetime.strptime(args.day, "%Y-%m-%d").date() if args.day
+         else datetime.date.today())
+  bazel_commits = get_bazel_commits(day)
   for project in PROJECTS:
     for platform in get_platforms(project["name"]):
       # bazel-bench doesn't support Windows for now.

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -141,17 +141,19 @@ def ci_step_for_platform_and_commits(bazel_commits, platform, project):
   return bazelci.create_step(label, " ".join(args), platform)
 
 
-def main(argv=None):
-  if agrv is None:
-    argv = sys.argv[1:]
+def main(args=None):
+  if agrs is None:
+    args = sys.argv[1:]
 
   parser = argparse.ArgumentParser(description="Bazel Bench CI Pipeline")
   parser.add_argument("--day", type=str)
-  args = parser.parse_args(argv)
+  parsed_args = parser.parse_args(args)
 
   bazel_bench_ci_steps = []
-  day = (datetime.datetime.strptime(args.day, "%Y-%m-%d").date() if args.day
-         else datetime.date.today())
+  day = (
+      datetime.datetime.strptime(parsed_args.day, "%Y-%m-%d").date()
+      if parsed_args.day
+      else datetime.date.today())
   bazel_commits = get_bazel_commits(day)
   for project in PROJECTS:
     for platform in get_platforms(project["name"]):

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -139,7 +139,7 @@ def ci_step_for_platform_and_commits(bazel_commits, platform, project):
       project["bazel_command"]
   ]
 
-  label = (bazelci.PLATFORMS[platform_name]["emoji-name"]
+  label = (bazelci.PLATFORMS[platform]["emoji-name"]
            + " Running bazel-bench on project: %s" % project)
   return bazelci.create_step(label, " ".join(args), platform)
 


### PR DESCRIPTION
This is part 2 of the series of PRs that fixes bazel-bench Nightly. (Part 1: #687)

Changes:
- Add a new flag --bazel_bench_options to allow more flexibility.
- Rm the constant BIGQUERY_TABLE. This should be set by --bazel_bench_options.