### PR TITLE
[bazel-bench nightly] Fix bazel_bench.py

### DIFF
--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -190,7 +190,7 @@ def main(argv=None):
   for project in PROJECTS:
     for platform in get_platforms(project["name"]):
       # bazel-bench doesn't support Windows for now.
-      if platform in ["windows", "macos", "rbe_ubuntu1604"]:
+      if platform in ["windows"]:
         continue
 
       # When running on the first platform, get the bazel commits.
@@ -204,12 +204,11 @@ def main(argv=None):
           ci_step_for_platform_and_commits(
               bazel_commits, platform, project, args.bazel_bench_options))
 
-  # Print the commands
   bazelci.eprint(yaml.dump({"steps": bazel_bench_ci_steps}))
-  buildkit_pipeline_cmd = (
+  buildkite_pipeline_cmd = (
       'cat <<EOF | buildkite-agent pipeline upload\n%s\nEOF'
       % yaml.dump({"steps": bazel_bench_ci_steps}))
-  subprocess.call(buildkit_pipeline_cmd, shell=True)
+  subprocess.call(buildkite_pipeline_cmd, shell=True)
 
 
 if __name__ == "__main__":

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -31,10 +31,10 @@ import yaml
 
 
 def _platform_path_str(posix_path):
-  """Converts the path to the appropriate format for platform."""
-  if os.name == "nt":
-    return posix_path.replace("/", "\\")
-  return posix_path
+    """Converts the path to the appropriate format for platform."""
+    if os.name == "nt":
+        return posix_path.replace("/", "\\")
+    return posix_path
 
 
 # TMP has different values, depending on the platform.
@@ -43,7 +43,7 @@ PROJECTS = [
     {
         "name": "Bazel",
         "git_repository": "https://github.com/bazelbuild/bazel.git",
-        "bazel_command": "build ..."
+        "bazel_command": "build ...",
     }
 ]
 BAZEL_REPOSITORY = "https://github.com/bazelbuild/bazel.git"
@@ -51,21 +51,21 @@ DATA_DIRECTORY = _platform_path_str("%s/.bazel-bench/out/" % TMP)
 
 
 def _bazel_bench_env_setup_command(platform, bazel_commits):
-  bazel_bench_env_setup_py_url = (
-      "https://raw.githubusercontent.com/bazelbuild/continuous-integration"
-      "/master/buildkite/bazel_bench_env_setup.py?%s"
-      % int(time.time()))
-  download_command = (
-      'curl -sS "%s" -o bazel_bench_env_setup.py'
-      % bazel_bench_env_setup_py_url)
-  exec_command = (
-      "%s bazel_bench_env_setup.py --platform=%s --bazel_commits=%s"
-      % (bazelci.PLATFORMS[platform]["python"], platform, bazel_commits))
-  return [download_command, exec_command]
+    bazel_bench_env_setup_py_url = (
+        "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazel_bench_env_setup.py?%s"
+        % int(time.time())
+    )
+    download_command = 'curl -sS "%s" -o bazel_bench_env_setup.py' % bazel_bench_env_setup_py_url
+    exec_command = "%s bazel_bench_env_setup.py --platform=%s --bazel_commits=%s" % (
+        bazelci.PLATFORMS[platform]["python"],
+        platform,
+        bazel_commits,
+    )
+    return [download_command, exec_command]
 
 
 def _get_bazel_commits(day, bazel_repo_path):
-  """Get the commits from a particular day.
+    """Get the commits from a particular day.
 
   Get the commits from 00:00 of day to 00:00 of day + 1.
 
@@ -76,22 +76,21 @@ def _get_bazel_commits(day, bazel_repo_path):
   Return:
     A list of string (commit hashes).
   """
-  day_plus_one = day + datetime.timedelta(days=1)
-  args = [
-      "git",
-      "log",
-      "--pretty=format:'%H'",
-      "--after='%s'" % day.strftime("%Y-%m-%d 00:00"),
-      "--until='%s'" % day_plus_one.strftime("%Y-%m-%d 00:00"),
-      "--reverse"
-  ]
-  command = subprocess.Popen(args, stdout=subprocess.PIPE, cwd=bazel_repo_path)
-  return [
-      line.decode('utf-8').rstrip("\n").strip("'") for line in command.stdout]
+    day_plus_one = day + datetime.timedelta(days=1)
+    args = [
+        "git",
+        "log",
+        "--pretty=format:'%H'",
+        "--after='%s'" % day.strftime("%Y-%m-%d 00:00"),
+        "--until='%s'" % day_plus_one.strftime("%Y-%m-%d 00:00"),
+        "--reverse",
+    ]
+    command = subprocess.Popen(args, stdout=subprocess.PIPE, cwd=bazel_repo_path)
+    return [line.decode("utf-8").rstrip("\n").strip("'") for line in command.stdout]
 
 
 def _get_platforms(project_name):
-  """Get the platforms on which this project is run on BazelCI.
+    """Get the platforms on which this project is run on BazelCI.
 
   Args:
     project_name: a string: the name of the project. e.g. "Bazel".
@@ -99,14 +98,14 @@ def _get_platforms(project_name):
   Returns:
     A list of string: the platforms for this project.
   """
-  http_config = bazelci.DOWNSTREAM_PROJECTS[project_name]["http_config"]
-  configs = bazelci.fetch_configs(http_config, None)
-  tasks = configs["tasks"]
-  return list(map(lambda k: bazelci.get_platform_for_task(k, tasks[k]), tasks))
+    http_config = bazelci.DOWNSTREAM_PROJECTS_PRODUCTION[project_name]["http_config"]
+    configs = bazelci.fetch_configs(http_config, None)
+    tasks = configs["tasks"]
+    return list(map(lambda k: bazelci.get_platform_for_task(k, tasks[k]), tasks))
 
 
 def _get_clone_path(repository, platform):
-  """Returns the path to a local clone of the project.
+    """Returns the path to a local clone of the project.
 
   If there's a mirror available, use that. bazel-bench will take care of
   pulling/checking out commits. Else, clone the repo.
@@ -118,17 +117,16 @@ def _get_clone_path(repository, platform):
   Returns:
     A path to the local clone.
   """
-  mirror_path = bazelci.get_mirror_path(repository, platform)
-  if os.path.exists(mirror_path):
-    bazelci.eprint("Found mirror for %s on %s." % repository, platform)
-    return mirror_path
+    mirror_path = bazelci.get_mirror_path(repository, platform)
+    if os.path.exists(mirror_path):
+        bazelci.eprint("Found mirror for %s on %s." % repository, platform)
+        return mirror_path
 
-  return repository
+    return repository
 
 
-def _ci_step_for_platform_and_commits(
-    bazel_commits, platform, project, extra_options):
-  """Perform bazel-bench for the platform-project combination.
+def _ci_step_for_platform_and_commits(bazel_commits, platform, project, extra_options):
+    """Perform bazel-bench for the platform-project combination.
   Uploads results to BigQuery.
 
   Args:
@@ -142,74 +140,79 @@ def _ci_step_for_platform_and_commits(
     An object: the result of applying bazelci.create_step to wrap the
       command to be executed by buildkite-agent.
   """
-  project_clone_path = _get_clone_path(project["git_repository"], platform)
-  bazel_clone_path = _get_clone_path(BAZEL_REPOSITORY, platform)
+    project_clone_path = _get_clone_path(project["git_repository"], platform)
+    bazel_clone_path = _get_clone_path(BAZEL_REPOSITORY, platform)
 
-  bazel_bench_command = " ".join([
-      "bazel",
-      "run",
-      "benchmark",
-      "--",
-      "--bazel_commits=%s" % ",".join(bazel_commits),
-      "--bazel_source=%s" % bazel_clone_path,
-      "--project_source=%s" % project_clone_path,
-      "--platform=%s" % platform,
-      "--collect_memory",
-      "--data_directory=%s" % DATA_DIRECTORY,
-      extra_options,
-      "--",
-      project["bazel_command"]
-  ])
+    bazel_bench_command = " ".join(
+        [
+            "bazel",
+            "run",
+            "benchmark",
+            "--",
+            "--bazel_commits=%s" % ",".join(bazel_commits),
+            "--bazel_source=%s" % bazel_clone_path,
+            "--project_source=%s" % project_clone_path,
+            "--platform=%s" % platform,
+            "--collect_memory",
+            "--data_directory=%s" % DATA_DIRECTORY,
+            extra_options,
+            "--",
+            project["bazel_command"],
+        ]
+    )
 
-  commands = ([bazelci.fetch_bazelcipy_command()]
-              + _bazel_bench_env_setup_command(platform, ",".join(bazel_commits))
-              + [bazel_bench_command])
-  label = (bazelci.PLATFORMS[platform]["emoji-name"]
-           + " Running bazel-bench on project: %s" % project["name"])
-  return bazelci.create_step(label, commands, platform)
+    commands = (
+        [bazelci.fetch_bazelcipy_command()]
+        + _bazel_bench_env_setup_command(platform, ",".join(bazel_commits))
+        + [bazel_bench_command]
+    )
+    label = (
+        bazelci.PLATFORMS[platform]["emoji-name"]
+        + " Running bazel-bench on project: %s" % project["name"]
+    )
+    return bazelci.create_step(label, commands, platform)
 
 
 def main(args=None):
-  if args is None:
-    args = sys.argv[1:]
+    if args is None:
+        args = sys.argv[1:]
 
-  parser = argparse.ArgumentParser(description="Bazel Bench CI Pipeline")
-  parser.add_argument("--day", type=str)
-  parser.add_argument("--bazel_bench_options", type=str, default="")
-  parsed_args = parser.parse_args(args)
+    parser = argparse.ArgumentParser(description="Bazel Bench CI Pipeline")
+    parser.add_argument("--day", type=str)
+    parser.add_argument("--bazel_bench_options", type=str, default="")
+    parsed_args = parser.parse_args(args)
 
-  bazel_bench_ci_steps = []
-  day = (datetime.datetime.strptime(parsed_args.day, "%Y-%m-%d").date()
-         if parsed_args.day
-         else datetime.date.today())
-  bazel_commits = None
-  for project in PROJECTS:
-    for platform in _get_platforms(project["name"]):
-      # bazel-bench doesn't support Windows for now.
-      if platform in ["windows"]:
-        continue
+    bazel_bench_ci_steps = []
+    day = (
+        datetime.datetime.strptime(parsed_args.day, "%Y-%m-%d").date()
+        if parsed_args.day
+        else datetime.date.today()
+    )
+    bazel_commits = None
+    for project in PROJECTS:
+        for platform in _get_platforms(project["name"]):
+            # bazel-bench doesn't support Windows for now.
+            if platform in ["windows"]:
+                continue
 
-      # When running on the first platform, get the bazel commits.
-      # The bazel commits should be the same regardless of platform.
-      if not bazel_commits:
-        bazel_clone_path = bazelci.clone_git_repository(
-            BAZEL_REPOSITORY, platform)
-        bazel_commits = _get_bazel_commits(day, bazel_clone_path)
+            # When running on the first platform, get the bazel commits.
+            # The bazel commits should be the same regardless of platform.
+            if not bazel_commits:
+                bazel_clone_path = bazelci.clone_git_repository(BAZEL_REPOSITORY, platform)
+                bazel_commits = _get_bazel_commits(day, bazel_clone_path)
 
-      bazel_bench_ci_steps.append(
-          _ci_step_for_platform_and_commits(
-              bazel_commits,
-              platform,
-              project,
-              parsed_args.bazel_bench_options))
+            bazel_bench_ci_steps.append(
+                _ci_step_for_platform_and_commits(
+                    bazel_commits, platform, project, parsed_args.bazel_bench_options
+                )
+            )
 
-  bazelci.eprint(yaml.dump({"steps": bazel_bench_ci_steps}))
-  buildkite_pipeline_cmd = (
-      'cat <<EOF | buildkite-agent pipeline upload\n%s\nEOF'
-      % yaml.dump({"steps": bazel_bench_ci_steps}))
-  subprocess.call(buildkite_pipeline_cmd, shell=True)
+    bazelci.eprint(yaml.dump({"steps": bazel_bench_ci_steps}))
+    buildkite_pipeline_cmd = "cat <<EOF | buildkite-agent pipeline upload\n%s\nEOF" % yaml.dump(
+        {"steps": bazel_bench_ci_steps}
+    )
+    subprocess.call(buildkite_pipeline_cmd, shell=True)
 
 
 if __name__ == "__main__":
-  sys.exit(main())
-
+    sys.exit(main())

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -117,6 +117,9 @@ def ci_step_for_platform_and_commits(
   # Download the binaries already built.
   # Bazel-bench won"t try to build these binaries again, since they exist.
   for bazel_commit in bazel_commits:
+    destination = BAZEL_BINARY_BASE_PATH + bazel_commit
+    if os.path.exists(destination):
+      continue
     bazelci.download_bazel_binary_at_commit(
         BAZEL_BINARY_BASE_PATH + bazel_commit,
         platform,

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -165,8 +165,8 @@ def ci_step_for_platform_and_commits(
   ])
 
   commands = ([bazelci.fetch_bazelcipy_command()]
-             #+ _bazel_bench_env_setup_command(platform, ",".join(bazel_commits))
-              + [bazel_bench_command])
+              + _bazel_bench_env_setup_command(platform, ",".join(bazel_commits))]
+             #+ [bazel_bench_command])
   label = (bazelci.PLATFORMS[platform]["emoji-name"]
            + " Running bazel-bench on project: %s" % project["name"])
   return bazelci.create_step(label, commands, platform)

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -23,7 +23,6 @@ import argparse
 import bazelci
 import datetime
 import os
-import shutil
 import subprocess
 import sys
 import tempfile

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -52,8 +52,8 @@ DATA_DIRECTORY = _platform_path_str("%s/.bazel-bench/out/" % TMP)
 
 def _bazel_bench_env_setup_command(platform, bazel_commits):
   bazel_bench_env_setup_py_url = (
-      "https://raw.githubusercontent.com/joeleba/continuous-integration"
-      "/bb-patch/buildkite/bazel_bench_env_setup.py?%s"
+      "https://raw.githubusercontent.com/bazelbuild/continuous-integration"
+      "/master/buildkite/bazel_bench_env_setup.py?%s"
       % int(time.time()))
   download_command = (
       'curl -sS "%s" -o bazel_bench_env_setup.py'

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -57,7 +57,7 @@ def _bazel_bench_env_setup_command(platform, bazel_commits):
       "/bb-patch/buildkite/bazel_bench_env_setup.py?%s"
       % int(time.time()))
   download_command = (
-      "curl -sS %s -o bazel_bench_env_setup.py"
+      'curl -sS "%s" -o bazel_bench_env_setup.py'
       % bazel_bench_env_setup_py_url)
   exec_command = (
       "%s bazel_bench_env_setup.py --platform=%s --bazel_commits=%s"
@@ -165,7 +165,7 @@ def ci_step_for_platform_and_commits(
   ])
 
   commands = ([bazelci.fetch_bazelcipy_command()]
-              + _bazel_bench_env_setup_command(platform, ",".join(bazel_commits))
+             #+ _bazel_bench_env_setup_command(platform, ",".join(bazel_commits))
               + [bazel_bench_command])
   label = (bazelci.PLATFORMS[platform]["emoji-name"]
            + " Running bazel-bench on project: %s" % project["name"])

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -206,7 +206,7 @@ def main(argv=None):
 
   # Print the commands
   bazelci.eprint(yaml.dump({"steps": bazel_bench_ci_steps}))
-  sys.stdout.write(yaml.dump({"steps": bazel_bench_ci_steps}), flush=True)
+  sys.stdout.write(yaml.dump({"steps": bazel_bench_ci_steps}))
   bazelci.eprint("After print")
 
 

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -171,7 +171,7 @@ def main(argv=None):
   for project in PROJECTS:
     for platform in get_platforms(project["name"]):
       # bazel-bench doesn't support Windows for now.
-      if platform == "windows":
+      if platform in ["windows", "macos"]:
         continue
 
       # When running on the first platform, get the bazel commits.

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -167,8 +167,8 @@ def ci_step_for_platform_and_commits(
   ])
 
   commands = ([bazelci.fetch_bazelcipy_command()]
-              + _bazel_bench_env_setup_command(platform, ",".join(bazel_commits)))
-             #+ [bazel_bench_command])
+              + _bazel_bench_env_setup_command(platform, ",".join(bazel_commits))
+              + [bazel_bench_command])
   label = (bazelci.PLATFORMS[platform]["emoji-name"]
            + " Running bazel-bench on project: %s" % project["name"])
   return bazelci.create_step(label, commands, platform)

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -109,6 +109,7 @@ def ci_step_for_platform_and_commits(
     An object: the result of applying bazelci.create_step to wrap the
       command to be executed by buildkite-agent.
   """
+  print("platform: %s" % platform)
   # It's ok to use mirror path as bazel-bench will take care of pulling/checking
   # out commits.
   project_clone_path = bazelci.get_mirror_path(

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -52,17 +52,17 @@ RUNS = 3
 
 
 def _bazel_bench_env_setup_command(platform, bazel_commits):
-    bazel_bench_env_setup_py_url = (
-        "https://raw.githubusercontent.com/joeleba/continuous-integration"
-        "/bb-patch/buildkite/bazel_bench_env_setup.py?%s"
-        % int(time.time()))
-    download_command = (
-        "curl -s %s -o bazel_bench_env_setup.py"
-        % bazel_bench_env_setup_py_url)
-    exec_command = (
-        "%s bazel_bench_env_setup.py --platform=%s --bazel_commits=%s"
-        % (bazelci.PLATFORMS[platform]["python"], platform, bazel_commits))
-    return [download_command, exec_command]
+  bazel_bench_env_setup_py_url = (
+      "https://raw.githubusercontent.com/joeleba/continuous-integration"
+      "/bb-patch/buildkite/bazel_bench_env_setup.py?%s"
+      % int(time.time()))
+  download_command = (
+      "curl -s %s -o bazel_bench_env_setup.py"
+      % bazel_bench_env_setup_py_url)
+  exec_command = (
+      "%s bazel_bench_env_setup.py --platform=%s --bazel_commits=%s"
+      % (bazelci.PLATFORMS[platform]["python"], platform, bazel_commits))
+  return [download_command, exec_command]
 
 
 def _get_bazel_commits(day, bazel_repo_path):
@@ -92,18 +92,18 @@ def _get_bazel_commits(day, bazel_repo_path):
 
 
 def get_platforms(project_name):
-    """Get the platforms on which this project is run on BazelCI.
+  """Get the platforms on which this project is run on BazelCI.
 
-    Args:
-      project_name: a string: the name of the project. e.g. "Bazel".
+  Args:
+    project_name: a string: the name of the project. e.g. "Bazel".
 
-    Returns:
-      A list of string: the platforms for this project.
-    """
-    http_config = bazelci.DOWNSTREAM_PROJECTS[project_name]["http_config"]
-    configs = bazelci.fetch_configs(http_config, None)
-    tasks = configs["tasks"]
-    return list(map(lambda k: bazelci.get_platform_for_task(k, tasks[k]), tasks))
+  Returns:
+    A list of string: the platforms for this project.
+  """
+  http_config = bazelci.DOWNSTREAM_PROJECTS[project_name]["http_config"]
+  configs = bazelci.fetch_configs(http_config, None)
+  tasks = configs["tasks"]
+  return list(map(lambda k: bazelci.get_platform_for_task(k, tasks[k]), tasks))
 
 
 def get_clone_path(repository, platform):

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -114,11 +114,11 @@ def ci_step_for_platform_and_commits(
   project_clone_path = bazelci.get_mirror_path(
       project["git_repository"], platform)
   if not os.path.exists(project_clone_path):
-    bazelci.clone_git_repository(project["git_repository"], platform)
+    project_clone_path = bazelci.clone_git_repository(project["git_repository"], platform)
 
   bazel_clone_path = bazelci.get_mirror_path(BAZEL_REPOSITORY, platform)
   if not os.path.exists(bazel_clone_path):
-    bazelci.clone_git_repository(BAZEL_REPOSITORY, platform)
+    bazel_clone_path = bazelci.clone_git_repository(BAZEL_REPOSITORY, platform)
 
   # Download the binaries already built.
   # Bazel-bench won"t try to build these binaries again, since they exist.

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -50,7 +50,6 @@ PROJECTS = [
 BAZEL_REPOSITORY = "https://github.com/bazelbuild/bazel.git"
 DATA_DIRECTORY = _platform_path_str("%s/.bazel-bench/out/" % TMP)
 RUNS = 3
-BIGQUERY_TABLE = "bazel_playground:bazel_bench:europe-west2"
 
 
 def get_bazel_commits(day, bazel_repo_path):
@@ -114,7 +113,12 @@ def ci_step_for_platform_and_commits(
   # out commits.
   project_clone_path = bazelci.get_mirror_path(
       project["git_repository"], platform)
+  if not os.path.exists(project_clone_path):
+    bazelci.clone_git_repository(project["git_repository"], platform)
+
   bazel_clone_path = bazelci.get_mirror_path(BAZEL_REPOSITORY, platform)
+  if not os.path.exists(bazel_clone_path):
+    bazelci.clone_git_repository(BAZEL_REPOSITORY, platform)
 
   # Download the binaries already built.
   # Bazel-bench won"t try to build these binaries again, since they exist.
@@ -140,7 +144,6 @@ def ci_step_for_platform_and_commits(
       "--collect_memory",
       "--runs=%s" % RUNS,
       "--data_directory=%s" % DATA_DIRECTORY,
-      "--upload_data_to=%s" % BIGQUERY_TABLE,
       extra_options,
       "--",
       project["bazel_command"]

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -144,7 +144,6 @@ def ci_step_for_platform_and_commits(
     An object: the result of applying bazelci.create_step to wrap the
       command to be executed by buildkite-agent.
   """
-  bazelci.eprint("platform: %s" % platform)
   project_clone_path = get_clone_path(project["git_repository"], platform)
   bazel_clone_path = get_clone_path(BAZEL_REPOSITORY, platform)
 

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -57,7 +57,7 @@ def _bazel_bench_env_setup_command(platform, bazel_commits):
       "/bb-patch/buildkite/bazel_bench_env_setup.py?%s"
       % int(time.time()))
   download_command = (
-      "curl -s %s -o bazel_bench_env_setup.py"
+      "curl -sS %s -o bazel_bench_env_setup.py"
       % bazel_bench_env_setup_py_url)
   exec_command = (
       "%s bazel_bench_env_setup.py --platform=%s --bazel_commits=%s"

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -164,11 +164,9 @@ def ci_step_for_platform_and_commits(
       project["bazel_command"]
   ])
 
-  commands = [
-      bazelci.fetch_bazelcipy_command(),
-      _bazel_bench_env_setup_command(platform, ",".join(bazel_commits)),
-      bazel_bench_command
-  ]
+  commands = ([bazelci.fetch_bazelcipy_command()]
+              + _bazel_bench_env_setup_command(platform, ",".join(bazel_commits))
+              + [bazel_bench_command])
   label = (bazelci.PLATFORMS[platform]["emoji-name"]
            + " Running bazel-bench on project: %s" % project["name"])
   return bazelci.create_step(label, commands, platform)

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -160,12 +160,13 @@ def ci_step_for_platform_and_commits(
       "--collect_memory",
       "--runs=%s" % RUNS,
       "--data_directory=%s" % DATA_DIRECTORY,
+      extra_options,
       "--",
       project["bazel_command"]
   ]
 
   label = (bazelci.PLATFORMS[platform]["emoji-name"]
-           + " Running bazel-bench on project: %s" % project)
+           + " Running bazel-bench on project: %s" % project["name"])
   return bazelci.create_step(label, " ".join(args), platform)
 
 
@@ -200,6 +201,7 @@ def main(argv=None):
               bazel_commits, platform, project, args.bazel_bench_options))
 
   # Print the commands
+  bazelci.eprint(yaml.dump({"steps": bazel_bench_ci_steps}))
   print(yaml.dump({"steps": bazel_bench_ci_steps}))
 
 if __name__ == "__main__":

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -110,9 +110,11 @@ def ci_step_for_platform_and_commits(
     An object: the result of applying bazelci.create_step to wrap the
       command to be executed by buildkite-agent.
   """
-  project_clone_path = bazelci.clone_git_repository(
+  # It's ok to use mirror path as bazel-bench will take care of pulling/checking
+  # out commits.
+  project_clone_path = bazelci.get_mirror_path(
       project["git_repository"], platform)
-  bazel_clone_path = bazelci.clone_git_repository(BAZEL_REPOSITORY, platform)
+  bazel_clone_path = bazelci.get_mirror_path(BAZEL_REPOSITORY, platform)
 
   # Download the binaries already built.
   # Bazel-bench won"t try to build these binaries again, since they exist.

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -160,7 +160,6 @@ def ci_step_for_platform_and_commits(
       "--collect_memory",
       "--runs=%s" % RUNS,
       "--data_directory=%s" % DATA_DIRECTORY,
-      extra_options,
       "--",
       project["bazel_command"]
   ]

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -165,7 +165,7 @@ def ci_step_for_platform_and_commits(
   ])
 
   commands = ([bazelci.fetch_bazelcipy_command()]
-              + _bazel_bench_env_setup_command(platform, ",".join(bazel_commits))]
+              + _bazel_bench_env_setup_command(platform, ",".join(bazel_commits)))
              #+ [bazel_bench_command])
   label = (bazelci.PLATFORMS[platform]["emoji-name"]
            + " Running bazel-bench on project: %s" % project["name"])

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -85,8 +85,8 @@ def _get_bazel_commits(day, bazel_repo_path):
         "--until='%s'" % day_plus_one.strftime("%Y-%m-%d 00:00"),
         "--reverse",
     ]
-    command = subprocess.Popen(args, stdout=subprocess.PIPE, cwd=bazel_repo_path)
-    return [line.decode("utf-8").rstrip("\n").strip("'") for line in command.stdout]
+    command_output = subprocess.check_output(args, cwd=bazel_repo_path)
+    return [line.decode("utf-8").rstrip("\n").strip("'") for line in command_output]
 
 
 def _get_platforms(project_name):

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -206,8 +206,10 @@ def main(argv=None):
 
   # Print the commands
   bazelci.eprint(yaml.dump({"steps": bazel_bench_ci_steps}))
-  yaml.dump({"steps": bazel_bench_ci_steps}, sys.stdout)
-  bazelci.eprint("After print")
+  buildkit_pipeline_cmd = (
+      "%s | buildkite pipeline upload"
+      % yaml.dump({"steps": bazel_bench_ci_steps}))
+  subprocess.call(buildkit_pipeline_cmd, shell=True)
 
 
 if __name__ == "__main__":

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -206,7 +206,7 @@ def main(argv=None):
 
   # Print the commands
   bazelci.eprint(yaml.dump({"steps": bazel_bench_ci_steps}))
-  sys.stdout.write(yaml.dump({"steps": bazel_bench_ci_steps}))
+  yaml.dump({"steps": bazel_bench_ci_steps}, sys.stdout)
   bazelci.eprint("After print")
 
 

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -61,7 +61,7 @@ def _bazel_bench_env_setup_command(platform, bazel_commits):
         % bazel_bench_env_setup_py_url)
     exec_command = (
         "%s bazel_bench_env_setup.py --platform=%s --bazel_commits=%s"
-        % (bazelci.PLATFORMS[platform_name]["python"], platform, bazel_commits))
+        % (bazelci.PLATFORMS[platform]["python"], platform, bazel_commits))
     return [download_command, exec_command]
 
 

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -67,7 +67,7 @@ def get_bazel_commits(day):
   args = [
       "git",
       "log",
-      "--pretty=format:'%H'",
+      "--pretty=format:'%h'",
       "--after='%s'" % day.strftime("%Y-%m-%d 00:00"),
       "--until='%s'" % day_plus_one.strftime("%Y-%m-%d 00:00"),
       "--reverse"

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -174,17 +174,18 @@ def ci_step_for_platform_and_commits(
   return bazelci.create_step(label, commands, platform)
 
 
-def main(argv=None):
-  if argv is None:
-    argv = sys.argv[1:]
+def main(args=None):
+  if args is None:
+    args = sys.argv[1:]
 
   parser = argparse.ArgumentParser(description="Bazel Bench CI Pipeline")
   parser.add_argument("--day", type=str)
   parser.add_argument("--bazel_bench_options", type=str, default="")
-  args = parser.parse_args(argv)
+  parsed_args = parser.parse_args(args)
 
   bazel_bench_ci_steps = []
-  day = (datetime.datetime.strptime(args.day, "%Y-%m-%d").date() if args.day
+  day = (datetime.datetime.strptime(parsed_args.day, "%Y-%m-%d").date()
+         if parsed_args.day
          else datetime.date.today())
   bazel_commits = None
   for project in PROJECTS:
@@ -202,7 +203,10 @@ def main(argv=None):
 
       bazel_bench_ci_steps.append(
           ci_step_for_platform_and_commits(
-              bazel_commits, platform, project, args.bazel_bench_options))
+              bazel_commits,
+              platform,
+              project,
+              parsed_args.bazel_bench_options))
 
   bazelci.eprint(yaml.dump({"steps": bazel_bench_ci_steps}))
   buildkite_pipeline_cmd = (

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -186,7 +186,7 @@ def main(argv=None):
   for project in PROJECTS:
     for platform in get_platforms(project["name"]):
       # bazel-bench doesn't support Windows for now.
-      if platform in ["windows", "macos"]:
+      if platform in ["windows", "macos", "rbe_ubuntu1604"]:
         continue
 
       # When running on the first platform, get the bazel commits.

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -109,7 +109,7 @@ def ci_step_for_platform_and_commits(
     An object: the result of applying bazelci.create_step to wrap the
       command to be executed by buildkite-agent.
   """
-  print("platform: %s" % platform)
+  bazelci.eprint("platform: %s" % platform)
   # It's ok to use mirror path as bazel-bench will take care of pulling/checking
   # out commits.
   project_clone_path = bazelci.get_mirror_path(

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -206,7 +206,7 @@ def main(argv=None):
 
   # Print the commands
   bazelci.eprint(yaml.dump({"steps": bazel_bench_ci_steps}))
-  print(yaml.dump({"steps": bazel_bench_ci_steps}))
+  print(yaml.dump({"steps": bazel_bench_ci_steps}), flush=True)
 
 if __name__ == "__main__":
   sys.exit(main())

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -207,7 +207,7 @@ def main(argv=None):
   # Print the commands
   bazelci.eprint(yaml.dump({"steps": bazel_bench_ci_steps}))
   buildkit_pipeline_cmd = (
-      'cat <<EOF | buildkite pipeline upload\n%s\nEOF'
+      'cat <<EOF | buildkite-agent pipeline upload\n%s\nEOF'
       % yaml.dump({"steps": bazel_bench_ci_steps}))
   subprocess.call(buildkit_pipeline_cmd, shell=True)
 

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -50,7 +50,6 @@ PROJECTS = [
 ]
 BAZEL_REPOSITORY = "https://github.com/bazelbuild/bazel.git"
 DATA_DIRECTORY = _platform_path_str("%s/.bazel-bench/out/" % TMP)
-RUNS = 3
 
 
 def _bazel_bench_env_setup_command(platform, bazel_commits):
@@ -159,7 +158,6 @@ def ci_step_for_platform_and_commits(
       "--project_source=%s" % project_clone_path,
       "--platform=%s" % platform,
       "--collect_memory",
-      "--runs=%s" % RUNS,
       "--data_directory=%s" % DATA_DIRECTORY,
       extra_options,
       "--",

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -37,7 +37,6 @@ def _platform_path_str(posix_path):
   return posix_path
 
 
-# TODO(leba): Make these configurable via flags to the script.
 # TMP has different values, depending on the platform.
 TMP = tempfile.gettempdir()
 PROJECTS = [
@@ -91,7 +90,7 @@ def _get_bazel_commits(day, bazel_repo_path):
       line.decode('utf-8').rstrip("\n").strip("'") for line in command.stdout]
 
 
-def get_platforms(project_name):
+def _get_platforms(project_name):
   """Get the platforms on which this project is run on BazelCI.
 
   Args:
@@ -106,7 +105,7 @@ def get_platforms(project_name):
   return list(map(lambda k: bazelci.get_platform_for_task(k, tasks[k]), tasks))
 
 
-def get_clone_path(repository, platform):
+def _get_clone_path(repository, platform):
   """Returns the path to a local clone of the project.
 
   If there's a mirror available, use that. bazel-bench will take care of
@@ -127,7 +126,7 @@ def get_clone_path(repository, platform):
   return repository
 
 
-def ci_step_for_platform_and_commits(
+def _ci_step_for_platform_and_commits(
     bazel_commits, platform, project, extra_options):
   """Perform bazel-bench for the platform-project combination.
   Uploads results to BigQuery.
@@ -143,8 +142,8 @@ def ci_step_for_platform_and_commits(
     An object: the result of applying bazelci.create_step to wrap the
       command to be executed by buildkite-agent.
   """
-  project_clone_path = get_clone_path(project["git_repository"], platform)
-  bazel_clone_path = get_clone_path(BAZEL_REPOSITORY, platform)
+  project_clone_path = _get_clone_path(project["git_repository"], platform)
+  bazel_clone_path = _get_clone_path(BAZEL_REPOSITORY, platform)
 
   bazel_bench_command = " ".join([
       "bazel",
@@ -185,7 +184,7 @@ def main(args=None):
          else datetime.date.today())
   bazel_commits = None
   for project in PROJECTS:
-    for platform in get_platforms(project["name"]):
+    for platform in _get_platforms(project["name"]):
       # bazel-bench doesn't support Windows for now.
       if platform in ["windows"]:
         continue
@@ -198,7 +197,7 @@ def main(args=None):
         bazel_commits = _get_bazel_commits(day, bazel_clone_path)
 
       bazel_bench_ci_steps.append(
-          ci_step_for_platform_and_commits(
+          _ci_step_for_platform_and_commits(
               bazel_commits,
               platform,
               project,

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -207,7 +207,7 @@ def main(argv=None):
   # Print the commands
   bazelci.eprint(yaml.dump({"steps": bazel_bench_ci_steps}))
   buildkit_pipeline_cmd = (
-      "%s | buildkite pipeline upload"
+      'cat <<EOF | buildkite pipeline upload\n%s\nEOF'
       % yaml.dump({"steps": bazel_bench_ci_steps}))
   subprocess.call(buildkit_pipeline_cmd, shell=True)
 

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -206,7 +206,9 @@ def main(argv=None):
 
   # Print the commands
   bazelci.eprint(yaml.dump({"steps": bazel_bench_ci_steps}))
-  print(yaml.dump({"steps": bazel_bench_ci_steps}), flush=True)
+  sys.stdout.write(yaml.dump({"steps": bazel_bench_ci_steps}), flush=True)
+  bazelci.eprint("After print")
+
 
 if __name__ == "__main__":
   sys.exit(main())

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -170,8 +170,9 @@ def main(argv=None):
 
       # When running on the first platform, get the bazel commits.
       # The bazel commits should be the same regardless of platform.
-      bazel_clone_path = bazelci.clone_git_repository(BAZEL_REPOSITORY, platform)
       if not bazel_commits:
+        bazel_clone_path = bazelci.clone_git_repository(
+            BAZEL_REPOSITORY, platform)
         bazel_commits = get_bazel_commits(day, bazel_clone_path)
 
       bazel_bench_ci_steps.append(

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -162,6 +162,7 @@ def main(argv=None):
         continue
 
       # When running on the first platform, get the bazel commits.
+      # The bazel commits should be the same regardless of platform.
       bazel_clone_path = bazelci.clone_git_repository(BAZEL_REPOSITORY, platform)
       if not bazel_commits:
         bazel_commits = get_bazel_commits(day, bazel_clone_path)

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -164,7 +164,6 @@ def ci_step_for_platform_and_commits(
       project["bazel_command"]
   ])
 
-  commands = set_up_env() + [bazel_bench_command]
   commands = [
       bazelci.fetch_bazelcipy_command(),
       _bazel_bench_env_setup_command(platform, ",".join(bazel_commits)),

--- a/buildkite/bazel_bench.py
+++ b/buildkite/bazel_bench.py
@@ -73,7 +73,8 @@ def get_bazel_commits(day):
       "--reverse"
   ]
   command = subprocess.Popen(args, stdout=subprocess.PIPE)
-  return [line.decode('utf-8').strip() for line in command.stdout]
+  return [
+      line.decode('utf-8').rstrip("\n").strip("'") for line in command.stdout]
 
 
 def get_platforms(project_name):
@@ -105,9 +106,6 @@ def ci_step_for_platform_and_commits(bazel_commits, platform, project):
     An object: the result of applying bazelci.create_step to wrap the
       command to be executed by buildkite-agent.
   """
-  # Get Bazel commits during the day
-  bazel_commits = get_bazel_commits(datetime.date.today())
-
   # Download the binaries already built.
   # Bazel-bench won"t try to build these binaries again, since they exist.
   for bazel_commit in bazel_commits:

--- a/buildkite/bazel_bench_env_setup.py
+++ b/buildkite/bazel_bench_env_setup.py
@@ -53,7 +53,7 @@ def main(argv=None):
 
     bazelci.download_bazel_binary_at_commit(
       destination,
-      platform,
+      args.platform,
       bazel_commit
     )
 

--- a/buildkite/bazel_bench_env_setup.py
+++ b/buildkite/bazel_bench_env_setup.py
@@ -22,11 +22,12 @@ import os
 import sys
 import tempfile
 
+
 def _platform_path_str(posix_path):
-  """Converts the path to the appropriate format for platform."""
-  if os.name == "nt":
-    return posix_path.replace("/", "\\")
-  return posix_path
+    """Converts the path to the appropriate format for platform."""
+    if os.name == "nt":
+        return posix_path.replace("/", "\\")
+    return posix_path
 
 
 # TMP has different values, depending on the platform.
@@ -34,32 +35,28 @@ TMP = tempfile.gettempdir()
 # The path to the directory that stores the bazel binaries.
 BAZEL_BINARY_BASE_PATH = _platform_path_str("%s/.bazel-bench/bazel-bin" % TMP)
 
+
 def main(argv=None):
-  if argv is None:
-    argv = sys.argv[1:]
+    if argv is None:
+        argv = sys.argv[1:]
 
-  parser = argparse.ArgumentParser(description="Bazel Bench Environment Setup")
-  parser.add_argument("--platform", type=str)
-  parser.add_argument("--bazel_commits", type=str)
-  args = parser.parse_args(argv)
+    parser = argparse.ArgumentParser(description="Bazel Bench Environment Setup")
+    parser.add_argument("--platform", type=str)
+    parser.add_argument("--bazel_commits", type=str)
+    args = parser.parse_args(argv)
 
-  bazel_commits = args.bazel_commits.split(",")
+    bazel_commits = args.bazel_commits.split(",")
 
-  for bazel_commit in bazel_commits:
-    destination = BAZEL_BINARY_BASE_PATH + '/' + bazel_commit
-    if os.path.exists(destination):
-      continue
-    try:
-      bazelci.download_bazel_binary_at_commit(
-        destination,
-        args.platform,
-        bazel_commit
-      )
-    except bazelci.BuildkiteException:
-      # Carry on.
-      bazelci.eprint("Binary for Bazel commit %s not found." % bazel_commit)
+    for bazel_commit in bazel_commits:
+        destination = BAZEL_BINARY_BASE_PATH + "/" + bazel_commit
+        if os.path.exists(destination):
+            continue
+        try:
+            bazelci.download_bazel_binary_at_commit(destination, args.platform, bazel_commit)
+        except bazelci.BuildkiteException:
+            # Carry on.
+            bazelci.eprint("Binary for Bazel commit %s not found." % bazel_commit)
 
 
 if __name__ == "__main__":
-  sys.exit(main())
-
+    sys.exit(main())

--- a/buildkite/bazel_bench_env_setup.py
+++ b/buildkite/bazel_bench_env_setup.py
@@ -35,7 +35,7 @@ TMP = tempfile.gettempdir()
 # The path to the directory that stores the bazel binaries.
 BAZEL_BINARY_BASE_PATH = _platform_path_str("%s/.bazel-bench/bazel-bin" % TMP)
 
-def main(argv):
+def main(argv=None):
   if argv is None:
     argv = sys.argv[1:]
 

--- a/buildkite/bazel_bench_env_setup.py
+++ b/buildkite/bazel_bench_env_setup.py
@@ -29,7 +29,6 @@ def _platform_path_str(posix_path):
   return posix_path
 
 
-# TODO(leba): Make these configurable via flags to the script.
 # TMP has different values, depending on the platform.
 TMP = tempfile.gettempdir()
 # The path to the directory that stores the bazel binaries.

--- a/buildkite/bazel_bench_env_setup.py
+++ b/buildkite/bazel_bench_env_setup.py
@@ -1,0 +1,61 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""To be executed on each docker container that runs the tasks.
+
+Clones the repository and downloads available bazel binaries.
+
+"""
+import argparse
+import bazelci
+import sys
+import tempfile
+
+def _platform_path_str(posix_path):
+  """Converts the path to the appropriate format for platform."""
+  if os.name == "nt":
+    return posix_path.replace("/", "\\")
+  return posix_path
+
+
+# TODO(leba): Make these configurable via flags to the script.
+# TMP has different values, depending on the platform.
+TMP = tempfile.gettempdir()
+# The path to the directory that stores the bazel binaries.
+BAZEL_BINARY_BASE_PATH = _platform_path_str("%s/.bazel-bench/bazel-bin" % TMP)
+
+def main(argv):
+  if argv is None:
+    argv = sys.argv[1:]
+
+  parser = argparse.ArgumentParser(description="Bazel Bench Environment Setup")
+  parser.add_argument("--platform", type=str)
+  parser.add_argument("--bazel_commits", type=str)
+  args = parser.parse_args(argv)
+
+  bazel_commits = args.bazel_commits.split(",")
+
+  for bazel_commit in bazel_commits:
+    destination = BAZEL_BINARY_BASE_PATH + '/' + bazel_commit
+    if os.path.exists(destination):
+      continue
+
+    bazelci.download_bazel_binary_at_commit(
+      destination,
+      platform,
+      bazel_commit
+    )
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/buildkite/bazel_bench_env_setup.py
+++ b/buildkite/bazel_bench_env_setup.py
@@ -18,6 +18,7 @@ Clones the repository and downloads available bazel binaries.
 """
 import argparse
 import bazelci
+import os
 import sys
 import tempfile
 

--- a/buildkite/bazel_bench_env_setup.py
+++ b/buildkite/bazel_bench_env_setup.py
@@ -50,13 +50,17 @@ def main(argv=None):
     destination = BAZEL_BINARY_BASE_PATH + '/' + bazel_commit
     if os.path.exists(destination):
       continue
-
-    bazelci.download_bazel_binary_at_commit(
-      destination,
-      args.platform,
-      bazel_commit
-    )
+    try:
+      bazelci.download_bazel_binary_at_commit(
+        destination,
+        args.platform,
+        bazel_commit
+      )
+    except bazelci.BuildkiteException:
+      # Carry on.
+      bazelci.eprint("Binary for Bazel commit %s not found." % bazel_commit)
 
 
 if __name__ == "__main__":
   sys.exit(main())
+


### PR DESCRIPTION
This PR fixes various issues with bazel_bench.py. The changes in particular:
- Add missing imports & wrong variable names.
- Make functions private where applicable.
- Add a new flag `--day` instead of relying on `datetime.date.now()`.
- Add a new flag `--bazel_bench_options` for more flexibility.
- Only `get_bazel_commits` once, instead of on each platform.
- Tasks like downloading bazel binaries, cloning projects are now distributed to destination VMs via bazel_bench_env_setup.py.
- Instead of piping stdout to `buildkite-agent pipeline upload`, do so directly in the script via `subprocess.call`. This also avoids the scenario where stdout is polluted and hence `buildkit-agent` fails.