### PR TITLE
Fix encoding of config hashes

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1834,7 +1834,8 @@ def hash_task_config(task_name, task_config):
 
     m = hashlib.md5()
     for key in sorted(cpy):
-        m.update("%s:%s;" % (key, cpy[key]))
+        value = "%s:%s;" % (key, cpy[key])
+        m.update(value.encode("utf-8"))
 
     return m.digest()
 


### PR DESCRIPTION
This commit solves the breakage in https://buildkite.com/bazel-testing/bazel-at-head-plus-downstream/builds/6#f864d6ef-de91-4463-a736-d1edb5bc8c97