### PR TITLE
Enable Bazel Codelabs in downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -100,7 +100,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/codelabs.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/codelabs/master/.bazelci/presubmit.yml",
         "pipeline_slug": "bazel-codelabs",
-        "disabled_reason": "https://github.com/bazelbuild/continuous-integration/issues/676",
     },
     "Bazel Remote Cache": {
         "git_repository": "https://github.com/buchgr/bazel-remote.git",


### PR DESCRIPTION
Bazel Codelabs is green with Bazel@HEAD
https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/203