### PR TITLE
ssmtp is no longer required for the Bazel release process.

### DIFF
--- a/buildkite/docker/Dockerfile
+++ b/buildkite/docker/Dockerfile
@@ -56,7 +56,7 @@ RUN dpkg --add-architecture i386 && \
     echo "Installing packages required by Android emulator" && \
     apt-get -qqy install cpio cpu-checker lsof qemu-kvm qemu-system-x86 unzip xvfb && \
     echo "Installing packages required by Bazel release process" && \
-    apt-get -qqy install devscripts gnupg pandoc reprepro ssmtp && \
+    apt-get -qqy install devscripts gnupg pandoc reprepro && \
     echo "Installing packages required by C++ coverage tests" && \
     apt-get -qqy install lcov llvm && \
     echo "Installing packages required by Swift toolchain" && \
@@ -155,7 +155,7 @@ RUN dpkg --add-architecture i386 && \
     echo "Installing packages required by Android emulator" && \
     apt-get -qqy install cpio cpu-checker lsof qemu-kvm qemu-system-x86 unzip xvfb && \
     echo "Installing packages required by Bazel release process" && \
-    apt-get -qqy install devscripts gnupg pandoc reprepro ssmtp && \
+    apt-get -qqy install devscripts gnupg pandoc reprepro && \
     echo "Installing packages required by C++ coverage tests" && \
     apt-get -qqy install lcov llvm && \
     echo "Installing packages required by Swift toolchain" && \


### PR DESCRIPTION
Removing from images.