### PR TITLE
remove remote execution

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -197,11 +197,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/pipelines/protobuf-postsubmit.yml",
         "pipeline_slug": "protobuf",
     },
-    "Remote execution": {
-        "git_repository": "https://github.com/bazelbuild/bazel.git",
-        "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/pipelines/bazel-remote-execution-postsubmit.yml",
-        "pipeline_slug": "remote-execution",
-    },
     "Skydoc": {
         "git_repository": "https://github.com/bazelbuild/skydoc.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/skydoc/master/.bazelci/presubmit.yml",


### PR DESCRIPTION
remove remote execution pipeline from downstream. the pipeline uses checked in toolchains for a specific Bazel release and thus is not a good signal for bazel head testing.