### PR TITLE
Small change to turn on Buildkit builder for all docker images.

### DIFF
--- a/buildkite/docker/build.sh
+++ b/buildkite/docker/build.sh
@@ -2,6 +2,10 @@
 
 set -euxo pipefail
 
+#Enable use of buildkit for all builds. No extra support in the docker file is required.
+export DOCKER_BUILDKIT=1
+
+
 docker build --target ubuntu1604-java8 -t gcr.io/bazel-public/ubuntu1604:java8 .
 docker build --target ubuntu1804-java11 -t gcr.io/bazel-public/ubuntu1804:java11 .
 docker build --target ubuntu1804-nojava -t gcr.io/bazel-public/ubuntu1804:nojava .


### PR DESCRIPTION
Enable by default the Buildkit builder for Docker for existing images. No changes have been made to the actual Dockerfile in this change, this is just enabling.