### PR TITLE
Use toolchain_java11 to build with Java 11

### DIFF
--- a/buildkite/pipelines/gerrit-postsubmit.yml
+++ b/buildkite/pipelines/gerrit-postsubmit.yml
@@ -9,17 +9,17 @@ platforms:
       - "//..."
   ubuntu1804:
     build_flags:
-      - "--define=ABSOLUTE_JAVABASE=/usr/lib/jvm/java-11-openjdk-amd64"
-      - "--host_javabase=@bazel_tools//tools/jdk:absolute_javabase"
-      - "--host_java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla"
-      - "--java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla"
+      - "--host_javabase=@bazel_tools//tools/jdk:remote_jdk11"
+      - "--javabase=@bazel_tools//tools/jdk:remote_jdk11"
+      - "--host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java11"
+      - "--java_toolchain=@bazel_tools//tools/jdk:toolchain_java11"
     build_targets:
       - "//:release"
     test_flags:
-      - "--define=ABSOLUTE_JAVABASE=/usr/lib/jvm/java-11-openjdk-amd64"
-      - "--host_javabase=@bazel_tools//tools/jdk:absolute_javabase"
-      - "--host_java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla"
-      - "--java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla"
+      - "--host_javabase=@bazel_tools//tools/jdk:remote_jdk11"
+      - "--javabase=@bazel_tools//tools/jdk:remote_jdk11"
+      - "--host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java11"
+      - "--java_toolchain=@bazel_tools//tools/jdk:toolchain_java11"
       - "--test_tag_filters=-slow,-flaky,-docker"
     test_targets:
       - "//..."


### PR DESCRIPTION
Now that toolchain_java11 is supported by Bazel, use it instead of
toolchain_vanilla.