### PR TITLE
Re-enable Gerrit in downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -176,7 +176,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://gerrit.googlesource.com/gerrit.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/pipelines/gerrit-postsubmit.yml",
         "pipeline_slug": "gerrit",
-        "disabled_reason": "https://bugs.chromium.org/p/gerrit/issues/detail?id=11122"
     },
     "Google Logging": {
         "git_repository": "https://github.com/google/glog.git",


### PR DESCRIPTION
https://bugs.chromium.org/p/gerrit/issues/detail?id=11122 is fixed and Gerrit is green with Bazel@HEAD:
https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/236