### PR TITLE
Re-enable Bazel Remote Cache

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -105,7 +105,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/buchgr/bazel-remote.git",
         "http_config": "https://raw.githubusercontent.com/buchgr/bazel-remote/master/.bazelci/presubmit.yml",
         "pipeline_slug": "bazel-remote-cache",
-        "disabled_reason": "https://github.com/buchgr/bazel-remote/issues/82",
     },
     "Bazel integration testing": {
         "git_repository": "https://github.com/bazelbuild/bazel-integration-testing.git",


### PR DESCRIPTION
https://github.com/buchgr/bazel-remote/issues/82 is fixed and the project is green with Bazel@HEAD
https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/239#_