### PR TITLE
Wrap an expected-to-fail call in a script

### DIFF
--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -155,18 +155,24 @@ steps:
       move bazel-bin\src\bazel artifacts\bazel-%RELEASE_NAME%-windows-x86_64.exe
       move bazel-genfiles\scripts\packages\bazel.zip artifacts\bazel-%RELEASE_NAME%-windows-x86_64.zip
 
-      echo DEBUG 8 git merge-base
+      echo DEBUG 8 write run-msi.bat
+      echo @echo off >run-msi.bat
       @rem  The scripts directory is taken from the release branch.
       @rem  Commit 874fe75428 contains a vital bugfix for make_msi_lib.ps1, so only build the .msi
       @rem  if the release branch has that commit.
       @rem  TODO(laszlocsomor): remove this version check and build the .msi unconditionally after
       @rem  Bazel 0.29 (the first version whose release branch will have 874fe75428) is released.
-      git merge-base --is-ancestor 874fe754282651bdf006c06147842cbb226c6ae9 HEAD 2>nul
-      if "%errorlevel%" equ "0" (
-        echo DEBUG 9 build msi
-        powershell scripts\packages\msi\make_msi.ps1 artifacts\bazel-%RELEASE_NAME%-windows-x86_64.exe
-        echo DEBUG 10 build msi done
-      )
+      echo git merge-base --is-ancestor 874fe754282651bdf006c06147842cbb226c6ae9 HEAD 2^>nul >>run-msi.bat
+      @rem  We cannot print %<envvar-name>% without resolving the envvar, but we can print the name
+      @rem  via another envvar.
+      set _errorlevel_=ERRORLEVEL
+      set _release_name_=RELEASE_NAME
+      echo if "%%_errorlevel_%%" equ "0" (powershell scripts\packages\msi\make_msi.ps1 artifacts\bazel-%%_release_name_%%-windows-x86_64.exe) >>run-msi.bat
+      echo exit /b 0 >>run-msi.bat
+      echo DEBUG 9 contents of run-msi.bat
+      type run-msi.bat
+      echo DEBUG 10 run the msi creation
+      run-msi.bat
 
       echo DEBUG 11 upload
       cd artifacts


### PR DESCRIPTION
In cmd.exe we cannot branch directly on exit code
like in Bash, we need to check ERRORLEVEL instead.

BuiltKite however checks ERRORLEVEL after every
call and fails-fast if the last call failed.

The "git merge-base" command may fail (we expect
that) so in order to branch on that, we wrap the
call in a .bat file.

See https://github.com/bazelbuild/continuous-integration/pull/752#issuecomment-512168511