### PR TITLE
Rename gcs to CloudStorage

### DIFF
--- a/metrics/main.go
+++ b/metrics/main.go
@@ -59,9 +59,9 @@ func main() {
 	}
 	bk := clients.CreateCachedBuildkiteClient(bkAPI, time.Duration(settings.BuildkiteCacheTimeoutMinutes)*time.Minute)
 
-	gcs, err := clients.CreateGcsClient()
+	storageClient, err := clients.CreateCloudStorageClient()
 	if err != nil {
-		log.Fatalf("Cannot create GCS client: %v", err)
+		log.Fatalf("Cannot create Cloud Storage client: %v", err)
 	}
 
 	/*
@@ -97,7 +97,7 @@ func main() {
 	criticalPath := metrics.CreateCriticalPath(bk, 20, pipelines...)
 	srv.AddMetric(criticalPath, minutes(60), defaultPublisher)
 
-	flakiness := metrics.CreateFlakiness(gcs, "bazel-buildkite-stats", "flaky-tests-bep", pipelines...)
+	flakiness := metrics.CreateFlakiness(storageClient, "bazel-buildkite-stats", "flaky-tests-bep", pipelines...)
 	srv.AddMetric(flakiness, minutes(60), defaultPublisher)
 
 	macPerformance := metrics.CreateMacPerformance(bk, 20, pipelines...)

--- a/metrics/metrics/flakiness.go
+++ b/metrics/metrics/flakiness.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Flakiness struct {
-	client    *clients.GcsClient
+	client    *clients.CloudStorageClient
 	columns   []Column
 	gcsBucket string
 	gcsSuffix string
@@ -113,7 +113,7 @@ type message struct {
 }
 
 // CREATE TABLE flakiness (org VARCHAR(255), pipeline VARCHAR(255), build INT, target VARCHAR(255), passed_count INT, failed_count INT, PRIMARY KEY(org, pipeline, build, target));
-func CreateFlakiness(client *clients.GcsClient, gcsBucket, gcsBasePath string, pipelines ...*data.PipelineID) *Flakiness {
+func CreateFlakiness(client *clients.CloudStorageClient, gcsBucket, gcsBasePath string, pipelines ...*data.PipelineID) *Flakiness {
 	columns := []Column{Column{"org", true}, Column{"pipeline", true}, Column{"build", true}, Column{"target", true}, Column{"passed_count", false}, Column{"failed_count", false}}
 	gcsSuffix := gcsBasePath
 	if !strings.HasSuffix(gcsBasePath, "/") {


### PR DESCRIPTION
A future commit will add GCE support, and having two three-letter module names that only differ in one letter is not very developer-friendly.