### PR TITLE
Use MSVC 2017 to build TensorFlow

### DIFF
--- a/buildkite/pipelines/tensorflow-postsubmit.yml
+++ b/buildkite/pipelines/tensorflow-postsubmit.yml
@@ -44,6 +44,7 @@ platforms:
   windows:
     environment:
       TF_IGNORE_MAX_BAZEL_VERSION: 1
+      BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC"
     batch_commands:
     - echo.| python ./configure.py
     build_flags:


### PR DESCRIPTION
TensorFlow has migrated to MSVC 2017, due to some compiler bug, the build no longer works with MSVC 2015.
https://buildkite.com/bazel/tensorflow/builds/3265#69cc72ae-f55a-4037-9a28-7434cbf90dfa