### PR TITLE
fix syntax error

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1170,7 +1170,7 @@ def remote_caching_flags(platform):
 
     platform_cache_key = [BUILDKITE_ORG.encode("utf-8")]
     # Whenever the remote cache was known to have been poisoned increase the number below
-    platform_cache_key += ["cache-poisoning-1"]
+    platform_cache_key += ["cache-poisoning-1".encode("utf-8")]
 
     if platform == "macos":
         platform_cache_key += [


### PR DESCRIPTION
https://buildkite.com/bazel/google-bazel-presubmit/builds/23009#cbf04235-89bc-4bde-b565-09aa4f95a6ae

```
Adding to platform cache key: b'bazel'
--
  | Adding to platform cache key: cache-poisoning-1
  | Traceback (most recent call last):
  | File "bazelci.py", line 2809, in <module>
  | sys.exit(main())
  | File "bazelci.py", line 2789, in main
  | bazel_version=task_config.get("bazel") or configs.get("bazel"),
  | File "bazelci.py", line 836, in execute_commands
  | incompatible_flags,
  | File "bazelci.py", line 1379, in execute_bazel_build
  | enable_remote_cache=True,
  | File "bazelci.py", line 1351, in compute_flags
  | aggregated_flags += remote_caching_flags(platform)
  | File "bazelci.py", line 1202, in remote_caching_flags
  | platform_cache_digest.update(key)
  | TypeError: Unicode-objects must be encoded before hashing
```