### PR TITLE
Run "setup" tasks before entering the working directory

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -779,6 +779,9 @@ def execute_commands(
             # be smart and converts strings like "true" and "false" to booleans.
             os.environ[key] = str(value)
 
+        cmd_exec_func = execute_batch_commands if platform == "windows" else execute_shell_commands
+        cmd_exec_func(task_config.get("setup", None))
+
         # Allow the config to override the current working directory.
         required_prefix = os.getcwd()
         requested_working_dir = os.path.abspath(task_config.get("working_directory", ""))


### PR DESCRIPTION
Tasks may now specify the optional "setup" field. It contains a list of commands which should be run *before* entering a custom working directory (as opposed to batch_commands and shell_commands that are run *inside* the working directory).

This mechanism is required by the Bazel federation and was already tested on Buildkite.