### PR TITLE
Enable SQL GC for zombie_instances metric

### DIFF
--- a/metrics/metrics/zombie_instances.go
+++ b/metrics/metrics/zombie_instances.go
@@ -30,6 +30,14 @@ func (zi *ZombieInstances) Columns() []Column {
 	return zi.columns
 }
 
+func (*ZombieInstances) Type() MetricType {
+	return TimeBasedMetric
+}
+
+func (*ZombieInstances) RelevantDelta() int {
+	return 10 * 60 // 10 minutes in seconds
+}
+
 func (zi *ZombieInstances) Collect() (data.DataSet, error) {
 	agentHostNameIndex, err := zi.getAgentHostNameIndex()
 	if err != nil {


### PR DESCRIPTION
This change has actually been deployed some time ago, but I forgot to open the pull request -.-