### PR TITLE
Pin Bazel to 0.28.1 because of a remote execution bug.

### DIFF
--- a/buildkite/emergency.yml
+++ b/buildkite/emergency.yml
@@ -19,4 +19,4 @@
 ---
 message: ""
 issue_url: ""
-last_good_bazel: ""
+last_good_bazel: "0.28.1"

--- a/buildkite/emergency.yml
+++ b/buildkite/emergency.yml
@@ -17,6 +17,6 @@
 # Please do not clear or delete this file when an incident is over.
 # Instead, simply replace all values with empty strings ("").
 ---
-message: ""
+message: "Bazel 0.29.0 is broken with remote execution"
 issue_url: "https://github.com/bazelbuild/bazel/issues/9284"
 last_good_bazel: "0.28.1"

--- a/buildkite/emergency.yml
+++ b/buildkite/emergency.yml
@@ -18,5 +18,5 @@
 # Instead, simply replace all values with empty strings ("").
 ---
 message: ""
-issue_url: ""
+issue_url: "https://github.com/bazelbuild/bazel/issues/9284"
 last_good_bazel: "0.28.1"


### PR DESCRIPTION
We can roll-forward to 0.29.1 when it is released.