### PR TITLE
Ensure that there is exactly one service instance

### DIFF
--- a/metrics/app.yaml
+++ b/metrics/app.yaml
@@ -5,6 +5,10 @@ api_version: go1
 beta_settings:
   cloud_sql_instances: bazel-untrusted:europe-west1:metrics
 
+automatic_scaling:
+  min_num_instances: 1
+  max_num_instances: 1
+
 handlers:
 - url: /.*
   script: _go_app


### PR DESCRIPTION
Having two instances doesn't make any sense since they both collect the same metrics at the same point in time.
This has caused some problems with Stackdriver since the two instances sent data points that were either too close to each other (~2 seconds) or not in order.