### PR TITLE
Test mode: Do not publish to Stackdriver by default

### DIFF
--- a/metrics/publishers/devnull.go
+++ b/metrics/publishers/devnull.go
@@ -1,0 +1,23 @@
+package publishers
+
+import (
+	"github.com/bazelbuild/continuous-integration/metrics/data"
+	"github.com/bazelbuild/continuous-integration/metrics/metrics"
+)
+
+type DevNull struct {
+}
+
+func (*DevNull) Name() string {
+	return "/dev/null"
+}
+
+func (*DevNull) RegisterMetric(metric metrics.Metric) error {
+	// Nothing to do.
+	return nil
+}
+
+func (*DevNull) Publish(metric metrics.Metric, newData data.DataSet) error {
+	// Nothing to do.
+	return nil
+}


### PR DESCRIPTION
Local test runs shouldn't write actual data to Stackdriver, since it might be used for alerting or VM autoscaling.
If you want to test the Stackdriver integration with --test=true, you have to pass an additional flag --always_enable_stackdriver=true.