### PR TITLE
Remove api_version from app.yaml

### DIFF
--- a/metrics/app.yaml
+++ b/metrics/app.yaml
@@ -1,6 +1,5 @@
 runtime: go
 env: flex
-api_version: go1
 
 beta_settings:
   cloud_sql_instances: bazel-untrusted:europe-west1:metrics


### PR DESCRIPTION
According to the documentation and Stackoverflow, this setting seems to be relevant for the standard environment only, but we're running in flex.