### PR TITLE
Update cache key to cache-poisoning-20191002

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1207,7 +1207,7 @@ def remote_caching_flags(platform):
 
     platform_cache_key = [BUILDKITE_ORG.encode("utf-8")]
     # Whenever the remote cache was known to have been poisoned increase the number below
-    platform_cache_key += ["cache-poisoning-20190830".encode("utf-8")]
+    platform_cache_key += ["cache-poisoning-20191002".encode("utf-8")]
 
     if platform == "macos":
         platform_cache_key += [


### PR DESCRIPTION
rules_haskell is failing on CI, the failure can only be reproduced with remote caching. Looks like there was probably a cache poisoning.
https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1214#c38ce667-7389-4fa5-8ae6-8ede377ae8fd