### PR TITLE
Always pass USE_BAZEL_VERSION as --test_env when it exists

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -804,6 +804,7 @@ def execute_commands(
                 # This will only work if the bazel binary in $PATH is actually a bazelisk binary
                 # (https://github.com/bazelbuild/bazelisk).
                 os.environ["USE_BAZEL_VERSION"] = bazel_version
+            if "USE_BAZEL_VERSION" in os.environ:
                 test_env_vars.append("USE_BAZEL_VERSION")
 
         for key, value in task_config.get("environment", {}).items():

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -795,17 +795,19 @@ def execute_commands(
             bazel_binary = download_bazel_binary_at_commit(
                 tmpdir, binary_platform, use_bazel_at_commit
             )
+            os.environ["USE_BAZEL_VERSION"] = bazel_binary
         elif use_but:
             print_collapsed_group(":gcloud: Downloading Bazel Under Test")
             bazel_binary = download_bazel_binary(tmpdir, binary_platform)
+            os.environ["USE_BAZEL_VERSION"] = bazel_binary
         else:
             bazel_binary = "bazel"
             if bazel_version:
-                # This will only work if the bazel binary in $PATH is actually a bazelisk binary
-                # (https://github.com/bazelbuild/bazelisk).
                 os.environ["USE_BAZEL_VERSION"] = bazel_version
-            if "USE_BAZEL_VERSION" in os.environ:
-                test_env_vars.append("USE_BAZEL_VERSION")
+        if "USE_BAZEL_VERSION" in os.environ:
+            # This will only work if the bazel binary in $PATH is actually a bazelisk binary
+            # (https://github.com/bazelbuild/bazelisk).
+            test_env_vars.append("USE_BAZEL_VERSION")
 
         for key, value in task_config.get("environment", {}).items():
             # We have to explicitly convert the value to a string, because sometimes YAML tries to


### PR DESCRIPTION
This is useful when manually start a build and set `USE_BAZEL_VERSION`, it will ensure all tests that invoke Bazel will also use the given Bazel version.