### PR TITLE
Add option to return non-0 exit code when migration is required

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -302,6 +302,29 @@ In this example the jobs on Windows and MacOS would use 0.20.0, whereas the job 
 CI supports several magic version values such as `latest`, `last_green` and `last_downstream_green`.
 Please see the [Bazelisk documentation](https://github.com/bazelbuild/bazelisk/blob/master/README.md#how-does-bazelisk-know-which-version-to-run) for more details.
 
+### Testing with incompatible flags
+
+Similar to the aforementioned downstream pipeline you can configure individual pipelines to run with
+[`bazelisk --migrate`](https://github.com/bazelbuild/bazelisk#other-features). As a result, the pipeline
+runs your targets with all incompatible flags that will be flipped in the next major Bazel release and
+prints detailed information about which flags need to be migrated.
+
+You can enable this feature by adding the following code to the top of the pipeline configuration:
+
+```yaml
+---
+env:
+  USE_BAZELISK_MIGRATE: true
+```
+
+ If you want your pipeline to fail if at least one flag needs migration, you need to add this code instead:
+
+```yaml
+---
+env:
+  USE_BAZELISK_MIGRATE: FAIL
+```
+
 ### macOS: Using a specific version of Xcode
 
 We upgrade the CI machines to the latest version of Xcode shortly after it is released and this

--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -28,7 +28,7 @@ BUILDKITE_ORG = os.environ["BUILDKITE_ORGANIZATION_SLUG"]
 
 PIPELINE = os.environ["BUILDKITE_PIPELINE_SLUG"]
 
-FAIL_IF_MIGRATION_REQUIRED = os.environ.get("USE_BAZELISK_MIGRATE") == "FAIL"
+FAIL_IF_MIGRATION_REQUIRED = os.environ.get("USE_BAZELISK_MIGRATE", "").upper() == "FAIL"
 
 
 class LogFetcher(threading.Thread):

--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -28,6 +28,8 @@ BUILDKITE_ORG = os.environ["BUILDKITE_ORGANIZATION_SLUG"]
 
 PIPELINE = os.environ["BUILDKITE_PIPELINE_SLUG"]
 
+FAIL_IF_MIGRATION_REQUIRED = os.environ.get("USE_BAZELISK_MIGRATE") == "FAIL"
+
 
 class LogFetcher(threading.Thread):
     def __init__(self, job, client):
@@ -216,6 +218,8 @@ def print_result_info(build_number, client):
     print_already_fail_jobs(already_failing_jobs)
 
     print_flags_ready_to_flip(failed_jobs_per_flag)
+    
+    return bool(failed_jobs_per_flag)
 
 
 def main(argv=None):
@@ -231,7 +235,10 @@ def main(argv=None):
     try:
         if args.build_number:
             client = bazelci.BuildkiteClient(org=BUILDKITE_ORG, pipeline=PIPELINE)
-            print_result_info(args.build_number, client)
+            migration_required = print_result_info(args.build_number, client)
+            if migration_required and FAIL_IF_MIGRATION_REQUIRED:
+                bazelci.eprint("Exiting with code 3 since a migration is required.")
+                return 3
         else:
             parser.print_help()
             return 2


### PR DESCRIPTION
Set `USE_BAZELISK_MIGRATE` to `FAIL` in order to enable this feature.

It should be used in combination with #837 for non-downstream pipelines.

Fixes #859