### PR TITLE
Don't update last green when running bazelisk --migrate

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1879,12 +1879,14 @@ def print_project_pipeline(
     #   3. This job doesn't run on master branch (could be a custom build launched manually)
     #   4. We don't intend to run the same job in downstream with Bazel@HEAD (eg. google-bazel-presubmit)
     #   5. We are testing incompatible flags
+    #   6. We are running `bazelisk --migrate` in a non-downstream pipeline
     if not (
         is_pull_request()
         or use_but
         or os.getenv("BUILDKITE_BRANCH") != "master"
         or pipeline_slug not in all_downstream_pipeline_slugs
         or incompatible_flags
+        or use_bazelisk_migrate()
     ):
         # We need to call "Try Update Last Green Commit" even if there are failures,
         # since we don't want a failing Buildifier step to block the update of


### PR DESCRIPTION
Part of #859

Fixes the problem demonstrated here: https://buildkite.com/bazel/rules-cc/builds/319#eb0a2aa0-e49a-4d18-a9bf-16079ea0322c