### PR TITLE
Build Bazel releases with Xcode 10.2.1

### DIFF
--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -100,6 +100,11 @@ steps:
       release_name=$(buildkite-agent meta-data get "release_name")
       echo "release_name = \"\$release_name\""
 
+      # Switch to Xcode 10.2.1 so that the Bazel release we build is still
+      # compatible with macOS High Sierra.
+      /usr/bin/sudo /usr/bin/xcode-select --switch /Applications/Xcode10.2.1.app
+      /usr/bin/sudo /usr/bin/xcodebuild -runFirstLaunch
+
       bazel build //src:bazel
       mkdir output
       cp bazel-bin/src/bazel output/bazel


### PR DESCRIPTION
This is the easiest solution for https://github.com/bazelbuild/bazel/issues/10297.

If we can figure out how to set a deployment target when building with newer Xcode versions, we can switch to that instead.