### PR TITLE
TensorFlow: use xcode 10.2.1

### DIFF
--- a/buildkite/pipelines/tensorflow-postsubmit.yml
+++ b/buildkite/pipelines/tensorflow-postsubmit.yml
@@ -24,6 +24,7 @@ platforms:
     environment:
       TF_IGNORE_MAX_BAZEL_VERSION: 1
       USE_BAZEL_VERSION: latest
+    xcode_version: "10.2.1"
     shell_commands:
     # - |-
     #   echo '


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/issues/32998
There is a Apple Clang issue in Xcode 11 that causes protoc to crash if it's compiled with certain options, we have to switch back to  Xcode 10 until this is resolved.