### PR TITLE
Display correct Bazel version and issue URL

### DIFF
--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -50,6 +50,8 @@ Please check the following CI builds for build and test results:
 
 {links}
 
+Never heard of incompatible flags before? We have [documentation](https://docs.bazel.build/versions/master/backward-compatibility.html) that explains everything.
+
 If you don't want to receive any future issues for {project} or if you have any questions,
 please file an issue in https://github.com/bazelbuild/continuous-integration
 

--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -148,9 +148,10 @@ def process_build_log(failed_jobs_per_flag, already_failing_jobs, log, job, deta
             if match:
                 flag = match.group("flag")
                 failed_jobs_per_flag[flag][job["id"]] = job
-                details_per_flag[flag] = FlagDetails(
-                    bazel_version=match.group("version"), issue_url=match.group("url")
-                )
+                if details_per_flag.get(flag, (None, None)) == (None, None):
+                    details_per_flag[flag] = FlagDetails(
+                        bazel_version=match.group("version"), issue_url=match.group("url")
+                    )
         log = log[0 : log.rfind("+++ Result")]
 
     # If the job failed for other reasons, we add it into already failing jobs.

--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -39,7 +39,7 @@ EMOJI_PATTERN = re.compile(r":([\w+-]+):")
 EMOJI_IMAGE_TEMPLATE = '<img src="https://raw.githubusercontent.com/buildkite/emojis/master/img-buildkite-64/{}.png" height="16"/>'
 
 INCOMPATIBLE_FLAG_LINE_PATTERN = re.compile(
-    r"\s*(?P<flag>--incompatible_\S+)\s*(\(Bazel\s+(?P<version>[^:]+):\s+(?P<url>[^\)]+)\))?"
+    r"\s*(?P<flag>--incompatible_\S+)\s*(\(Bazel (?P<version>.+?): (?P<url>.+?)\))?"
 )
 
 ISSUE_TEMPLATE = """Incompatible flag {flag} will be enabled by default in Bazel {version}, thus breaking {project}.

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -512,8 +512,6 @@ SKIP_TASKS_ENV_VAR = "CI_SKIP_TASKS"
 
 CONFIG_FILE_EXTENSIONS = {".yml", ".yaml"}
 
-BAZEL_VERSION_METADATA_KEY = "bazel_version"
-
 
 class BuildkiteException(Exception):
     """
@@ -840,7 +838,6 @@ def execute_commands(
             execute_shell_commands(task_config.get("shell_commands", None))
 
         bazel_version = print_bazel_version_info(bazel_binary, platform)
-        store_bazel_version(bazel_version)
 
         print_environment_variables_info()
 
@@ -1038,15 +1035,6 @@ def print_bazel_version_info(bazel_binary, platform):
 
     match = BUILD_LABEL_PATTERN.search(version_output)
     return match.group(1) if match else "unreleased binary"
-
-
-def store_bazel_version(bazel_version):
-    code = execute_command(
-        ["buildkite-agent", "meta-data", "set", BAZEL_VERSION_METADATA_KEY, bazel_version],
-        fail_if_nonzero=False,
-    )
-    if code:
-        eprint("Unable to store Bazel version")
 
 
 def print_environment_variables_info():


### PR DESCRIPTION
This PR fixes the (previously incorrect) Bazel version, adds a link to the corresponding GitHub issue and points to the documentation about the incompatible flag mechanism.

It will only work once https://github.com/bazelbuild/bazelisk/pull/103 has been merged and deployed to all CI workers.

Part of #869