### PR TITLE
Get flags exclusively from Bazelisk

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2291,11 +2291,7 @@ def fetch_incompatible_flags():
             incompatible_flags[flag] = ""
         return incompatible_flags
 
-    # Get bazel major version on CI, eg. 0.21 from "Build label: 0.21.0\n..."
-    output = subprocess.check_output(
-        ["bazel", "--nomaster_bazelrc", "--bazelrc=/dev/null", "version"]
-    ).decode("utf-8")
-    bazel_major_version = output.split()[2].rsplit(".", 1)[0]
+    bazel_major_version = get_bazel_major_version()
 
     output = subprocess.check_output(
         [
@@ -2319,6 +2315,14 @@ def fetch_incompatible_flags():
             )
 
     return incompatible_flags
+
+
+def get_bazel_major_version():
+    # Get bazel major version on CI, eg. 0.21 from "Build label: 0.21.0\n..."
+    output = subprocess.check_output(
+        ["bazel", "--nomaster_bazelrc", "--bazelrc=/dev/null", "version"]
+    ).decode("utf-8")
+    return output.split()[2].rsplit(".", 1)[0]
 
 
 def print_bazel_downstream_pipeline(


### PR DESCRIPTION
The old code invoked bazelci.fetch_incompatible_flags() to get all incompatible flags as well as their issue URLs.
This commit removes the function call and retrieves all flags from Bazelisk's output.

There are several advantages:
- Less global state (no INCOMPATIBLE_FLAGS variable)
- Fewer GitHub API calls
- The handling of already flipped flags is now explicit in the code. Previously these flags were silently ignored.

Previously we already took the URLs of failing flags from Bazelisk's output. Now we have to collect URLs from passing flags, too.

Part of #869