### PR TITLE
Make sure BuildKite release pipeline works without git notes

### DIFF
--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -26,6 +26,8 @@ steps:
     command: |
       git fetch origin master
       git fetch --force origin refs/notes/*:refs/notes/*
+      git checkout ${BUILDKITE_BRANCH}
+
       release_name=\$(source scripts/release/common.sh; get_full_release_name)
       echo "release_name = \"\$release_name\""
       buildkite-agent meta-data set "release_name" "\$release_name"
@@ -58,6 +60,7 @@ steps:
     command: |
       git fetch origin master
       git fetch --force origin refs/notes/*:refs/notes/*
+      git checkout ${BUILDKITE_BRANCH}
 
       release_name=$(buildkite-agent meta-data get "release_name")
       echo "release_name = \"\$release_name\""
@@ -96,6 +99,7 @@ steps:
     command: |
       git fetch origin master
       git fetch --force origin refs/notes/*:refs/notes/*
+      git checkout ${BUILDKITE_BRANCH}
 
       release_name=$(buildkite-agent meta-data get "release_name")
       echo "release_name = \"\$release_name\""
@@ -131,6 +135,7 @@ steps:
     command: |
       git fetch origin master
       git fetch --force origin refs/notes/*:refs/notes/*
+      git checkout ${BUILDKITE_BRANCH}
 
       buildkite-agent meta-data get "release_name" > release_name.txt
       SET /p RELEASE_NAME=<release_name.txt
@@ -143,7 +148,7 @@ steps:
       copy bazel-bin\src\bazel.exe output\bazel.exe
 
       output\bazel build -c opt --copt=-w --host_copt=-w --stamp --embed_label %RELEASE_NAME% src/bazel scripts/packages/bazel.zip
-      
+
       mkdir artifacts
       move bazel-bin\src\bazel artifacts\bazel-%RELEASE_NAME%-windows-x86_64.exe
       move bazel-bin\scripts\packages\bazel.zip artifacts\bazel-%RELEASE_NAME%-windows-x86_64.zip
@@ -179,6 +184,7 @@ steps:
     command: |
       git fetch origin master
       git fetch --force origin refs/notes/*:refs/notes/*
+      git checkout ${BUILDKITE_BRANCH}
 
       release_name=$(buildkite-agent meta-data get "release_name")
       echo "release_name = \"\$release_name\""
@@ -195,6 +201,7 @@ steps:
     command: |
       git fetch origin master
       git fetch --force origin refs/notes/*:refs/notes/*
+      git checkout ${BUILDKITE_BRANCH}
 
       release_name=$(buildkite-agent meta-data get "release_name")
       echo "release_name = \"\$release_name\""
@@ -210,6 +217,7 @@ steps:
     command: |
       git fetch origin master
       git fetch --force origin refs/notes/*:refs/notes/*
+      git checkout ${BUILDKITE_BRANCH}
 
       buildkite-agent meta-data get "release_name" > release_name.txt
       SET /p RELEASE_NAME=<release_name.txt
@@ -252,6 +260,7 @@ steps:
       echo "+++ Fetching Git notes"
       git fetch origin master
       git fetch --force origin refs/notes/*:refs/notes/*
+      git checkout ${BUILDKITE_BRANCH}
 
       echo "+++ Downloading release artifacts"
       ARTIFACTS="$(mktemp -d)"
@@ -298,6 +307,7 @@ steps:
     command: |
       git fetch origin master
       git fetch --force origin refs/notes/*:refs/notes/*
+      git checkout ${BUILDKITE_BRANCH}
 
       source scripts/ci/build.sh
       generate_email


### PR DESCRIPTION
We will not rely on git notes for getting release information, instead
we rely on parsing the release branch name. Therefore, we should make
sure the branch name is correct. But we still keep fetchting the git
notes in case we want to do patch release on older branches.