### PR TITLE
Move job utility functions into common.go

### DIFF
--- a/metrics/metrics/critical_path.go
+++ b/metrics/metrics/critical_path.go
@@ -2,11 +2,9 @@ package metrics
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/bazelbuild/continuous-integration/metrics/clients"
 	"github.com/bazelbuild/continuous-integration/metrics/data"
-	"github.com/buildkite/go-buildkite/buildkite"
 )
 
 type CriticalPath struct {
@@ -57,64 +55,18 @@ func (cp *CriticalPath) Collect() (data.DataSet, error) {
 			// Caveat: The Buildkite API only returns the latest invocation of each job within a given build,
 			// which causes a problem when a failing build is retried via the web UI. In this case the time
 			// between the original run and the retry will be counted as wait time by this code.
-			wait_time_seconds, longest_task_name, longest_task_time_seconds, err := analyzeJobs(build.ScheduledAt, build.Jobs)
+			performance, err := analyzeJobsPerformance(build.Jobs)
 			if err != nil {
-				return nil, fmt.Errorf("Could not calculate waiting time for build %d: %v", *build.Number, err)
+				return nil, fmt.Errorf("Could not calculate job performance for build %d: %v", *build.Number, err)
 			}
 
-			run_time_seconds := getDifferenceSeconds(build.CreatedAt, build.FinishedAt) - wait_time_seconds
-			err = result.AddRow(pipeline.Org, pipeline.Slug, *build.Number, wait_time_seconds, run_time_seconds, longest_task_name, longest_task_time_seconds, *build.State)
+			err = result.AddRow(pipeline.Org, pipeline.Slug, *build.Number, performance.totalWaitSeconds, performance.totalRunSeconds, performance.longestRunningTaskName, performance.longestRunningTaskRunSeconds, *build.State)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to add result for build %d: %v", *build.Number, err)
 			}
 		}
 	}
 	return result, nil
-}
-
-type event struct {
-	*buildkite.Timestamp
-	runDelta int
-}
-
-func analyzeJobs(scheduleTime *buildkite.Timestamp, jobs []*buildkite.Job) (wait_time_seconds float64, longest_task_name string, longest_task_time_seconds float64, err error) {
-	events := make([]event, 0)
-	for _, job := range jobs {
-		// Name == nil -> "wait" step
-		// StartedAt == nil -> step was cancelled while waiting for an agent
-		// FinishedAt == nil -> step is still running
-		if job.Name == nil || job.StartedAt == nil || job.FinishedAt == nil {
-			continue
-		}
-
-		// Job lifecycle: scheduled -> created -> runnable -> started -> finished
-		// wait time = started - runnable
-		// run time = finished - started
-		// total time = finished - runnable
-		// Scheduled and created are affected by "wait" steps, so we don't look at them here.
-		duration := getDifferenceSeconds(job.RunnableAt, job.FinishedAt)
-		if duration > longest_task_time_seconds {
-			longest_task_name = *job.Name
-			longest_task_time_seconds = duration
-		}
-		events = append(events, event{job.StartedAt, 1}, event{job.FinishedAt, -1})
-	}
-	sortFunc := func(i, j int) bool { return events[i].Time.Before(events[j].Time) }
-	sort.Slice(events, sortFunc)
-
-	runningTasks := 0
-	prevTime := scheduleTime
-	for _, evt := range events {
-		if runningTasks == 0 {
-			wait_time_seconds += getDifferenceSeconds(prevTime, evt.Timestamp)
-		}
-		runningTasks += evt.runDelta
-		prevTime = evt.Timestamp
-	}
-	if runningTasks > 0 {
-		err = fmt.Errorf("There are %d unfinished jobs", runningTasks)
-	}
-	return
 }
 
 // CREATE TABLE critical_path (org VARCHAR(255), pipeline VARCHAR(255), build INT, wait_time_seconds FLOAT, run_time_seconds FLOAT, longest_task_name VARCHAR(255), longest_task_time_seconds FLOAT, result VARCHAR(255), PRIMARY KEY(org, pipeline, build));

--- a/metrics/metrics/pipeline_performance.go
+++ b/metrics/metrics/pipeline_performance.go
@@ -43,7 +43,7 @@ func (pp *PipelinePerformance) Collect() (data.DataSet, error) {
 		for _, build := range builds {
 			skippedTasks := getSkippedTasks(build)
 			for _, job := range build.Jobs {
-				if job.Name == nil || job.FinishedAt == nil || job.RunnableAt == nil {
+				if !isFinishedWorkerTask(job) {
 					continue
 				}
 				err := result.AddRow(pipeline.Org, pipeline.Slug, *build.Number, *job.Name, job.RunnableAt.Time, getDifferenceSeconds(job.RunnableAt, job.StartedAt), getDifferenceSeconds(job.StartedAt, job.FinishedAt), skippedTasks)


### PR DESCRIPTION
These functions are going to be needed by the pipeline_performance file once it supports sharding.