### PR TITLE
Ignore error when decoding with utf-8

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -597,7 +597,7 @@ P9w8kNhEbw==
             return (
                 urllib.request.urlopen("{}?access_token={}{}".format(url, self._token, params_str))
                 .read()
-                .decode("utf-8")
+                .decode("utf-8", "ignore")
             )
         except urllib.error.HTTPError as ex:
             raise BuildkiteException("Failed to open {}: {} - {}".format(url, ex.code, ex.reason))


### PR DESCRIPTION
When getting job logs, there might be some bytes that's not compatible with utf-8, this will break our Bazelisk + Incompatible flags pipepline. Therefore, we should just ignore decoding errors.

eg. https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/426#71a493e9-9afa-457f-a48e-04c1926c2e43
The breakages was caused by rules_kotline