### PR TITLE
Add python36-requests to our CentOS container

### DIFF
--- a/buildkite/docker/centos7/Dockerfile
+++ b/buildkite/docker/centos7/Dockerfile
@@ -29,6 +29,7 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
     python-six \
     python36 \
     python36-PyYAML \
+    python36-requests \
     python36-six \
     unzip \
     which \


### PR DESCRIPTION
Required by Bazel Auto Sheriff.