### PR TITLE
shell_commands should fail immediately if one of the commands fails

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1340,7 +1340,7 @@ def execute_shell_commands(commands):
     if not commands:
         return
     print_collapsed_group(":bash: Setup (Shell Commands)")
-    shell_command = "\n".join(commands)
+    shell_command = "\n".join(["set -e"] + commands)
     execute_command([shell_command], shell=True)
 
 


### PR DESCRIPTION
It seems that shell_commands are joined with newlines and then run in a single subprocess.run call, in which case the return value is that of the last command- any failures in previous commands are ignored.

Users probably expect such failures to cause the entire build to fail. Changing this behaviour feels like the right thing to do, even though it may cause some projects to fail CI until the corresponding errors are fixed.

By prepending "set -e" to the shell commands, the shell will exit immediately with an error code when a command fails (apart from some special cases like if conditions or commands followed by ||).

This might fix #938 for linux/mac.