### PR TITLE
Install pywin32 pip package on Windows

### DIFF
--- a/buildkite/setup-windows.ps1
+++ b/buildkite/setup-windows.ps1
@@ -156,7 +156,8 @@ Write-Host "Installing Python packages..."
     requests `
     pyyaml `
     keras_applications `
-    keras_preprocessing
+    keras_preprocessing `
+    pywin32
 
 ## CMake (for rules_foreign_cc).
 Write-Host "Installing CMake..."


### PR DESCRIPTION
Required by https://github.com/bazelbuild/bazel/pull/11047