### PR TITLE
Turn on long path support on Windows for Git

### DIFF
--- a/buildkite/setup-windows.ps1
+++ b/buildkite/setup-windows.ps1
@@ -97,6 +97,8 @@ Write-Host "Installing Git for Windows..."
 $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine")
 # Don't convert the line endings when cloning the repository because that could break some tests
 & git config --system core.autocrlf false
+# Turn on long path support on Windows
+& git config --system core.longpaths true
 
 ## Install Azul Zulu.
 Write-Host "Installing OpenJDK..."


### PR DESCRIPTION
Helps avoid build failure like:
https://buildkite.com/bazel-testing/bazel-at-head-plus-downstream/builds/406#be2d95d5-56c5-48a0-825a-68d3fa87805c