### PR TITLE
Re-enable Envoy in downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -176,7 +176,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/envoyproxy/envoy.git",
         "http_config": "https://raw.githubusercontent.com/envoyproxy/envoy/master/.bazelci/presubmit.yml",
         "pipeline_slug": "envoy",
-        "disabled_reason": "https://github.com/envoyproxy/envoy/issues/11400"
     },
     "FlatBuffers": {
         "git_repository": "https://github.com/google/flatbuffers.git",


### PR DESCRIPTION
The failure has been fixed at https://github.com/envoyproxy/envoy/pull/11859