### PR TITLE
Add support to generate kzip by kythe with `index_*` directives

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -260,6 +260,33 @@ tasks:
     - "..."
 ```
 
+### Generating semantic information with Kythe
+
+You can use `kythe_ubuntu2004` platform along with some `index_*` fields to create a task that generate semantic information of your code with [Kythe](https://kythe.io/).
+
+The `index_targets` field contains list of targets that should be indexed.
+
+The `index_targets_query` field contains a query string that is used to generate additional index targets by command `bazel query ${index_targets_query}`. The returned targets will be merged into `index_targets`.
+
+The `index_flags` field contains list of build flags that should be used when indexing.
+
+The `index_upload_policy` field is used to set policy for uploading generated files. Available values are:
+  - `Always`: Always upload generated files even build failed.
+  - `IfBuildSuccess`: __Default value__. Only upload generated files if build succeed and raise error when build failed.
+  - `Never`: Never upload index files and raise error when build failed.
+
+```yaml
+---
+tasks:
+  kythe_ubuntu2004:
+    index_targets:
+    - "..."
+    index_targets_query: "kind(\"java_(binary|import|library|plugin|test|proto_library) rule\", ...)"
+    index_flags:
+    - "--define=kythe_corpus=github.com/bazelbuild/bazel"
+    index_upload_policy: "IfBuildSuccess"
+```
+
 ### Legacy Format
 
 Most existing configuration use the legacy format with a "platforms" dictionary:

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1741,6 +1741,21 @@ def calculate_targets(task_config, platform, bazel_binary, build_only, test_only
     test_targets = [] if build_only else task_config.get("test_targets", [])
     index_targets = [] if (build_only or test_only) else task_config.get("index_targets", [])
 
+    index_targets_query = None if (build_only or test_only) else task_config.get("index_targets_query", None)
+    if index_targets_query:
+        output = execute_command_and_get_output(
+            [bazel_binary]
+            + common_startup_flags(platform)
+            + [
+                "--nomaster_bazelrc",
+                "--bazelrc=/dev/null",
+                "query",
+                index_targets_query,
+            ],
+            print_output=False,
+        )
+        index_targets += output.strip().split("\n")
+
     # Remove the "--" argument splitter from the list that some configs explicitly
     # include. We'll add it back again later where needed.
     build_targets = [x.strip() for x in build_targets if x.strip() != "--"]


### PR DESCRIPTION
[Kythe](https://kythe.io/) can be used to generate indexing files for [Code Search](https://cs.opensource.google/) to support cross reference feature.

This PR enable Bazel CI automatically generate indexing files by:
- Add `index_flags`, used to specify build flags when indexing.
- Add `index_targets`, used to specify indexing targets.
- Add `index_targets_query`, get additional targets by running `bazel query index_targets_query`. The returned targets will be merged into `index_targets`.

`index_*` directives must be used within `kythe_*` platform such as `kythe_ubuntu2004`. The final kzip file will be uploaded to Buildkite.

Example configuration for `Bazel`:
```
---
tasks:
...
  kythe_ubuntu2004:
    shell_commands:
    - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
      android_ndk_repository/android_ndk_repository/' WORKSPACE
    - rm -f WORKSPACE.bak
    index_flags:
    - "--define=kythe_corpus=github.com/bazelbuild/bazel"
    index_targets_query: "kind(\"cc_(binary|library|test|proto_library) rule\", ...) union kind(\"java_(binary|import|library|plugin|test|proto_library) rule\", ...) union kind(\"proto_library rule\", ...)"

...
```

[Here](https://buildkite.com/bazel/test-bazel-indexing-with-kythe/builds/10#ebf5c967-4622-40c9-a548-90dd302fa5e8) is the output for above task.

Next step:
- Upload to Google Cloud Storage
    - Buildkite support [uploading artifacts to Google Cloud Storage](https://buildkite.com/docs/agent/v3/gcloud#uploading-artifacts-to-google-cloud-storage). We can leverage that feature to automatically upload final kzip to GCS.
- Update document on how to indexing targets.