### PR TITLE
Install ARM and ARM64 build tools with visual c++ 2017 and 2019

### DIFF
--- a/buildkite/setup-windows.ps1
+++ b/buildkite/setup-windows.ps1
@@ -118,14 +118,14 @@ $env:JAVA_HOME = $zulu_root
 
 ## Install Visual C++ 2017 Build Tools.
 Write-Host "Installing Visual C++ 2017 Build Tools..."
-& choco install visualstudio2017buildtools
+& choco install visualstudio2017buildtools --add Microsoft.VisualStudio.Component.VC.v141.ARM --add Microsoft.VisualStudio.Component.VC.v141.ARM64
 & choco install visualstudio2017-workload-vctools
 [Environment]::SetEnvironmentVariable("BAZEL_VC", "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC", "Machine")
 $env:BAZEL_VC = [Environment]::GetEnvironmentVariable("BAZEL_VC", "Machine")
 
 ## Install Visual C++ 2019 Build Tools.
 Write-Host "Installing Visual C++ 2019 Build Tools..."
-& choco install visualstudio2019buildtools
+& choco install visualstudio2019buildtools --add Microsoft.VisualStudio.Component.VC.Tools.ARM --add Microsoft.VisualStudio.Component.VC.Tools.ARM64
 & choco install visualstudio2019-workload-vctools
 
 ## Install Windows 10 SDK


### PR DESCRIPTION
Install ARM and ARM64 build tools for visual c++ 2017 and 2019 to support building c++ binaries for these target architectures.