### PR TITLE
Re-enable Envoy in downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -183,7 +183,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/envoyproxy/envoy.git",
         "http_config": "https://raw.githubusercontent.com/envoyproxy/envoy/master/.bazelci/presubmit.yml",
         "pipeline_slug": "envoy",
-        "disabled_reason": "https://github.com/envoyproxy/envoy/issues/13079",
     },
     "FlatBuffers": {
         "git_repository": "https://github.com/google/flatbuffers.git",


### PR DESCRIPTION
Envoy is green in downstream again:
https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/688