### PR TITLE
Re-enable Bazel Federation in downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -121,7 +121,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/bazel-federation.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/bazel-federation/master/.bazelci/presubmit.yml",
         "pipeline_slug": "bazel-federation",
-        "disabled_reason": "https://github.com/bazelbuild/bazel-federation/issues/120 and https://github.com/bazelbuild/bazel-federation/issues/121",
     },
     "Bazel Remote Cache": {
         "git_repository": "https://github.com/buchgr/bazel-remote.git",


### PR DESCRIPTION
Bazel Federation is now green with Bazel@HEAD
https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/700