### PR TITLE
Upload info.json with metadata for each commit

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -516,6 +516,14 @@ PLATFORMS = {
         "queue": "windows",
         "python": "python.exe",
     },
+    "rbe_macos": {
+        "name": "RBE (macOS, OpenJDK 8)",
+        "emoji-name": ":gcloud::darwin: (OpenJDK 8)",
+        "downstream-root": "/Users/buildkite/builds/${BUILDKITE_AGENT_NAME}/${BUILDKITE_ORGANIZATION_SLUG}-downstream-projects",
+        "publish_binary": [],
+        "queue": "macos",
+        "python": "python3.7",
+    },
     "rbe_ubuntu1604": {
         "name": "RBE (Ubuntu 16.04, OpenJDK 8)",
         "emoji-name": "RBE (:ubuntu: 16.04, OpenJDK 8)",

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2869,9 +2869,14 @@ def bazelci_builds_nojdk_gs_url(platform, git_commit):
     return "gs://{}/artifacts/{}/{}/bazel_nojdk".format(bucket_name, platform, git_commit)
 
 
-def bazelci_builds_metadata_url():
+def bazelci_latest_build_metadata_url():
     bucket_name = "bazel-testing-builds" if THIS_IS_TESTING else "bazel-builds"
     return "gs://{}/metadata/latest.json".format(bucket_name)
+
+
+def bazelci_builds_metadata_url(git_commit):
+    bucket_name = "bazel-testing-builds" if THIS_IS_TESTING else "bazel-builds"
+    return "gs://{}/artifacts/metadata/{}/info.json".format(bucket_name, git_commit)
 
 
 def bazelci_last_green_commit_url(git_repository, pipeline_slug):
@@ -2985,7 +2990,7 @@ def latest_generation_and_build_number():
     output = None
     for attempt in range(5):
         output = subprocess.check_output(
-            [gsutil_command(), "stat", bazelci_builds_metadata_url()], env=os.environ
+            [gsutil_command(), "stat", bazelci_latest_build_metadata_url()], env=os.environ
         )
         match = re.search("Generation:[ ]*([0-9]+)", output.decode("utf-8"))
         if not match:
@@ -2998,7 +3003,7 @@ def latest_generation_and_build_number():
         expected_md5hash = base64.b64decode(match.group(1))
 
         output = subprocess.check_output(
-            [gsutil_command(), "cat", bazelci_builds_metadata_url()], env=os.environ
+            [gsutil_command(), "cat", bazelci_latest_build_metadata_url()], env=os.environ
         )
         hasher = hashlib.md5()
         hasher.update(output)
@@ -3099,11 +3104,20 @@ def try_publish_binaries(bazel_hashes, bazel_nojdk_hashes, build_number, expecte
                     "Content-Type:application/json",
                     "cp",
                     info_file,
-                    bazelci_builds_metadata_url(),
+                    bazelci_latest_build_metadata_url(),
                 ]
             )
         except subprocess.CalledProcessError:
             raise BinaryUploadRaceException()
+
+        execute_command(
+            [
+                    gsutil_command(),
+                    "cp",
+                    bazelci_latest_build_metadata_url(),
+                    bazelci_builds_metadata_url(git_commit),
+            ]
+        )
     finally:
         shutil.rmtree(tmpdir)
 
@@ -3142,7 +3156,7 @@ def publish_binaries():
 
         eprint(
             "Successfully updated '{0}' to binaries from build {1}.".format(
-                bazelci_builds_metadata_url(), current_build_number
+                bazelci_latest_build_metadata_url(), current_build_number
             )
         )
         break

--- a/pipelines/publish-bazel-binaries.yml
+++ b/pipelines/publish-bazel-binaries.yml
@@ -1,6 +1,6 @@
 steps:
   - command: |-
-      curl -s "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)" -o bazelci.py
+      curl -s "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)" -o bazelci.py
       python3.6 bazelci.py bazel_publish_binaries_pipeline --file_config=.bazelci/build_bazel_binaries.yml | buildkite-agent pipeline upload
     label: "Setup"
     agents:


### PR DESCRIPTION
The metadata of every build is stored separately in https://storage.googleapis.com/bazel-builds/artifacts/metadata/$COMMIT_HASH/info.json

While the metadata of the latest published binary continues to be stored in https://storage.googleapis.com/bazel-builds/metadata/latest.json

Fixes: #1045 