### PR TITLE
Upload info.json with metadata for each commit

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2861,9 +2861,14 @@ def bazelci_builds_nojdk_gs_url(platform, git_commit):
     return "gs://{}/artifacts/{}/{}/bazel_nojdk".format(bucket_name, platform, git_commit)
 
 
-def bazelci_builds_metadata_url():
+def bazelci_latest_build_metadata_url():
     bucket_name = "bazel-testing-builds" if THIS_IS_TESTING else "bazel-builds"
     return "gs://{}/metadata/latest.json".format(bucket_name)
+
+
+def bazelci_builds_metadata_url(git_commit):
+    bucket_name = "bazel-testing-builds" if THIS_IS_TESTING else "bazel-builds"
+    return "gs://{}/artifacts/metadata/{}/info.json".format(bucket_name, git_commit)
 
 
 def bazelci_last_green_commit_url(git_repository, pipeline_slug):
@@ -2977,7 +2982,7 @@ def latest_generation_and_build_number():
     output = None
     for attempt in range(5):
         output = subprocess.check_output(
-            [gsutil_command(), "stat", bazelci_builds_metadata_url()], env=os.environ
+            [gsutil_command(), "stat", bazelci_latest_build_metadata_url()], env=os.environ
         )
         match = re.search("Generation:[ ]*([0-9]+)", output.decode("utf-8"))
         if not match:
@@ -2990,7 +2995,7 @@ def latest_generation_and_build_number():
         expected_md5hash = base64.b64decode(match.group(1))
 
         output = subprocess.check_output(
-            [gsutil_command(), "cat", bazelci_builds_metadata_url()], env=os.environ
+            [gsutil_command(), "cat", bazelci_latest_build_metadata_url()], env=os.environ
         )
         hasher = hashlib.md5()
         hasher.update(output)
@@ -3091,11 +3096,20 @@ def try_publish_binaries(bazel_hashes, bazel_nojdk_hashes, build_number, expecte
                     "Content-Type:application/json",
                     "cp",
                     info_file,
-                    bazelci_builds_metadata_url(),
+                    bazelci_latest_build_metadata_url(),
                 ]
             )
         except subprocess.CalledProcessError:
             raise BinaryUploadRaceException()
+
+        execute_command(
+            [
+                gsutil_command(),
+                "cp",
+                bazelci_latest_build_metadata_url(),
+                bazelci_builds_metadata_url(git_commit),
+            ]
+        )
     finally:
         shutil.rmtree(tmpdir)
 
@@ -3134,7 +3148,7 @@ def publish_binaries():
 
         eprint(
             "Successfully updated '{0}' to binaries from build {1}.".format(
-                bazelci_builds_metadata_url(), current_build_number
+                bazelci_latest_build_metadata_url(), current_build_number
             )
         )
         break

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2868,7 +2868,7 @@ def bazelci_latest_build_metadata_url():
 
 def bazelci_builds_metadata_url(git_commit):
     bucket_name = "bazel-testing-builds" if THIS_IS_TESTING else "bazel-builds"
-    return "gs://{}/artifacts/metadata/{}/info.json".format(bucket_name, git_commit)
+    return "gs://{}/metadata/{}.json".format(bucket_name, git_commit)
 
 
 def bazelci_last_green_commit_url(git_repository, pipeline_slug):


### PR DESCRIPTION
The metadata of every build is stored separately in https://storage.googleapis.com/bazel-builds/artifacts/metadata/$COMMIT_HASH/info.json

While the metadata of the latest published binary continues to be stored in https://storage.googleapis.com/bazel-builds/metadata/latest.json

Fixes: #1045