### PR TITLE
Fix overriding buildkite agent version

### DIFF
--- a/buildkite/setup-windows.ps1
+++ b/buildkite/setup-windows.ps1
@@ -263,7 +263,7 @@ $res.Close()
 $buildkite_agent_version = $res.ResponseUri.AbsolutePath.TrimStart("/buildkite/agent/releases/tag/v")
 
 ## Workaround bug https://github.com/bazelbuild/continuous-integration/issues/1034
-$buildkite_agent_version = "v3.22.1"
+$buildkite_agent_version = "3.22.1"
 
 Write-Host "Downloading Buildkite agent..."
 $buildkite_agent_url = "https://github.com/buildkite/agent/releases/download/v${buildkite_agent_version}/buildkite-agent-windows-amd64-${buildkite_agent_version}.zip"


### PR DESCRIPTION
The url already has the "v" prefix.