### PR TITLE
Remove tensorflow Xcode version lock

### DIFF
--- a/buildkite/pipelines/tensorflow-postsubmit.yml
+++ b/buildkite/pipelines/tensorflow-postsubmit.yml
@@ -25,7 +25,6 @@ platforms:
     environment:
       TF_IGNORE_MAX_BAZEL_VERSION: 1
       USE_BAZEL_VERSION: latest
-    xcode_version: "10.3"
     shell_commands:
     # - |-
     #   echo '


### PR DESCRIPTION
Tensorflow was using Xcode 10.3 which is no longer supported for App
Store uploads. This unpins the version since it should be compatible
with any Xcode version.

This is required to unblock https://github.com/bazelbuild/bazel/pull/12265