### PR TITLE
Remove rules_typescript from Bazel CI

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -386,11 +386,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "pipeline_slug": "rules-swift-swift",
         "do_not_notify": "https://github.com/bazelbuild/continuous-integration/issues/915",
     },
-    "rules_typescript": {
-        "git_repository": "https://github.com/bazelbuild/rules_typescript.git",
-        "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_typescript/master/.bazelci/presubmit.yml",
-        "pipeline_slug": "rules-typescript-typescript",
-    },
     "rules_webtesting": {
         "git_repository": "https://github.com/bazelbuild/rules_webtesting.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_webtesting/master/.bazelci/presubmit.yml",


### PR DESCRIPTION
https://github.com/bazelbuild/rules_typescript has been archived, and rules_nodejs should cover all rules_typescript tests.