### PR TITLE
Gerrit: Remove ubuntu1604 and temporarily disable macos

### DIFF
--- a/buildkite/pipelines/gerrit-postsubmit.yml
+++ b/buildkite/pipelines/gerrit-postsubmit.yml
@@ -1,13 +1,5 @@
 ---
 platforms:
-  ubuntu1604:
-    build_targets:
-      - "//:release"
-      - "//:api"
-    test_flags:
-      - "--test_tag_filters=-slow,-flaky,-docker"
-    test_targets:
-      - "//..."
   ubuntu1804:
     build_flags:
       - "--host_javabase=@bazel_tools//tools/jdk:remote_jdk11"
@@ -25,11 +17,11 @@ platforms:
       - "--test_tag_filters=-slow,-flaky,-docker"
     test_targets:
       - "//..."
-  macos:
-    build_targets:
-      - "//:release"
-      - "//:api"
-    test_flags:
-      - "--test_tag_filters=-slow,-flaky,-docker"
-    test_targets:
-      - "//..."
+#   macos:
+#     build_targets:
+#       - "//:release"
+#       - "//:api"
+#     test_flags:
+#       - "--test_tag_filters=-slow,-flaky,-docker"
+#     test_targets:
+#       - "//..."


### PR DESCRIPTION
Gerrit is dropping support for JDK 8.

The ubuntu1604 config still uses JDK 8, which is failing for Gerrit.
Our mac machines don't have JDK 11 yet, so disable mac platform until we enable JDK 11.

Related https://bugs.chromium.org/p/gerrit/issues/detail?id=13676#c4

/cc @davido 