### PR TITLE
Gerrit: Switch to using JDK 8 toolchain on ubuntu1604 and macos

### DIFF
--- a/buildkite/pipelines/gerrit-postsubmit.yml
+++ b/buildkite/pipelines/gerrit-postsubmit.yml
@@ -1,10 +1,13 @@
 ---
 platforms:
   ubuntu1604:
+    build_flags:
+      - "--java_toolchain=@bazel_tools//tools/jdk:toolchain_java8"
     build_targets:
       - "//:release"
       - "//:api"
     test_flags:
+      - "--java_toolchain=@bazel_tools//tools/jdk:toolchain_java8"
       - "--test_tag_filters=-slow,-flaky,-docker"
     test_targets:
       - "//..."
@@ -26,10 +29,13 @@ platforms:
     test_targets:
       - "//..."
   macos:
+    build_flags:
+      - "--java_toolchain=@bazel_tools//tools/jdk:toolchain_java8"
     build_targets:
       - "//:release"
       - "//:api"
     test_flags:
+      - "--java_toolchain=@bazel_tools//tools/jdk:toolchain_java8"
       - "--test_tag_filters=-slow,-flaky,-docker"
     test_targets:
       - "//..."


### PR DESCRIPTION
Closes: https://bugs.chromium.org/p/gerrit/issues/detail?id=13676