### PR TITLE
Restore Tulsi gitsync

### DIFF
--- a/gitsync/gitsync.sh
+++ b/gitsync/gitsync.sh
@@ -23,6 +23,7 @@
 #   direction can be ==> or <=>
 REPOSITORIES=(
     "https://bazel.googlesource.com/bazel ==> git@github.com:bazelbuild/bazel.git bazel master"
+    "https://bazel.googlesource.com/tulsi ==> git@github.com:bazelbuild/tulsi.git tulsi upstream"
 )
 
 set -euxo pipefail


### PR DESCRIPTION
While GitHub is the source of truth, the rules_apple/Tulsi community maintainers are still receiving code pushes from google3 for Tulsi into the GitHub repo's upstream branch.