### PR TITLE
Upgrade Kythe to v0.0.49

### DIFF
--- a/buildkite/docker/ubuntu2004/Dockerfile
+++ b/buildkite/docker/ubuntu2004/Dockerfile
@@ -137,7 +137,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 
 FROM ubuntu2004-java11 AS ubuntu2004-java11-kythe
 RUN mkdir /usr/local/kythe && \
-    curl -sSL https://github.com/kythe/kythe/releases/download/v0.0.45/kythe-v0.0.45.tar.gz | \
+    curl -sSL https://github.com/kythe/kythe/releases/download/v0.0.49/kythe-v0.0.49.tar.gz | \
     tar xvz --no-same-owner --strip-components 1 --directory /usr/local/kythe && \
     chmod -R a+r /usr/local/kythe && \
     test -f /usr/local/kythe/WORKSPACE


### PR DESCRIPTION
Kythe v0.0.48 and below don't work with Bazel 4.0.0.