### PR TITLE
Update the buildifier binary name

### DIFF
--- a/buildifier/buildifier.py
+++ b/buildifier/buildifier.py
@@ -139,7 +139,7 @@ def get_releases():
 
 def get_release_urls(release):
     buildifier_assets = [
-        a for a in release["assets"] if a["name"] in ("buildifier", "buildifier.linux")
+        a for a in release["assets"] if a["name"] in ("buildifier", "buildifier-linux-amd64")
     ]
     if not buildifier_assets:
         raise Exception("There is no Buildifier binary for release {}".format(release["tag_name"]))


### PR DESCRIPTION
Starting with the version 4.0.0 (to be released today) the binaries uploaded to GitHub will have different name schema:

    buildifier-darwin-amd64
    buildifier-linux-amd64
    buildifier-windows-amd64.exe
    buildozer-darwin-amd64
    buildozer-linux-amd64
    buildozer-windows-amd64.exe
    unused_deps-darwin-amd64
    unused_deps-linux-amd64
    unused_deps-windows-amd64.exe
