### PR TITLE
Bump default Xcode version to 12.4.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -533,7 +533,7 @@ DEFAULT_PLATFORM = "ubuntu1804"
 # release platform for all Linux downstream tests.
 LINUX_BINARY_PLATFORM = "centos7"
 
-DEFAULT_XCODE_VERSION = "11.7"
+DEFAULT_XCODE_VERSION = "12.4"
 XCODE_VERSION_REGEX = re.compile(r"^\d+\.\d+(\.\d+)?$")
 XCODE_VERSION_OVERRIDES = {"10.2.1": "10.3", "11.2": "11.2.1", "11.3": "11.3.1"}
 


### PR DESCRIPTION
This doesn't affect Bazel due to https://github.com/bazelbuild/bazel/commit/caf13559e367da9c791cc5e559d2970400d5478b.

It has the risk of breaking downstream projects, but we'll have to fix or disable them then (remaining on an older Xcode version is not viable).