### PR TITLE
Change Python binary name on macOS

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -503,7 +503,7 @@ PLATFORMS = {
         "downstream-root": "/Users/buildkite/builds/${BUILDKITE_AGENT_NAME}/${BUILDKITE_ORGANIZATION_SLUG}-downstream-projects",
         "publish_binary": ["macos"],
         "queue": "macos",
-        "python": "python3.7",
+        "python": "python3",
     },
     "windows": {
         "name": "Windows, OpenJDK 8",


### PR DESCRIPTION
We switched to the native Python 3 version of macOS / Xcode (/usr/bin/python3) and thus should no longer use the one installed via Homebrew.