### PR TITLE
Set --sandbox_tmpfs_path=/tmp to avoid SIGBUS

### DIFF
--- a/docgen/docgen.py
+++ b/docgen/docgen.py
@@ -21,7 +21,7 @@ import sys
 
 import bazelci
 
-DEFAULT_FLAGS = ["--action_env=PATH=/usr/local/bin:/usr/bin:/bin"]
+DEFAULT_FLAGS = ["--action_env=PATH=/usr/local/bin:/usr/bin:/bin", "--sandbox_tmpfs_path=/tmp"]
 
 Settings = collections.namedtuple(
     "Settings", ["target", "build_flags", "output_dir", "gcs_bucket", "gcs_subdir", "landing_page"]


### PR DESCRIPTION
This workaround was suggested by philwo. The root cause is https://github.com/bazelbuild/bazel/issues/3236

Fixes #1116