### PR TITLE
Add macos_arm64 platform

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -512,6 +512,16 @@ PLATFORMS = {
         "queue": "macos",
         "python": "python3",
     },
+    "macos_arm64": {
+        "name": "macOS (arm64), OpenJDK 8",
+        "emoji-name": ":darwin: (arm64) (OpenJDK 8)",
+        "downstream-root": "/Users/buildkite/builds/${BUILDKITE_AGENT_NAME}/${BUILDKITE_ORGANIZATION_SLUG}-downstream-projects",
+        "publish_binary": [], # Change to ["macos_arm64"] when bazel_publish_binaries.yml is updated.
+        # TODO(pcloudy): Switch to macos_arm64 queue when Apple Silicon machines are available,
+        # current we just use x86_64 machines to do cross compile.
+        "queue": "macos",
+        "python": "python3",
+    },
     "windows": {
         "name": "Windows, OpenJDK 8",
         "emoji-name": ":windows: (OpenJDK 8)",

--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -173,6 +173,44 @@ steps:
       cd artifacts
       buildkite-agent artifact upload "*"
 
+  - label: macOS (arm64)
+    agents:
+      # TODO(pcloudy): Switch to macos_arm64 queue when Apple Silicon machines are available,
+      # current we just use x86_64 machines to do cross compile.
+      - queue=macos
+    command: |
+      git fetch origin ${BUILDKITE_BRANCH}
+      git checkout ${BUILDKITE_BRANCH}
+
+      release_name=$(buildkite-agent meta-data get "release_name")
+      echo "release_name = \"\$release_name\""
+
+      /usr/bin/sudo /usr/bin/xcode-select --switch /Applications/Xcode12.4.app
+      /usr/bin/sudo /usr/bin/xcodebuild -runFirstLaunch
+
+      bazel build //src:bazel
+      mkdir output
+      cp bazel-bin/src/bazel output/bazel
+
+      output/bazel build \
+          --define IPHONE_SDK=1 \
+          -c opt \
+          --stamp \
+          --embed_label "\${release_name}" \
+          --workspace_status_command=scripts/ci/build_status_command.sh \
+          --cpu=darwin_arm64 \
+          src/bazel \
+          src/bazel_nojdk \
+          scripts/packages/with-jdk/install.sh
+
+      mkdir artifacts
+      cp "bazel-bin/src/bazel" "artifacts/bazel-\${release_name}-darwin-arm64"
+      cp "bazel-bin/src/bazel_nojdk" "artifacts/bazel_nojdk-\${release_name}-darwin-arm64"
+      cp "bazel-bin/scripts/packages/with-jdk/install.sh" "artifacts/bazel-\${release_name}-installer-darwin-arm64.sh"
+
+      cd artifacts
+      buildkite-agent artifact upload "*"
+
   - label: Windows
     agents:
       - queue=windows
@@ -285,6 +323,23 @@ steps:
       chmod +x "bazel-\${release_name}-darwin-x86_64"
 
       "./bazel-\${release_name}-darwin-x86_64" info
+
+  - label: "Test on macOS (arm64)"
+    agents:
+      # TODO(pcloudy): Switch to macos_arm64 queue and write a proper test step
+      # when Apple Silicon machines are available,
+      - queue=macos
+    command: |
+      git fetch origin ${BUILDKITE_BRANCH}
+      git checkout ${BUILDKITE_BRANCH}
+
+      release_name=$(buildkite-agent meta-data get "release_name")
+      echo "release_name = \"\$release_name\""
+
+      buildkite-agent artifact download "bazel-\${release_name}-darwin-arm64" .
+
+      output=$(lipo -info "bazel-\${release_name}-darwin-arm64")
+      [[ $output == *"architecture: arm64"* ]] || (echo "architecture arm64 expected, but got: \"$output\"" && exit 1)
 
   - label: "Test on Windows"
     agents:


### PR DESCRIPTION
1. Add macos_arm64 as a new platform, but underlying we still use x86_64
   machines to do cross-compiling. We'll switch to actual Apple Silicon
   machines when they are available. This is useful for enabling the "Publish Bazel binaries" pipeline for macos_arm64.

2. Publish cross-compiled arm64 Bazel binary. Note that the binary is
   not yet well tested on Apple Silicon.