### PR TITLE
Add rules_dotnet to downstream pipeline (2nd try)

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -296,6 +296,11 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_docker/master/.bazelci/presubmit.yml",
         "pipeline_slug": "rules-docker-docker",
     },
+    "rules_dotnet": {
+        "git_repository": "https://github.com/bazelbuild/rules_dotnet.git",
+        "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_dotnet/master/.bazelci/presubmit.yml",
+        "pipeline_slug": "rules-dotnet-edge",
+    },
     "rules_foreign_cc": {
         "git_repository": "https://github.com/bazelbuild/rules_foreign_cc.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_foreign_cc/master/.bazelci/config.yaml",


### PR DESCRIPTION
This PR is a revival of https://github.com/bazelbuild/continuous-integration/pull/504. At the time we decided to NOT merge the PR since the pipeline had been broken for quite some time.
However, this has now changed, as the pipeline is stable and has been green for several weeks: https://buildkite.com/bazel/rules-dotnet-edge/builds?branch=master

Fixes https://github.com/bazelbuild/continuous-integration/issues/312