### PR TITLE
Update rules_foreign_cc branch

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -298,7 +298,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     },
     "rules_foreign_cc": {
         "git_repository": "https://github.com/bazelbuild/rules_foreign_cc.git",
-        "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_foreign_cc/master/.bazelci/config.yaml",
+        "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_foreign_cc/main/.bazelci/config.yaml",
         "pipeline_slug": "rules-foreign-cc",
         "owned_by_bazel": True,
     },


### PR DESCRIPTION
Change the branch of rules_foreign_cc to `main` instead of [the deprecated `master`](https://github.com/bazelbuild/rules_foreign_cc/commit/67a76a387b768580e09b0a868f1e3ea7594b04f0) . This update should fix the rules_foreign_cc [failing tests](https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1976#43899663-74d5-4905-a858-726ad2a276d1) in the Bazel Downstream pipeline that fail due to change in the tests name in the config.yml in [`main` branch](https://github.com/bazelbuild/rules_foreign_cc/blob/main/.bazelci/config.yaml#L38) that [is not reflected in `master`](https://github.com/bazelbuild/rules_foreign_cc/blob/master/.bazelci/config.yaml#L32).