### PR TITLE
Mark Buildifier Python script as executable

### DIFF
--- a/buildifier/Dockerfile
+++ b/buildifier/Dockerfile
@@ -8,4 +8,6 @@ RUN apk add curl && \
 
 COPY --chown=root:root buildifier.py /usr/local/bin/buildifier.py
 
+RUN chmod 0755 /usr/local/bin/buildifier.py
+
 ENTRYPOINT [ "/usr/local/bin/buildifier.py" ]


### PR DESCRIPTION
Recent versions of the image produced "[FATAL tini (6)] exec /usr/local/bin/buildifier.py failed: Permission denied" errors.

Fixes https://github.com/bazelbuild/continuous-integration/issues/1089