### PR TITLE
Always download Buildifier from GitHub

### DIFF
--- a/buildifier/Dockerfile
+++ b/buildifier/Dockerfile
@@ -1,11 +1,5 @@
 FROM python:alpine
 
-# Latest release from: https://github.com/bazelbuild/buildtools/releases
-RUN apk add curl && \
-    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.22.0/buildifier && \
-    chown root:root /usr/local/bin/buildifier && \
-    chmod 0755 /usr/local/bin/buildifier
-
 COPY --chown=root:root buildifier.py /usr/local/bin/buildifier.py
 
 RUN chmod 0755 /usr/local/bin/buildifier.py

--- a/buildifier/buildifier.py
+++ b/buildifier/buildifier.py
@@ -153,7 +153,7 @@ def get_release_urls(release):
     buildifier_assets = [
         a
         for a in release["assets"]
-        if a["name"] in ("buildifier", "buildifier-linux-amd64")
+        if a["name"] in ("buildifier", "buildifier-linux-amd64", "buildifier.linux")
     ]
     if not buildifier_assets:
         raise Exception(
@@ -203,25 +203,15 @@ def main(argv=None):
 
     buildifier_binary = "buildifier"
     display_url = BUILDIFIER_DEFAULT_DISPLAY_URL
-    version = os.environ.get(VERSION_ENV_VAR)
-    if version:
-        eprint("+++ :github: Downloading Buildifier version '{}'".format(version))
-        try:
-            version, display_url, download_url = get_buildifier_info(version)
-            eprint("Downloading Buildifier {} from {}".format(version, download_url))
-            buildifier_binary = download_buildifier(download_url)
-        except Exception as ex:
-            print_error("downloading Buildifier", str(ex))
-            return 1
-
-    # Determine Buildifier version if the user did not request a specific version.
-    if not version:
-        eprint("+++ :female-detective: Detecting Buildifier version")
-        version_result = run_buildifier(
-            buildifier_binary, ["--version"], what="Version info"
-        )
-        match = BUILDIFIER_VERSION_PATTERN.search(version_result.stdout)
-        version = match.group(1) if match and match.group(1) != "redacted" else None
+    version = os.environ.get(VERSION_ENV_VAR, "latest")
+    eprint("+++ :github: Downloading Buildifier version '{}'".format(version))
+    try:
+        version, display_url, download_url = get_buildifier_info(version)
+        eprint("Downloading Buildifier {} from {}".format(version, download_url))
+        buildifier_binary = download_buildifier(download_url)
+    except Exception as ex:
+        print_error("downloading Buildifier", str(ex))
+        return 1
 
     flags = ["--mode=check", "--lint=warn"]
     warnings = os.getenv(WARNINGS_ENV_VAR)


### PR DESCRIPTION
Previously CI used the Buildifier binary from the Docker container if the user did not request a specific version.
However, since we forgot to update the Docker container, it still contained an ancient version (0.22.0 - for comparison, the most recent release is 4.0.1).

With this commit CI will always download a Buildifier binary from GitHub, with "no version" implying "latest".
Moreover, this commit fixes the download logic to recognise binaries of older releases such as 0.4.3.

Consequently, we no longer ship a Buildifier binary as part of the Docker container.

More progress towards #1080.