### PR TITLE
Do not upload Kythe index files for pull requests

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1201,7 +1201,7 @@ def execute_commands(
                     if index_upload_policy != INDEX_UPLOAD_POLICY_ALWAYS:
                         handle_bazel_failure(e, "build")
 
-                if should_upload_kzip:
+                if should_upload_kzip and not is_pull_request():
                     try:
                         merge_and_upload_kythe_kzip(platform, index_upload_gcs)
                     except subprocess.CalledProcessError:


### PR DESCRIPTION
When running a job for a pull request, we should not upload Kythe index files to GCS.

For Bazel this doesn't matter, because we use a split presubmit / postsubmit config, but other projects only have a single pipeline and thus would unnecessarily upload index files for commits belonging to pull requests.