### PR TITLE
Always create convenience symlinks for Kythe

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1746,7 +1746,10 @@ def kythe_startup_flags():
 
 
 def kythe_build_flags():
-    return [f"--override_repository=kythe_release={KYTHE_DIR}"]
+    return [
+        "--experimental_convenience_symlinks=normal",
+        f"--override_repository=kythe_release={KYTHE_DIR}"
+    ]
 
 
 def execute_bazel_build(


### PR DESCRIPTION
Some projects set `--experimental_convenience_symlinks=ignore` in their .bazelrc file, which will cause the kzip merging step to fail, as it globs under `bazel-out/`.

The real fix would be to glob under `$(bazel info output_path)/` instead of `bazel-out/`, then we would not need the convenience symlinks for our purposes, but this is easier and helps for now.