### PR TITLE
Add soft_fail option to pipeline steps

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2092,7 +2092,7 @@ def terminate_background_process(process):
             process.kill()
 
 
-def create_step(label, commands, platform, shards=1):
+def create_step(label, commands, platform, shards=1, soft_fail=None):
     if "docker-image" in PLATFORMS[platform]:
         step = create_docker_step(
             label, image=PLATFORMS[platform]["docker-image"], commands=commands
@@ -2107,6 +2107,9 @@ def create_step(label, commands, platform, shards=1):
     if shards > 1:
         step["label"] += " (shard %n)"
         step["parallelism"] = shards
+
+    if soft_fail is not None:
+        step["soft_fail"] = soft_fail
 
     # Enforce a global 8 hour job timeout.
     step["timeout_in_minutes"] = 8 * 60
@@ -2232,6 +2235,7 @@ def print_project_pipeline(
     for task, task_config in task_configs.items():
         platform = get_platform_for_task(task, task_config)
         task_name = task_config.get("name")
+        soft_fail = task_config.get("soft_fail")
 
         # We override the Bazel version in downstream pipelines. This means that two tasks that
         # only differ in the value of their explicit "bazel" field will be identical in the
@@ -2272,6 +2276,7 @@ def print_project_pipeline(
             use_but=use_but,
             incompatible_flags=incompatible_flags,
             shards=shards,
+            soft_fail=soft_fail,
         )
         pipeline_steps.append(step)
 
@@ -2467,6 +2472,7 @@ def runner_step(
     use_but=False,
     incompatible_flags=None,
     shards=1,
+    soft_fail=None,
 ):
     command = PLATFORMS[platform]["python"] + " bazelci.py runner --task=" + task
     if http_config:
@@ -2485,7 +2491,7 @@ def runner_step(
         command += " --incompatible_flag=" + flag
     label = create_label(platform, project_name, task_name=task_name)
     return create_step(
-        label=label, commands=[fetch_bazelcipy_command(), command], platform=platform, shards=shards
+        label=label, commands=[fetch_bazelcipy_command(), command], platform=platform, shards=shards, soft_fail=soft_fail
     )
 
 


### PR DESCRIPTION
[`soft_fail`](https://buildkite.com/changelog/56-command-steps-can-now-be-made-to-soft-fail) will allow the pipeline to succeed even if one of its steps failed. You only need to specify the list of exit status codes that you want to ignore in a given step.
