### PR TITLE
Avoid HTTP redirect for staging presubmit landing page

### DIFF
--- a/docgen/docgen.py
+++ b/docgen/docgen.py
@@ -63,7 +63,7 @@ DOCGEN_SETTINGS = {
             output_dir="bazel-bin/site/site-build",
             gcs_bucket="docs-staging.bazel.build",
             gcs_subdir=os.getenv("BUILDKITE_BUILD_NUMBER"),
-            landing_page="bazel-overview.html",
+            landing_page="versions/master/bazel-overview.html",
         ),
     },
 }


### PR DESCRIPTION
The previous landing page had a redirect, which did not work due to the different directory layout.