### PR TITLE
remove conformance_test targets from CI on windows.

### DIFF
--- a/buildkite/pipelines/protobuf-postsubmit.yml
+++ b/buildkite/pipelines/protobuf-postsubmit.yml
@@ -24,3 +24,5 @@ platforms:
       # https://github.com/bazelbuild/bazel/issues/10590
       - "-//:cc_proto_blacklist_test"
       - "@com_google_protobuf//:cc_proto_blacklist_test"
+      - "-//java/core:conformance_test"
+      - "-//java/lite:conformance_test"


### PR DESCRIPTION
Fixes https://github.com/protocolbuffers/protobuf/issues/8619