### PR TITLE
Add include_remote_grpc_log

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -968,6 +968,7 @@ def bazelisk_flags():
 
 def calculate_flags(task_config, task_config_key, action_key, tmpdir, test_env_vars):
     include_json_profile = task_config.get("include_json_profile", [])
+    include_remote_grpc_log = task_config.get("include_remote_grpc_log", [])
     capture_corrupted_outputs = task_config.get("capture_corrupted_outputs", [])
 
     json_profile_flags = []
@@ -975,6 +976,12 @@ def calculate_flags(task_config, task_config_key, action_key, tmpdir, test_env_v
     if action_key in include_json_profile:
         json_profile_out = os.path.join(tmpdir, "{}.profile.gz".format(action_key))
         json_profile_flags = get_json_profile_flags(json_profile_out)
+
+    remote_grpc_log_flags = []
+    remote_grpc_log_out = None
+    if action_key in include_remote_grpc_log:
+        remote_grpc_log_out = os.path.join(tmpdir, "{}_remote_grpc_log.bin".format(action_key))
+        remote_grpc_log_flags = ["--experimental_remote_grpc_log={}".format(remote_grpc_log_out)]
      
     capture_corrupted_outputs_flags = []
     capture_corrupted_outputs_dir = None
@@ -984,13 +991,14 @@ def calculate_flags(task_config, task_config_key, action_key, tmpdir, test_env_v
 
     flags = task_config.get(task_config_key) or []
     flags += json_profile_flags
+    flags += remote_grpc_log_flags
     flags += capture_corrupted_outputs_flags
     # We have to add --test_env flags to `build`, too, otherwise Bazel
     # discards its analysis cache between `build` and `test`.
     if test_env_vars:
         flags += ["--test_env={}".format(v) for v in test_env_vars]
 
-    return flags, json_profile_out, capture_corrupted_outputs_dir
+    return flags, json_profile_out, remote_grpc_log_out, capture_corrupted_outputs_dir
 
 
 def execute_commands(
@@ -1119,7 +1127,7 @@ def execute_commands(
         )
 
         if build_targets:
-            build_flags, json_profile_out_build, capture_corrupted_outputs_dir_build = calculate_flags(
+            build_flags, json_profile_out_build, remote_grpc_log_out_build, capture_corrupted_outputs_dir_build = calculate_flags(
                 task_config, "build_flags", "build", tmpdir, test_env_vars
             )
             try:
@@ -1137,11 +1145,13 @@ def execute_commands(
             finally:
                 if json_profile_out_build:
                     upload_json_profile(json_profile_out_build, tmpdir)
+                if remote_grpc_log_out_build:
+                    upload_remote_grpc_log(remote_grpc_log_out_build, tmpdir)
                 if capture_corrupted_outputs_dir_build:
                     upload_corrupted_outputs(capture_corrupted_outputs_dir_build, tmpdir)
 
         if test_targets:
-            test_flags, json_profile_out_test, capture_corrupted_outputs_dir_test = calculate_flags(
+            test_flags, json_profile_out_test, remote_grpc_log_out_test, capture_corrupted_outputs_dir_test = calculate_flags(
                 task_config, "test_flags", "test", tmpdir, test_env_vars
             )
             if not is_windows():
@@ -1177,6 +1187,8 @@ def execute_commands(
                 finally:
                     if json_profile_out_test:
                         upload_json_profile(json_profile_out_test, tmpdir)
+                    if remote_grpc_log_out_test:
+                        upload_remote_grpc_log(remote_grpc_log_out_test, tmpdir)
                     if capture_corrupted_outputs_dir_test:
                         upload_corrupted_outputs(capture_corrupted_outputs_dir_test, tmpdir)
             finally:
@@ -1184,7 +1196,7 @@ def execute_commands(
                 upload_thread.join()
 
         if index_targets:
-            index_flags, json_profile_out_index, capture_corrupted_outputs_dir_index = calculate_flags(
+            index_flags, json_profile_out_index, remote_grpc_log_out_index, capture_corrupted_outputs_dir_index = calculate_flags(
                 task_config, "index_flags", "index", tmpdir, test_env_vars
             )
             index_upload_policy = task_config.get("index_upload_policy", "IfBuildSuccess")
@@ -1220,6 +1232,8 @@ def execute_commands(
             finally:
                 if json_profile_out_index:
                     upload_json_profile(json_profile_out_index, tmpdir)
+                if remote_grpc_log_out_index:
+                    upload_remote_grpc_log(remote_grpc_log_out_index, tmpdir)
                 if capture_corrupted_outputs_dir_index:
                     upload_corrupted_outputs(capture_corrupted_outputs_dir_index, tmpdir)
 
@@ -2024,6 +2038,12 @@ def upload_json_profile(json_profile_path, tmpdir):
         return
     print_collapsed_group(":gcloud: Uploading JSON Profile")
     execute_command(["buildkite-agent", "artifact", "upload", json_profile_path], cwd=tmpdir)
+
+def upload_remote_grpc_log(remote_grpc_log_path, tmpdir):
+    if not os.path.exists(remote_grpc_log_path):
+        return
+    print_collapsed_group(":gcloud: Uploading Remote gRPC log")
+    execute_command(["buildkite-agent", "artifact", "upload", remote_grpc_log_path], cwd=tmpdir)
 
 def upload_corrupted_outputs(capture_corrupted_outputs_dir, tmpdir):
     if not os.path.exists(capture_corrupted_outputs_dir):


### PR DESCRIPTION
When it is set, Bazel CI will pass the flag `--experimental_remote_grpc_log` to Bazel and upload the log to Buildkite.