### PR TITLE
Add --remote_timeout=3600 to workaround gRPC bug

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1669,6 +1669,7 @@ def rbe_flags(original_flags, accept_cached):
     flags = [
         "--remote_executor=remotebuildexecution.googleapis.com",
         "--remote_instance_name=projects/bazel-untrusted/instances/default_instance",
+        "--remote_timeout=3600",
         "--incompatible_strict_action_env",
         "--google_default_credentials",
         "--toolchain_resolution_debug",


### PR DESCRIPTION
The bug is fixed in Bazel >= 4.1.0, but it doesn't hurt.

Context: https://github.com/bazelbuild/continuous-integration/issues/1174