### PR TITLE
rules_python: Read config from 'main' branch

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -373,7 +373,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     },
     "rules_python": {
         "git_repository": "https://github.com/bazelbuild/rules_python.git",
-        "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_python/master/.bazelci/presubmit.yml",
+        "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_python/main/.bazelci/presubmit.yml",
         "pipeline_slug": "rules-python-python",
         "owned_by_bazel": True,
     },


### PR DESCRIPTION
They're about to rename their "master" branch to "main". Obviously this PR should only be merged once the renaming is complete.

Progress towards https://github.com/bazelbuild/rules_python/issues/500