### PR TITLE
Fix converting test label to path

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2039,12 +2039,9 @@ def rename_test_logs_for_upload(test_logs, tmpdir):
 
 def test_label_to_path(tmpdir, label, attempt):
     # remove leading //
-    path = label[2:]
+    path = label.lstrip("/:")
     path = path.replace("/", os.sep)
-    if path[0] == ':':
-        path = path[1:]
-    else:
-        path = path.replace(":", os.sep)
+    path = path.replace(":", os.sep)
     if attempt == 0:
         path = os.path.join(path, "test.log")
     else:

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2041,7 +2041,10 @@ def test_label_to_path(tmpdir, label, attempt):
     # remove leading //
     path = label[2:]
     path = path.replace("/", os.sep)
-    path = path.replace(":", os.sep)
+    if path[0] == ':':
+        path = path[1:]
+    else:
+        path = path.replace(":", os.sep)
     if attempt == 0:
         path = os.path.join(path, "test.log")
     else:


### PR DESCRIPTION
For test targets with name "//:target_name", bazelci fails to upload the failed tests log files. This is because `test_label_to_path` function converts it to "/target_name" [(by replacing ':' to '/') ](https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazelci.py#L2044) and os.path.join treats this as an absolute path and does not join it to the temp directory path.  So we get permission denied for attempting to create "/target_name" directory to upload the failed tests log files.