### PR TITLE
Disable projects broken by Bazel<->rules_apple incompatibilities

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -117,6 +117,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/examples.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/examples/master/.bazelci/presubmit.yml",
         "pipeline_slug": "bazel-bazel-examples",
+        "disabled_reason": "https://github.com/bazelbuild/bazel/issues/13811",
     },
     "Bazel Federation": {
         "git_repository": "https://github.com/bazelbuild/bazel-federation.git",
@@ -194,6 +195,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/google/flatbuffers.git",
         "http_config": "https://raw.githubusercontent.com/google/flatbuffers/master/.bazelci/presubmit.yml",
         "pipeline_slug": "flatbuffers",
+        "disabled_reason": "https://github.com/bazelbuild/bazel/issues/13811",
     },
     "Flogger": {
         "git_repository": "https://github.com/google/flogger.git",
@@ -249,11 +251,13 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/tensorflow/tensorflow.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/pipelines/tensorflow-postsubmit.yml",
         "pipeline_slug": "tensorflow",
+        "disabled_reason": "https://github.com/bazelbuild/bazel/issues/13811",
     },
     "Tulsi": {
         "git_repository": "https://github.com/bazelbuild/tulsi.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/tulsi/master/.bazelci/presubmit.yml",
         "pipeline_slug": "tulsi-bazel-darwin",
+        "disabled_reason": "https://github.com/bazelbuild/bazel/issues/13811",
     },
     "re2": {
         "git_repository": "https://github.com/google/re2.git",


### PR DESCRIPTION
These projects haven't managed to fix their stuff for two / three months. Let's disable them for now.

Tracking issue: https://github.com/bazelbuild/bazel/issues/13811