### PR TITLE
Install libc++-dev in Ubuntu images

### DIFF
--- a/buildkite/docker/ubuntu1604/Dockerfile
+++ b/buildkite/docker/ubuntu1604/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get -y update && \
     iputils-ping \
     lcov \
     less \
+    libc++-dev \
     libssl-dev \
     llvm \
     llvm-dev \

--- a/buildkite/docker/ubuntu1804/Dockerfile
+++ b/buildkite/docker/ubuntu1804/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get -y update && \
     iputils-ping \
     lcov \
     less \
+    libc++-dev \
     libssl-dev \
     llvm \
     llvm-dev \

--- a/buildkite/docker/ubuntu2004/Dockerfile
+++ b/buildkite/docker/ubuntu2004/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get -y update && \
     iputils-ping \
     lcov \
     less \
+    libc++-dev \
     libncurses5 \
     libssl-dev \
     llvm \


### PR DESCRIPTION
In https://github.com/bazelbuild/bazel/pull/13666, Bazel's auto-detected
host toolchain for Unix gained support for using libc++ with clang. The
tests for that functionality are contained in
https://github.com/bazelbuild/bazel/pull/13824, which requires libc++
and its headers to be installed on the images used for tests.