### PR TITLE
Truncate `BUILDKITE_MESSAGE` to 1000 characters

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3458,6 +3458,12 @@ def main(argv=None):
 
             platform = get_platform_for_task(args.task, task_config)
 
+            # The value of `BUILDKITE_MESSAGE` defaults to the commit message, which can be too large
+            # on Windows, therefore we truncate the value to 1000 characters.
+            # See https://github.com/bazelbuild/continuous-integration/issues/1218
+            if "BUILDKITE_MESSAGE" in os.environ:
+                os.environ["BUILDKITE_MESSAGE"] = os.environ["BUILDKITE_MESSAGE"][:1000]
+
             execute_commands(
                 task_config=task_config,
                 platform=platform,

--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -215,6 +215,8 @@ steps:
     agents:
       - queue=windows
     command: |
+      set BUILDKITE_MESSAGE=%BUILDKITE_MESSAGE:~0,1000%
+
       git fetch origin ${BUILDKITE_BRANCH}
       git checkout ${BUILDKITE_BRANCH}
 
@@ -346,6 +348,8 @@ steps:
     agents:
       - queue=windows
     command: |
+      set BUILDKITE_MESSAGE=%BUILDKITE_MESSAGE:~0,1000%
+
       git fetch origin ${BUILDKITE_BRANCH}
       git checkout ${BUILDKITE_BRANCH}
 


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/continuous-integration/issues/1218