### PR TITLE
Add script for BCR presubmit pipeline

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -53,7 +53,7 @@ THIS_IS_SPARTA = True
 
 CLOUD_PROJECT = "bazel-public" if THIS_IS_TRUSTED else "bazel-untrusted"
 
-GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "testing"}[
+GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "pcloudy-bcr-test"}[
     BUILDKITE_ORG
 ]
 
@@ -992,7 +992,7 @@ def execute_commands(
     platform,
     git_repository,
     git_commit,
-    git_repo_location,
+    repo_location,
     use_bazel_at_commit,
     use_but,
     save_but,
@@ -1028,8 +1028,8 @@ def execute_commands(
     tmpdir = tempfile.mkdtemp()
     sc_process = None
     try:
-        if platform == "macos" or platform == "macos_arm64":
-            activate_xcode(task_config)
+        # if platform == "macos" or platform == "macos_arm64":
+            # activate_xcode(task_config)
 
         # If the CI worker runs Bazelisk, we need to forward all required env variables to the test.
         # Otherwise any integration test that invokes Bazel (=Bazelisk in this case) will fail.
@@ -1039,8 +1039,8 @@ def execute_commands(
         os.environ["BAZELISK_USER_AGENT"] = "Bazelisk/BazelCI"
         test_env_vars.append("BAZELISK_USER_AGENT")
 
-        if git_repo_location:
-            os.chdir(git_repo_location)
+        if repo_location:
+            os.chdir(repo_location)
         elif git_repository:
             clone_git_repository(git_repository, platform, git_commit)
 
@@ -3389,7 +3389,7 @@ def main(argv=None):
         "--git_commit", type=str, help="Reset the git repository to this commit after cloning it"
     )
     runner.add_argument(
-        "--git_repo_location",
+        "--repo_location",
         type=str,
         help="Use an existing repository instead of cloning from github",
     )
@@ -3469,7 +3469,7 @@ def main(argv=None):
                 platform=platform,
                 git_repository=args.git_repository,
                 git_commit=args.git_commit,
-                git_repo_location=args.git_repo_location,
+                repo_location=args.repo_location,
                 use_bazel_at_commit=args.use_bazel_at_commit,
                 use_but=args.use_but,
                 save_but=args.save_but,

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -53,7 +53,7 @@ THIS_IS_SPARTA = True
 
 CLOUD_PROJECT = "bazel-public" if THIS_IS_TRUSTED else "bazel-untrusted"
 
-GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "pcloudy-bcr-test"}[
+GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "testing"}[
     BUILDKITE_ORG
 ]
 
@@ -1028,8 +1028,8 @@ def execute_commands(
     tmpdir = tempfile.mkdtemp()
     sc_process = None
     try:
-        # if platform == "macos" or platform == "macos_arm64":
-            # activate_xcode(task_config)
+        if platform == "macos" or platform == "macos_arm64":
+            activate_xcode(task_config)
 
         # If the CI worker runs Bazelisk, we need to forward all required env variables to the test.
         # Otherwise any integration test that invokes Bazel (=Bazelisk in this case) will fail.

--- a/buildkite/bcr_presubmit.py
+++ b/buildkite/bcr_presubmit.py
@@ -26,6 +26,7 @@ import pathlib
 import re
 import sys
 import subprocess
+import time
 import yaml
 
 import bazelci
@@ -35,10 +36,10 @@ BCR_REPO_DIR = pathlib.Path(os.getcwd())
 BUILDKITE_ORG = os.environ["BUILDKITE_ORGANIZATION_SLUG"]
 
 SCRIPT_URL = {
-    "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/pcloudy-bcr-test/buildkite/bcr_presubmit.py",
+    "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bcr_presubmit.py",
     "bazel-trusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bcr_presubmit.py",
     "bazel": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bcr_presubmit.py",
-}[BUILDKITE_ORG]
+}[BUILDKITE_ORG] + "?{}".format(int(time.time()))
 
 
 def fetch_bcr_presubmit_py_command():

--- a/buildkite/bcr_presubmit.py
+++ b/buildkite/bcr_presubmit.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+#
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint: disable=line-too-long
+# pylint: disable=missing-function-docstring
+# pylint: disable=unspecified-encoding
+# pylint: disable=invalid-name
+"""The CI script for Bazel Central Registry."""
+
+
+import argparse
+import os
+import pathlib
+import re
+import sys
+import subprocess
+import yaml
+
+import bazelci
+
+BCR_REPO_DIR = pathlib.Path(os.getcwd())
+
+BUILDKITE_ORG = os.environ["BUILDKITE_ORGANIZATION_SLUG"]
+
+SCRIPT_URL = {
+    "bazel-testing": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/pcloudy-bcr-test/buildkite/bcr_presubmit.py",
+    "bazel-trusted": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bcr_presubmit.py",
+    "bazel": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bcr_presubmit.py",
+}[BUILDKITE_ORG]
+
+
+def fetch_bcr_presubmit_py_command():
+    return "curl -s {0} -o bcr_presubmit.py".format(SCRIPT_URL)
+
+
+class BcrPipelineException(Exception):
+    """Raised whenever something goes wrong and we should exit with an error."""
+
+
+def get_target_modules():
+    """
+    If the `MODULE_NAME` and `MODULE_VERSION(S)` are specified, calculate the target modules from those env vars.
+    Otherwise, calculate target modules based on changed files from the main branch.
+    """
+    modules = []
+    if "MODULE_NAME" in os.environ:
+        name = os.environ["MODULE_NAME"]
+        if "MODULE_VERSION" in os.environ:
+            modules.append((name, os.environ["MODULE_VERSION"]))
+        elif "MODULE_VERSIONS" in os.environ:
+            for version in os.environ["MODULE_VERSIONS"].split(","):
+                modules.append((name, version))
+
+    if modules:
+        return list(set(modules))
+
+    # Get the list of changed files compared to the main branch
+    output = subprocess.check_output(
+        ["git", "diff", "main", "--name-only", "--pretty=format:"]
+    )
+    # Matching modules/<name>/<version>/
+    for line in output.decode("utf-8").split():
+        s = re.match(r"modules\/([^\/]+)\/([^\/]+)\/", line)
+        if s:
+            modules.append(s.groups())
+
+    return list(set(modules))
+
+
+def get_presubmit_yml(module_name, module_version):
+    return BCR_REPO_DIR.joinpath("modules/%s/%s/presubmit.yml" % (module_name, module_version))
+
+
+def get_task_config(module_name, module_version):
+    return bazelci.load_config(http_url=None,
+                               file_config=get_presubmit_yml(module_name, module_version),
+                               allow_imports=False)
+
+
+def add_presubmit_jobs(module_name, module_version, task_config, pipeline_steps):
+    for task_name in task_config:
+        platform_name = bazelci.get_platform_for_task(task_name, task_config)
+        label = bazelci.PLATFORMS[platform_name]["emoji-name"] + " {0}@{1}".format(
+            module_name, module_version
+        )
+        command = (
+            '%s bcr_presubmit.py runner --module_name="%s" --module_version="%s" --task=%s'
+            % (
+                bazelci.PLATFORMS[platform_name]["python"],
+                module_name,
+                module_version,
+                task_name,
+            )
+        )
+        commands = [bazelci.fetch_bazelcipy_command(), fetch_bcr_presubmit_py_command(), command]
+        pipeline_steps.append(bazelci.create_step(label, commands, platform_name))
+
+
+def scratch_file(root, relative_path, lines=None):
+    """Creates a file under the root directory"""
+    if not relative_path:
+        return None
+    abspath = pathlib.Path(root).joinpath(relative_path)
+    with open(abspath, 'w') as f:
+        if lines:
+            for l in lines:
+                f.write(l)
+                f.write('\n')
+    return abspath
+
+
+def create_test_repo(module_name, module_version, task):
+    configs = get_task_config(module_name, module_version)
+    platform = bazelci.get_platform_for_task(task, configs.get("tasks", None))
+    # TODO(pcloudy): We use the "downstream root" as the repo root, find a better root path for BCR presubmit.
+    root = pathlib.Path(bazelci.downstream_projects_root(platform))
+    scratch_file(root, "WORKSPACE")
+    scratch_file(root, "BUILD")
+    # TODO(pcloudy): Should we test this module as the root module? Maybe we do if we support dev dependency.
+    # Because if the module is not root module, dev dependencies are ignored, which can break test targets.
+    # Another work around is that we can copy the dev dependencies to the generated MODULE.bazel.
+    scratch_file(root, "MODULE.bazel", ["bazel_dep(name = '%s', version = '%s')" % (module_name, module_version)])
+    scratch_file(root, ".bazelrc", [
+        "build --experimental_enable_bzlmod",
+        "build --registry=%s" % BCR_REPO_DIR.as_uri(),
+    ])
+    return root
+
+
+def run_test(repo_location, module_name, module_version, task):
+    try:
+        return bazelci.main(
+            [
+                "runner",
+                "--task=" + task,
+                "--file_config=%s" % get_presubmit_yml(module_name, module_version),
+                "--repo_location=%s" % repo_location,
+            ]
+        )
+    except subprocess.CalledProcessError as e:
+        bazelci.eprint(str(e))
+        return 1
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(description="Bazel Central Regsitry Presubmit Test Generator")
+
+    subparsers = parser.add_subparsers(dest="subparsers_name")
+
+    subparsers.add_parser("bcr_presubmit")
+
+    runner = subparsers.add_parser("runner")
+    runner.add_argument("--module_name", type=str)
+    runner.add_argument("--module_version", type=str)
+    runner.add_argument("--task", type=str)
+
+    args = parser.parse_args(argv)
+    if args.subparsers_name == "bcr_presubmit":
+        modules = get_target_modules()
+        if not modules:
+            bazelci.eprint("No target modules detected in this branch!")
+        pipeline_steps = []
+        for module_name, module_version in modules:
+            configs = get_task_config(module_name, module_version)
+            add_presubmit_jobs(module_name, module_version, configs.get("tasks", None), pipeline_steps)
+        print(yaml.dump({"steps": pipeline_steps}))
+    elif args.subparsers_name == "runner":
+        repo_location = create_test_repo(args.module_name, args.module_version, args.task)
+        return run_test(repo_location, args.module_name, args.module_version, args.task)
+    else:
+        parser.print_help()
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/buildkite/culprit_finder.py
+++ b/buildkite/culprit_finder.py
@@ -74,7 +74,7 @@ def get_tasks(project_name):
 
 
 def test_with_bazel_at_commit(
-    project_name, task_name, git_repo_location, bazel_commit, needs_clean, repeat_times
+    project_name, task_name, repo_location, bazel_commit, needs_clean, repeat_times
 ):
     http_config = bazelci.DOWNSTREAM_PROJECTS[project_name]["http_config"]
     for i in range(1, repeat_times + 1):
@@ -86,7 +86,7 @@ def test_with_bazel_at_commit(
                     "runner",
                     "--task=" + task_name,
                     "--http_config=" + http_config,
-                    "--git_repo_location=" + git_repo_location,
+                    "--repo_location=" + repo_location,
                     "--use_bazel_at_commit=" + bazel_commit,
                 ]
                 + (["--needs_clean"] if needs_clean else [])
@@ -110,7 +110,7 @@ def clone_git_repository(project_name, task_name):
 
 
 def start_bisecting(
-    project_name, task_name, git_repo_location, commits_list, needs_clean, repeat_times
+    project_name, task_name, repo_location, commits_list, needs_clean, repeat_times
 ):
     left = 0
     right = len(commits_list)
@@ -122,7 +122,7 @@ def start_bisecting(
         for i in range(left, right):
             bazelci.eprint(commits_list[i] + "\n")
         if test_with_bazel_at_commit(
-            project_name, task_name, git_repo_location, mid_commit, needs_clean, repeat_times
+            project_name, task_name, repo_location, mid_commit, needs_clean, repeat_times
         ):
             bazelci.print_collapsed_group(":bazel: Succeeded at " + mid_commit)
             left = mid + 1
@@ -236,12 +236,12 @@ def main(argv=None):
             repeat_times=repeat_times,
         )
     elif args.subparsers_name == "runner":
-        git_repo_location = clone_git_repository(args.project_name, args.task_name)
+        repo_location = clone_git_repository(args.project_name, args.task_name)
         bazelci.print_collapsed_group("Check good bazel commit " + args.good_bazel_commit)
         if not test_with_bazel_at_commit(
             project_name=args.project_name,
             task_name=args.task_name,
-            git_repo_location=git_repo_location,
+            repo_location=repo_location,
             bazel_commit=args.good_bazel_commit,
             needs_clean=args.needs_clean,
             repeat_times=args.repeat_times,
@@ -253,7 +253,7 @@ def main(argv=None):
         start_bisecting(
             project_name=args.project_name,
             task_name=args.task_name,
-            git_repo_location=git_repo_location,
+            repo_location=repo_location,
             commits_list=get_bazel_commits_between(args.good_bazel_commit, args.bad_bazel_commit),
             needs_clean=args.needs_clean,
             repeat_times=args.repeat_times,


### PR DESCRIPTION
This pipeline provides presubmit test for pull requests for the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry) repository.

For now, as Bzlmod is still under development and only available from HEAD, we'll set up the pipelien to use Bazel@last_green to build (thanks to Bazelisk and the USE_BAZEL_VERSION env var). Later, we'll add support for all maintained Bazel LTS releases that support Bzlmod.

More context: https://docs.google.com/document/d/1ReuBBp4EHnsuvcpfXM6ITDmP2lrOu8DGlePMUKvDnXM/edit#heading=h.1o9h5yrz477i