### PR TITLE
Run all unflipped incompatible flags

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2819,13 +2819,10 @@ def fetch_incompatible_flags():
             incompatible_flags[flag] = ""
         return incompatible_flags
 
-    bazel_major_version = get_bazel_major_version()
-
     output = subprocess.check_output(
         [
             "curl",
-            "https://api.github.com/search/issues?per_page=100&q=repo:bazelbuild/bazel+label:migration-%s"
-            % bazel_major_version,
+            "https://api.github.com/search/issues?per_page=100&q=repo:bazelbuild/bazel+label:incompatible-change+state:open"
         ]
     ).decode("utf-8")
     issue_info = json.loads(output)
@@ -2843,14 +2840,6 @@ def fetch_incompatible_flags():
             )
 
     return incompatible_flags
-
-
-def get_bazel_major_version():
-    # Get bazel major version on CI, eg. 0.21 from "Build label: 0.21.0\n..."
-    output = subprocess.check_output(
-        ["bazel", "--nomaster_bazelrc", "--bazelrc=/dev/null", "version"]
-    ).decode("utf-8")
-    return output.split()[2].rsplit(".", 1)[0]
 
 
 def print_bazel_downstream_pipeline(


### PR DESCRIPTION
Previously CI examined GitHub issues to see which incompatible flags will be flipped in the next release, and then tested only those flags.
However, due to changes to the incompatible flags process the issue labels on GitHub are no longer guaranteed to be up-to-date.
As a result, we should simply run all yet-unflipped flags in the present Bazel binary when testing incompatible flags.

More context: https://github.com/bazelbuild/bazelisk/pull/248

Temporary fix for #1208