### PR TITLE
Re-introduce get_bazel_major_version()

### DIFF
--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -19,6 +19,7 @@ import collections
 import os
 import re
 import requests
+import subprocess
 import sys
 import threading
 
@@ -391,7 +392,7 @@ def handle_already_flipped_flags(failed_jobs_per_flag, details_per_flag):
     # Process and remove all flags that have already been flipped.
     # Bazelisk may return already flipped flags if a project uses an old Bazel version
     # via its .bazelversion file.
-    current_major_version = bazelci.get_bazel_major_version()
+    current_major_version = get_bazel_major_version()
     failed_jobs_for_new_flags = {}
     details_for_new_flags = {}
 
@@ -410,6 +411,14 @@ def handle_already_flipped_flags(failed_jobs_per_flag, details_per_flag):
             failed_jobs_for_new_flags[flag] = failed_jobs_per_flag[flag]
 
     return failed_jobs_for_new_flags, details_for_new_flags
+
+
+def get_bazel_major_version():
+    # Get bazel major version on CI, eg. 0.21 from "Build label: 0.21.0\n..."
+    output = subprocess.check_output(
+        ["bazel", "--nomaster_bazelrc", "--bazelrc=/dev/null", "version"]
+    ).decode("utf-8")
+    return output.split()[2].rsplit(".", 1)[0]
 
 
 def print_result_info(already_failing_jobs, failed_jobs_per_flag, details_per_flag):


### PR DESCRIPTION
get_bazel_major_version() was deleted from bazelci.py in #1226 since I didn't realize that it was still being called from aggregate_incompatible_flags_test_result.py.

This commit restores the original version of the function, but adds it to aggregate_incompatible_flags_test_result.py since it's only being used in that file.