### PR TITLE
Agent: Change base path of testlogs from outputPath to BINDIR

### DIFF
--- a/agent/src/artifact/upload.rs
+++ b/agent/src/artifact/upload.rs
@@ -11,6 +11,8 @@ use std::{
 };
 use tracing::error;
 
+use crate::utils::split_path_inclusive;
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
     // Upload as Buildkite's artifacts
@@ -217,6 +219,11 @@ fn upload_test_log(
     mode: Mode,
 ) -> Result<()> {
     let path = uri_to_file_path(test_log)?;
+
+    if let Some((first, second)) = split_path_inclusive(&path, "testlogs") {
+        return upload_artifact(dry, Some(&first), &second, mode);
+    }
+
     let artifact = if let Some(local_exec_root) = local_exec_root {
         if let Ok(relative_path) = path.strip_prefix(local_exec_root) {
             relative_path

--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod artifact;
+pub mod utils;

--- a/agent/src/utils.rs
+++ b/agent/src/utils.rs
@@ -1,0 +1,36 @@
+use std::path::{Path, PathBuf};
+
+/// Splits [`Path`] into two parts separated by `target`. The `target` itself is included
+/// in the end of first part.
+/// 
+/// ```
+/// # use std::path::Path;
+/// # use bazelci_agent::utils::split_path_inclusive;
+///
+/// let path = Path::new("a/b/c");
+/// let (first, second) = split_path_inclusive(path, "b").unwrap();
+/// assert_eq!(first, Path::new("a/b"));
+/// assert_eq!(second, Path::new("c"));
+/// ```
+///
+pub fn split_path_inclusive(path: &Path, target: &str) -> Option<(PathBuf, PathBuf)> {
+    let mut iter = path.iter();
+
+    let mut first = PathBuf::new();
+    let mut found = false;
+    while let Some(comp) = iter.next() {
+        first.push(Path::new(comp));
+        if comp == target {
+            found = true;
+            break;
+        }
+    }
+
+    if found {
+    let second: PathBuf = iter.collect();
+    Some((first, second))
+
+    } else {
+        None
+    }
+}

--- a/agent/tests/artifact/upload.rs
+++ b/agent/tests/artifact/upload.rs
@@ -15,7 +15,7 @@ fn test_logs_uploaded_to_buildkite() -> Result<()> {
     ]);
     cmd.assert()
         .success()
-        .stdout(predicates::str::contains("buildkite-agent artifact upload bazel-out\\x64_windows-fastbuild\\testlogs\\src\\test\\shell\\bazel\\resource_compiler_toolchain_test\\test.log"));
+        .stdout(predicates::str::contains("buildkite-agent artifact upload src\\test\\shell\\bazel\\resource_compiler_toolchain_test\\test.log"));
 
     Ok(())
 }
@@ -33,7 +33,7 @@ fn test_logs_uploaded_to_buildkite() -> Result<()> {
     ]);
     cmd.assert()
         .success()
-        .stdout(predicates::str::contains("buildkite-agent artifact upload bazel-out/darwin-fastbuild/testlogs/src/test/shell/bazel/starlark_repository_test/shard_4_of_6/test_attempts/attempt_1.log"));
+        .stdout(predicates::str::contains("buildkite-agent artifact upload src/test/shell/bazel/starlark_repository_test/shard_4_of_6/test_attempts/attempt_1.log"));
 
     Ok(())
 }


### PR DESCRIPTION
So instead of
```
bazel-out/k8-fastbuild/testlogs/src/test/shell/bazel/bazel_java17_test/test_attempts/attempt_1.log
```

the test log in Buildkite's artifacts tab will be
```
src/test/shell/bazel/bazel_java17_test/test_attempts/attempt_1.log
```