### PR TITLE
Agent: Add presubmit check actions which run test and check format for PRs

### DIFF
--- a/.github/workflows/presubmit-agent.yml
+++ b/.github/workflows/presubmit-agent.yml
@@ -45,11 +45,11 @@ jobs:
 
     - name: Cargo Build
       working-directory: agent
-      run: cargo build --verbose --release --target ${{ matrix.target }}
+      run: cargo build --verbose --target ${{ matrix.target }}
 
     - name: Cargo Test
       working-directory: agent
-      run: cargo test --verbose --release --target ${{ matrix.target }}
+      run: cargo test --verbose --target ${{ matrix.target }}
 
     - name: Cargo Format Check
       working-directory: agent


### PR DESCRIPTION
To prevent common errors like https://github.com/bazelbuild/continuous-integration/pull/1230#discussion_r716687209.

The actions only run when files under `agent/` directory are changed.

Example run:
- [Check code format](https://github.com/coeuvre/continuous-integration/pull/1)
- [Check tests](https://github.com/coeuvre/continuous-integration/pull/2)