### PR TITLE
Install sudo and update /etc/sudoers to allow users install additional packages

### DIFF
--- a/buildkite/docker/centos7/Dockerfile
+++ b/buildkite/docker/centos7/Dockerfile
@@ -29,11 +29,15 @@ RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf && 
     python36-requests \
     python36-six \
     rpm-build \
+    sudo \
     unzip \
     which \
     zip \
     && \
     yum clean all
+
+# Allow ALL users to install additional packages
+RUN echo "ALL ALL=NOPASSWD: /usr/bin/yum" >> /etc/sudoers
 
 RUN yum install -y yum-utils && \
     yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \

--- a/buildkite/docker/debian10/Dockerfile
+++ b/buildkite/docker/debian10/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get -y update && \
     python3-wheel \
     python3-yaml \
     software-properties-common \
+    sudo \
     unzip \
     wget \
     xvfb \
@@ -51,6 +52,9 @@ RUN apt-get -y update && \
     && \
     apt-get -y purge apport && \
     rm -rf /var/lib/apt/lists/*
+
+# Allow ALL users to install additional packages
+RUN echo "ALL ALL=NOPASSWD: /usr/bin/apt, /usr/bin/apt-get" >> /etc/sudoers
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${BUILDARCH}
 

--- a/buildkite/docker/ubuntu1604/Dockerfile
+++ b/buildkite/docker/ubuntu1604/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get -y update && \
     python3-wheel \
     realpath \
     software-properties-common \
+    sudo \
     unzip \
     wget \
     zip \
@@ -49,6 +50,9 @@ RUN apt-get -y update && \
     && \
     apt-get -y purge apport && \
     rm -rf /var/lib/apt/lists/*
+
+# Allow ALL users to install additional packages
+RUN echo "ALL ALL=NOPASSWD: /usr/bin/apt, /usr/bin/apt-get" >> /etc/sudoers
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-${BUILDARCH}
 

--- a/buildkite/docker/ubuntu1804/Dockerfile
+++ b/buildkite/docker/ubuntu1804/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get -y update && \
     python3-wheel \
     python3-yaml \
     software-properties-common \
+    sudo \
     unzip \
     wget \
     zip \
@@ -50,6 +51,9 @@ RUN apt-get -y update && \
     && \
     apt-get -y purge apport && \
     rm -rf /var/lib/apt/lists/*
+
+# Allow ALL users to install additional packages
+RUN echo "ALL ALL=NOPASSWD: /usr/bin/apt, /usr/bin/apt-get" >> /etc/sudoers
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${BUILDARCH}
 

--- a/buildkite/docker/ubuntu2004/Dockerfile
+++ b/buildkite/docker/ubuntu2004/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get -y update && \
     python3-wheel \
     python3-yaml \
     software-properties-common \
+    sudo \
     unzip \
     wget \
     zip \
@@ -51,6 +52,9 @@ RUN apt-get -y update && \
     && \
     apt-get -y purge apport && \
     rm -rf /var/lib/apt/lists/*
+
+# Allow ALL users to install additional packages
+RUN echo "ALL ALL=NOPASSWD: /usr/bin/apt" >> /etc/sudoers
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${BUILDARCH}
 


### PR DESCRIPTION
When running the containers as non-root, users can install additional packages via `sudo`.

Tested locally.