### PR TITLE
Use terraform to manage pipelines in bazel-testing

### DIFF
--- a/buildkite/terraform/.gitignore
+++ b/buildkite/terraform/.gitignore
@@ -1,0 +1,2 @@
+.terraform/
+terraform.tfstate

--- a/buildkite/terraform/README.md
+++ b/buildkite/terraform/README.md
@@ -1,0 +1,53 @@
+This directory contains terraform configuration files to manage pipelines on Buildkite.
+
+```
+terraform
+|
+|- bazel-testing    # Configuration files for bazel-testing
+```
+
+The terraform [state](https://www.terraform.io/docs/language/state/index.html) is stored in GCS bucket `bazel-buildkite-tf-state` (non-public).
+
+## Setup
+Please follow these steps to setup your local terraform environment:
+  1. Install [terraform](https://www.terraform.io/downloads.html).
+  1. Install Google Cloud SDK and authenticate using application default credentials. Make sure you have permissions to access bucket `bazel-buildkite-tf-state`. Check [here](https://www.terraform.io/docs/language/settings/backends/gcs.html#authentication) for more details about authentication.
+  1. Generate Buildkite API token by following this [doc](https://registry.terraform.io/providers/buildkite/buildkite/latest/docs). Make sure required scopes are selected and GraphQL is enabled.
+  1. Use environment to allow `terraform` read the API token:
+      ```
+      export BUILDKITE_API_TOKEN=TOKEN
+      ```
+  1. Run `terraform init` in one of the configurtion directories, e.g. `terraform/bazel-testing`.
+
+## Add new pipeline
+  1. Add `buildkite_pipeline` resource, e.g.:
+      ```
+      resource "buildkite_pipeline" "android-testing" {
+        name = "Android Testing"
+        repository = "https://github.com/googlesamples/android-testing.git"
+        steps = templatefile("pipeline.yml.tpl", { flags = ["--file_config=bazelci/buildkite-pipeline.yml"] })
+      }
+      ```
+     You can check all available properties [here](https://registry.terraform.io/providers/buildkite/buildkite/latest/docs/resources/pipeline).
+  1. Run `terraform plan` to preview the change.
+  1. Run `terraform apply` to apply the change.
+
+## Update managed pipeline
+  1. Edit `buildkite_pipeline` resource.
+  1. Run `terraform plan` to preview the change.
+  1. Run `terraform apply` to apply the change.
+
+## Import existing pipeline from Buildkite
+
+  1. Add `buildkite_pipeline` resource, e.g.:
+      ```
+      resource "buildkite_pipeline" "foo" {
+      }
+      ```
+      It is recommended to name the resource with the slug of existing pipeline.
+  1. Find the existing pipeline ID. You can find it in the `GraphQL API Integration` section of the `Pipeline Settings` of that pipeline on Buildkite. e.g. `UGlwZWxpbmUtLS0xYmJmYmM2NS0wMzE5LTQxMDMtOGY2Yy0zOGQ3MDQyYzVlZjc=`
+  1. Bind the resource with existing pipeline:
+      ```
+      terraform import buildkite_pipeline.foo PIPELINE_ID
+      ```
+  1. The pipeline should be imported. Run `terraform plan` to see the difference and update the resource accordingly if you don't want to make the change.

--- a/buildkite/terraform/bazel-testing/.terraform.lock.hcl
+++ b/buildkite/terraform/bazel-testing/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/buildkite/buildkite" {
+  version     = "0.5.0"
+  constraints = "0.5.0"
+  hashes = [
+    "h1:I3U6Smix6A1iMp/r3zv9veQA9+kM7tTp4P1PFZeoGUg=",
+    "zh:12bcddfec2f92afb67f515f21434b3d548580ba16c3e0b5170e17be20fd2ef2b",
+    "zh:238a2848ea81f356352ba89df2d4311df6468180ca8c3a5020dae730c05c19b9",
+    "zh:6a055856c7c68ebd80789539e6118cd0e32ea3823118c06315302bdbc20f9a8a",
+    "zh:836ed5dcde00d0740a65d06814eb2cf7903bfd8ccc7052eedf3868cf0e4422d5",
+    "zh:8ad359a08fa68e85847c96485fad3aaf74833c1e822511a2957538c8d9a61305",
+    "zh:a30b0779075e39d4ce8e035ea217351c3f7ff5e0d1723d1712a4837735cc7e0b",
+    "zh:a796024c9bc7699a82eeaf63c8c41f9faa92b9c2879f47693d78310b314816d9",
+    "zh:b264592226e5033c6e9d5f46d80ca9a509ca2288ad19667627ee849ec235f950",
+    "zh:b2843ff14406903f9287b551e80415001c5fe569fecc6773e63c67cf942d8a03",
+    "zh:bb1b66d05d9632c96c7d2ca7c04dfc8366d4b7646f144fe98d14a64ea4f67c29",
+    "zh:d2a38357ea469029238aa00ce3fa6dd936b1c6b2a666df531e0a38b7a37d2bea",
+    "zh:f3af8534086498523dd5f11591d2ef3b5b106f192d0197894dbe361068947e8b",
+    "zh:fe4350560ad79a733c6918c24bb84eaa2ce7f0af604a20664e329900b775391f",
+  ]
+}

--- a/buildkite/terraform/bazel-testing/main.tf
+++ b/buildkite/terraform/bazel-testing/main.tf
@@ -1,0 +1,69 @@
+terraform {
+  backend "gcs" {
+    bucket  = "bazel-buildkite-tf-state"
+    prefix  = "bazel-testing"
+  }
+
+  required_providers {
+    buildkite = {
+      source = "buildkite/buildkite"
+      version = "0.5.0"
+    }
+  }
+}
+
+provider "buildkite" {
+  # can also be set from env: BUILDKITE_API_TOKEN
+  #api_token = ""
+  organization = "bazel-testing"
+}
+
+resource "buildkite_pipeline" "android-testing" {
+  name = "Android Testing"
+  repository = "https://github.com/googlesamples/android-testing.git"
+  steps = templatefile("pipeline.yml.tpl", { flags = ["--file_config=bazelci/buildkite-pipeline.yml"] })
+  
+  provider_settings {
+    trigger_mode = "none"
+  }
+}
+
+resource "buildkite_pipeline" "apple-support-darwin" {
+  name = "apple_support :darwin:"
+  repository = "https://github.com/bazelbuild/apple_support.git"
+  steps = templatefile("pipeline.yml.tpl", { flags = [] })
+
+  provider_settings {
+    trigger_mode = "none"
+  }
+}
+
+resource "buildkite_pipeline" "bazel-bazel" {
+  name = "Bazel :bazel:"
+  repository = "https://github.com/bazelbuild/bazel.git"
+  steps = templatefile("pipeline.yml.tpl", { flags = ["--file_config=.bazelci/postsubmit.yml"] })
+
+  provider_settings {
+    trigger_mode = "none"
+  }
+}
+
+resource "buildkite_pipeline" "bazel-bazel-github-presubmit" {
+  name = "Bazel :bazel: Github Presubmit"
+  repository = "https://github.com/bazelbuild/bazel.git"
+  steps = templatefile("pipeline.yml.tpl", { flags = ["--file_config=.bazelci/presubmit.yml"] })
+
+  provider_settings {
+    trigger_mode = "none"
+  }
+}
+
+resource "buildkite_pipeline" "upb" {
+  name = "upb"
+  repository = "https://github.com/protocolbuffers/upb.git"
+  steps = templatefile("pipeline.yml.tpl", { flags = [] })
+
+  provider_settings {
+    trigger_mode = "none"
+  }
+}

--- a/buildkite/terraform/bazel-testing/main.tf
+++ b/buildkite/terraform/bazel-testing/main.tf
@@ -21,49 +21,35 @@ provider "buildkite" {
 resource "buildkite_pipeline" "android-testing" {
   name = "Android Testing"
   repository = "https://github.com/googlesamples/android-testing.git"
-  steps = templatefile("pipeline.yml.tpl", { flags = ["--file_config=bazelci/buildkite-pipeline.yml"] })
-  
-  provider_settings {
-    trigger_mode = "none"
-  }
+  steps = templatefile("pipeline.yml.tpl", { flags = ["project_pipeline", "--file_config=bazelci/buildkite-pipeline.yml"] })
 }
 
 resource "buildkite_pipeline" "apple-support-darwin" {
   name = "apple_support :darwin:"
   repository = "https://github.com/bazelbuild/apple_support.git"
-  steps = templatefile("pipeline.yml.tpl", { flags = [] })
-
-  provider_settings {
-    trigger_mode = "none"
-  }
+  steps = templatefile("pipeline.yml.tpl", { flags = ["project_pipeline"] })
 }
 
 resource "buildkite_pipeline" "bazel-bazel" {
   name = "Bazel :bazel:"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { flags = ["--file_config=.bazelci/postsubmit.yml"] })
-
-  provider_settings {
-    trigger_mode = "none"
-  }
+  steps = templatefile("pipeline.yml.tpl", { flags = ["project_pipeline", "--file_config=.bazelci/postsubmit.yml"] })
 }
 
 resource "buildkite_pipeline" "bazel-bazel-github-presubmit" {
   name = "Bazel :bazel: Github Presubmit"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { flags = ["--file_config=.bazelci/presubmit.yml"] })
+  steps = templatefile("pipeline.yml.tpl", { flags = ["project_pipeline", "--file_config=.bazelci/presubmit.yml"] })
+}
 
-  provider_settings {
-    trigger_mode = "none"
-  }
+resource "buildkite_pipeline" "bazel-at-head-plus-disabled" {
+  name = "Bazel@HEAD + Disabled"
+  repository = "https://github.com/bazelbuild/bazel.git"
+  steps = templatefile("pipeline.yml.tpl", { flags = ["bazel_downstream_pipeline", "--http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml", "--test_disabled_projects"] })
 }
 
 resource "buildkite_pipeline" "upb" {
   name = "upb"
   repository = "https://github.com/protocolbuffers/upb.git"
-  steps = templatefile("pipeline.yml.tpl", { flags = [] })
-
-  provider_settings {
-    trigger_mode = "none"
-  }
+  steps = templatefile("pipeline.yml.tpl", { flags = ["project_pipeline"] })
 }

--- a/buildkite/terraform/bazel-testing/pipeline.yml.tpl
+++ b/buildkite/terraform/bazel-testing/pipeline.yml.tpl
@@ -2,7 +2,7 @@
 steps:
   - command: |-
       curl -sS "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)" -o bazelci.py
-      python3.6 bazelci.py project_pipeline %{ for flag in flags ~} ${flag} %{ endfor ~} | buildkite-agent pipeline upload
+      python3.6 bazelci.py %{ for flag in flags ~} ${flag} %{ endfor ~} | buildkite-agent pipeline upload
     label: ":pipeline:"
     agents:
       - "queue=default"

--- a/buildkite/terraform/bazel-testing/pipeline.yml.tpl
+++ b/buildkite/terraform/bazel-testing/pipeline.yml.tpl
@@ -1,0 +1,28 @@
+---
+steps:
+  - command: |-
+      curl -sS "https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)" -o bazelci.py
+      python3.6 bazelci.py project_pipeline %{ for flag in flags ~} ${flag} %{ endfor ~} | buildkite-agent pipeline upload
+    label: ":pipeline:"
+    agents:
+      - "queue=default"
+    plugins:
+      - docker#v3.8.0:
+          always-pull: true
+          environment:
+            - "ANDROID_HOME"
+            - "ANDROID_SDK_ROOT"
+            - "ANDROID_NDK_HOME"
+            - "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"
+          image: "gcr.io/bazel-public/ubuntu1804-java11"
+          network: "host"
+          privileged: true
+          propagate-environment: true
+          propagate-uid-gid: true
+          volumes:
+            - "/etc/group:/etc/group:ro"
+            - "/etc/passwd:/etc/passwd:ro"
+            - "/opt:/opt:ro"
+            - "/var/lib/buildkite-agent:/var/lib/buildkite-agent"
+            - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
+            - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
This PR add terraform configuration files used to manage pipelines for [`bazel-testing`](https://buildkite.com/bazel-testing).

All instructions are written in README. I didn't import all the pipelines so you can give it a try after this is merged.