### PR TITLE
Fix missing github-release in release pipeline

### DIFF
--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -447,6 +447,11 @@ steps:
       echo "+++ Installing required packages"
       sudo apt -y update && sudo apt -y install devscripts pandoc reprepro
 
+      echo "+++ Downloading github-release"
+      curl -L https://mirror.bazel.build/github.com/c4milo/github-release/releases/download/v1.1.0/github-release_v1.1.0_linux_amd64.tar.gz | sudo tar xz -C /usr/local/bin
+      sudo chown root:root /usr/local/bin/github-release
+      sudo chmod 0755 /usr/local/bin/github-release
+
       echo "+++ Checking out Git branch"
       git fetch origin ${BUILDKITE_BRANCH}
       git checkout ${BUILDKITE_BRANCH}


### PR DESCRIPTION
Apparently the "Generate announcement mail text" step also needs it, even though it doesn't actually use it.