### PR TITLE
Fix string to boolean conversion in bazelci.py

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -933,6 +933,7 @@ def print_expanded_group(name):
 def is_trueish(s):
     return str(s).lower() in ["true", "1", "t", "y", "yes"]
 
+
 def use_bazelisk_migrate():
     """
     If USE_BAZELISK_MIGRATE is set, we use `bazelisk --migrate` to test incompatible flags.


### PR DESCRIPTION
I think the old code didn't actually work as intended - because os.environ can only contain strings, it didn't convert values like 'false' or '0' correctly.