### PR TITLE
Add build_branches and build_tags to bazel-trusted/publish-bazel-binaries

### DIFF
--- a/buildkite/terraform/bazel-trusted/main.tf
+++ b/buildkite/terraform/bazel-trusted/main.tf
@@ -208,8 +208,8 @@ resource "buildkite_pipeline" "publish-bazel-binaries" {
   team = [{ access_level = "READ_ONLY", slug = "everyone" }]
   provider_settings {
     trigger_mode = "code"
-    skip_pull_request_builds_for_existing_commits = true
-    prefix_pull_request_fork_branch_names = true
+    build_branches = true
+    build_tags = true
   }
 }
 


### PR DESCRIPTION
I think reason why these two settings are not set when the first time I "import" the pipeline using script is probably described in https://github.com/buildkite/terraform-provider-buildkite/issues/162.

> We could trace back this issue to an error (?) of the BK API, which reports sometimes no value at all and sometimes true (correct!) for build_branches configs of different BK pipelines.

i.e. the Buildkite REST API returns no value for `build_branches` and `build_tags` for `bazel-trusted/publish-bazel-binaries` when I ran the import script.

The removed two settings are only meaningful when `build_pull_requests` is `true`.