### PR TITLE
Print generated pipeline before upload to buildkite

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2494,7 +2494,7 @@ def upload_project_pipeline_step(
         pipeline_command += " --http_config=" + http_config
     if file_config:
         pipeline_command += " --file_config=" + file_config
-    pipeline_command += " | buildkite-agent pipeline upload"
+    pipeline_command += " | tee /dev/tty | buildkite-agent pipeline upload"
 
     return create_step(
         label="Setup {0}".format(project_name),
@@ -2839,7 +2839,7 @@ def print_bazel_downstream_pipeline(
                         fetch_bazelcipy_command(),
                         fetch_incompatible_flag_verbose_failures_command(),
                         PLATFORMS[DEFAULT_PLATFORM]["python"]
-                        + " incompatible_flag_verbose_failures.py --build_number=%s | buildkite-agent pipeline upload"
+                        + " incompatible_flag_verbose_failures.py --build_number=%s | tee /dev/tty | buildkite-agent pipeline upload"
                         % current_build_number,
                     ],
                     platform=DEFAULT_PLATFORM,

--- a/buildkite/terraform/bazel-testing/main.tf
+++ b/buildkite/terraform/bazel-testing/main.tf
@@ -21,13 +21,13 @@ provider "buildkite" {
 resource "buildkite_pipeline" "upb" {
   name = "upb"
   repository = "https://github.com/protocolbuffers/upb.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
 }
 
 resource "buildkite_pipeline" "bcr-presubmit" {
   name = "BCR Presubmit"
   repository = "https://github.com/meteorcloudy/bazel-central-registry.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = jsondecode("{\"USE_BAZEL_VERSION\": \"last_green\"}"), steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/pcloudy-bcr-test/buildkite/bazelci.py\" -o bazelci.py", "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/pcloudy-bcr-test/buildkite/bcr_presubmit.py\" -o bcr_presubmit.py", "python3.6 bcr_presubmit.py bcr_presubmit | buildkite-agent pipeline upload "] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = jsondecode("{\"USE_BAZEL_VERSION\": \"last_green\"}"), steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/pcloudy-bcr-test/buildkite/bazelci.py\" -o bazelci.py", "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/pcloudy-bcr-test/buildkite/bcr_presubmit.py\" -o bcr_presubmit.py", "python3.6 bcr_presubmit.py bcr_presubmit | tee /dev/tty | buildkite-agent pipeline upload "] } })
   description = "The presubmit for adding new Bazel module into the Bazel Central Registry"
   default_branch = "main"
   provider_settings {
@@ -46,7 +46,7 @@ resource "buildkite_pipeline" "bcr-presubmit" {
 resource "buildkite_pipeline" "protobuf" {
   name = "Protobuf"
   repository = "https://github.com/protocolbuffers/protobuf.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/pipelines/protobuf-postsubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/pipelines/protobuf-postsubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   provider_settings {
     trigger_mode = "code"
@@ -60,105 +60,105 @@ resource "buildkite_pipeline" "protobuf" {
 resource "buildkite_pipeline" "intellij-plugin" {
   name = "IntelliJ plugin"
   repository = "https://github.com/bazelbuild/intellij.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/aspect.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/aspect.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
 }
 
 resource "buildkite_pipeline" "google-bazel-presubmit" {
   name = "Google Bazel Presubmit"
   repository = "https://bazel.googlesource.com/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
 }
 
 resource "buildkite_pipeline" "tulsi-bazel-darwin" {
   name = "Tulsi :bazel: :darwin:"
   repository = "https://github.com/bazelbuild/tulsi.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
 }
 
 resource "buildkite_pipeline" "apple-support-darwin" {
   name = "apple_support :darwin:"
   repository = "https://github.com/bazelbuild/apple_support.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
 }
 
 resource "buildkite_pipeline" "rules-apple-darwin" {
   name = "rules_apple :darwin:"
   repository = "https://github.com/bazelbuild/rules_apple.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
 }
 
 resource "buildkite_pipeline" "android-testing" {
   name = "Android Testing"
   repository = "https://github.com/googlesamples/android-testing.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=bazelci/buildkite-pipeline.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=bazelci/buildkite-pipeline.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
 }
 
 resource "buildkite_pipeline" "rules-swift-swift" {
   name = "rules_swift :swift:"
   repository = "https://github.com/bazelbuild/rules_swift.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
 }
 
 resource "buildkite_pipeline" "rules-scala-scala" {
   name = "rules_scala :scala:"
   repository = "https://github.com/bazelbuild/rules_scala.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
 }
 
 resource "buildkite_pipeline" "rules-groovy" {
   name = "rules_groovy"
   repository = "https://github.com/bazelbuild/rules_groovy.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
 }
 
 resource "buildkite_pipeline" "rules-rust-rustlang" {
   name = "rules_rust :rustlang:"
   repository = "https://github.com/bazelbuild/rules_rust.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
 }
 
 resource "buildkite_pipeline" "rules-kotlin-kotlin" {
   name = "rules_kotlin :kotlin:"
   repository = "https://github.com/bazelbuild/rules_kotlin.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
 }
 
 resource "buildkite_pipeline" "rules-docker-docker" {
   name = "rules_docker :docker:"
   repository = "https://github.com/bazelbuild/rules_docker.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
 }
 
 resource "buildkite_pipeline" "rules-go-golang" {
   name = "rules_go :golang:"
   repository = "https://github.com/bazelbuild/rules_go.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
 }
 
 resource "buildkite_pipeline" "rules-nodejs-nodejs" {
   name = "rules_nodejs :nodejs:"
   repository = "https://github.com/bazelbuild/rules_nodejs.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --monitor_flaky_tests=true | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --monitor_flaky_tests=true | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "stable"
 }
 
 resource "buildkite_pipeline" "publish-bazel-binaries" {
   name = "Publish Bazel binaries"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/pipelines/publish-bazel-binaries.yml?$(date +%s)\" | buildkite-agent pipeline upload --replace"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/pipelines/publish-bazel-binaries.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   description = "Publish Bazel binaries to GCS (http://storage.googleapis.com/bazel-testing-builds/metadata/latest.json)"
   default_branch = "master"
   branch_configuration = "master"
@@ -167,7 +167,7 @@ resource "buildkite_pipeline" "publish-bazel-binaries" {
 resource "buildkite_pipeline" "bazelisk-plus-incompatible-flags" {
   name = "Bazelisk + Incompatible flags"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = jsondecode("{\"USE_BAZELISK_MIGRATE\": true}"), steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --test_incompatible_flags --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = jsondecode("{\"USE_BAZELISK_MIGRATE\": true}"), steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --test_incompatible_flags --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Use bazelisk --migrate to test incompatible flags with downstream projects@last_green_commit"
   default_branch = "master"
 }
@@ -175,7 +175,7 @@ resource "buildkite_pipeline" "bazelisk-plus-incompatible-flags" {
 resource "buildkite_pipeline" "bazel-at-head-plus-disabled" {
   name = "Bazel@HEAD + Disabled"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml --test_disabled_projects | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml --test_disabled_projects | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Test disabled downstream projects to see if they are already fixed."
   default_branch = "master"
 }
@@ -183,7 +183,7 @@ resource "buildkite_pipeline" "bazel-at-head-plus-disabled" {
 resource "buildkite_pipeline" "bazel-at-head-plus-downstream" {
   name = "Bazel@HEAD + Downstream"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Test Bazel@HEAD + downstream projects@last_green_commit"
   default_branch = "master"
 }
@@ -191,7 +191,7 @@ resource "buildkite_pipeline" "bazel-at-head-plus-downstream" {
 resource "buildkite_pipeline" "bazelisk" {
   name = "Bazelisk"
   repository = "https://github.com/bazelbuild/bazelisk.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/config.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/config.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   branch_configuration = "master"
 }
@@ -199,7 +199,7 @@ resource "buildkite_pipeline" "bazelisk" {
 resource "buildkite_pipeline" "bazel-bazel-github-presubmit" {
   name = "Bazel :bazel: Github Presubmit"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   branch_configuration = "!*"
 }
@@ -207,13 +207,7 @@ resource "buildkite_pipeline" "bazel-bazel-github-presubmit" {
 resource "buildkite_pipeline" "bazel-bazel" {
   name = "Bazel :bazel:"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/postsubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/postsubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   branch_configuration = "master release-*"
-  provider_settings {
-    trigger_mode = "code"
-    skip_pull_request_builds_for_existing_commits = true
-    prefix_pull_request_fork_branch_names = true
-    build_branches = true
-  }
 }

--- a/buildkite/terraform/bazel-trusted/main.tf
+++ b/buildkite/terraform/bazel-trusted/main.tf
@@ -36,7 +36,7 @@ resource "buildkite_pipeline" "bazel-arm64" {
 resource "buildkite_pipeline" "docgen-bazel-website" {
   name = "DocGen: Bazel-website"
   repository = "https://github.com/bazelbuild/bazel-website.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | buildkite-agent pipeline upload --replace"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   default_branch = "master"
   branch_configuration = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-docs" }]
@@ -51,7 +51,7 @@ resource "buildkite_pipeline" "docgen-bazel-website" {
 resource "buildkite_pipeline" "docgen-bazel-blog" {
   name = "DocGen: Bazel-blog"
   repository = "https://github.com/bazelbuild/bazel-blog.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | buildkite-agent pipeline upload --replace"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   default_branch = "master"
   branch_configuration = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-docs" }]
@@ -66,7 +66,7 @@ resource "buildkite_pipeline" "docgen-bazel-blog" {
 resource "buildkite_pipeline" "docgen-bazel" {
   name = "DocGen: Bazel"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | buildkite-agent pipeline upload --replace"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   default_branch = "master"
   branch_configuration = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-docs" }]
@@ -81,7 +81,7 @@ resource "buildkite_pipeline" "docgen-bazel" {
 resource "buildkite_pipeline" "bazel-custom-release" {
   name = "Bazel Custom Release"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-custom-release.yml?$(date +%s)\" | buildkite-agent pipeline upload --replace"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-custom-release.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "release-managers" }]
 }
@@ -169,7 +169,7 @@ resource "buildkite_pipeline" "bazel-bench-nightly" {
 resource "buildkite_pipeline" "java-tools-binaries-java" {
   name = "java_tools binaries :java:"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/java_tools-binaries.yml?$(date +%s)\" | buildkite-agent pipeline upload --replace"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/java_tools-binaries.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   description = "Temporary pipeline for building java_tools binaries on all platforms"
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "java-tools-team" }, { access_level = "READ_ONLY", slug = "everyone" }]
@@ -185,7 +185,7 @@ resource "buildkite_pipeline" "java-tools-binaries-java" {
 resource "buildkite_pipeline" "bazel-release" {
   name = "Bazel Release"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-release.yml?$(date +%s)\" | buildkite-agent pipeline upload --replace"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-release.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   default_branch = "0.21.0"
   branch_configuration = "release-* 0.* 1.* 2.* 3.* 4.* 5.* 6.*"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "release-managers" }, { access_level = "READ_ONLY", slug = "everyone" }]
@@ -201,7 +201,7 @@ resource "buildkite_pipeline" "bazel-release" {
 resource "buildkite_pipeline" "publish-bazel-binaries" {
   name = "Publish Bazel binaries"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/publish-bazel-binaries.yml?$(date +%s)\" | buildkite-agent pipeline upload --replace"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/publish-bazel-binaries.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   description = "Publish Bazel binaries to GCS (http://storage.googleapis.com/bazel-builds/metadata/latest.json)"
   default_branch = "master"
   branch_configuration = "master"
@@ -216,7 +216,7 @@ resource "buildkite_pipeline" "publish-bazel-binaries" {
 resource "buildkite_pipeline" "build-embedded-minimized-jdk" {
   name = "Build embedded (minimized) JDK"
   repository = "https://bazel.googlesource.com/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/build-embedded-minimized-jdk.yml?$(date +%s)\" | buildkite-agent pipeline upload --replace"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/build-embedded-minimized-jdk.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   default_branch = "master"
   team = [{ access_level = "READ_ONLY", slug = "everyone" }]
 }

--- a/buildkite/terraform/bazel/main.tf
+++ b/buildkite/terraform/bazel/main.tf
@@ -21,7 +21,7 @@ provider "buildkite" {
 resource "buildkite_pipeline" "fwe-inc-test" {
   name = "fwe inc test"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = jsondecode("{\"USE_BAZELISK_MIGRATE\": \"true\"}"), steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/fweikert/continuous-integration/inc/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --test_incompatible_flags --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = jsondecode("{\"USE_BAZELISK_MIGRATE\": \"true\"}"), steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/fweikert/continuous-integration/inc/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --test_incompatible_flags --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   provider_settings {
     trigger_mode = "code"
@@ -55,7 +55,7 @@ resource "buildkite_pipeline" "bcr-postsubmit" {
 resource "buildkite_pipeline" "bcr-presubmit" {
   name = "BCR Presubmit"
   repository = "https://github.com/bazelbuild/bazel-central-registry.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = jsondecode("{\"USE_BAZEL_VERSION\": \"last_green\"}"), steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py\" -o bazelci.py", "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazel-central-registry/bcr_presubmit.py\" -o bcr_presubmit.py", "python3.6 bcr_presubmit.py bcr_presubmit | buildkite-agent pipeline upload "] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = jsondecode("{\"USE_BAZEL_VERSION\": \"last_green\"}"), steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py\" -o bazelci.py", "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazel-central-registry/bcr_presubmit.py\" -o bcr_presubmit.py", "python3.6 bcr_presubmit.py bcr_presubmit | tee /dev/tty | buildkite-agent pipeline upload "] } })
   description = "The presubmit for adding new Bazel module into the Bazel Central Registry"
   default_branch = "main"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }]
@@ -73,7 +73,7 @@ resource "buildkite_pipeline" "bcr-presubmit" {
 resource "buildkite_pipeline" "limdor-bazel-examples" {
   name = "limdor/bazel-examples"
   repository = "https://github.com/limdor/bazel-examples"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "rules-qt" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -91,7 +91,7 @@ resource "buildkite_pipeline" "limdor-bazel-examples" {
 resource "buildkite_pipeline" "intellij-ue-plugin" {
   name = "IntelliJ UE plugin"
   repository = "https://github.com/bazelbuild/intellij.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij-ue.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij-ue.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Tests the Bazel IntelliJ plugin with IntelliJ IDEA Ultimate"
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -109,7 +109,7 @@ resource "buildkite_pipeline" "intellij-ue-plugin" {
 resource "buildkite_pipeline" "btwiuse-k0s" {
   name = "btwiuse/k0s"
   repository = "https://github.com/btwiuse/k0s"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -124,7 +124,7 @@ resource "buildkite_pipeline" "btwiuse-k0s" {
 resource "buildkite_pipeline" "bcsgh-utilities" {
   name = "bcsgh/utilities"
   repository = "https://github.com/bcsgh/utilities"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bcsgh" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -140,7 +140,7 @@ resource "buildkite_pipeline" "bcsgh-utilities" {
 resource "buildkite_pipeline" "bcsgh-tbd" {
   name = "bcsgh/tbd"
   repository = "https://github.com/bcsgh/tbd"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bcsgh" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -156,7 +156,7 @@ resource "buildkite_pipeline" "bcsgh-tbd" {
 resource "buildkite_pipeline" "bcsgh-tbd-http" {
   name = "bcsgh/tbd-http"
   repository = "https://github.com/bcsgh/tbd-http"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bcsgh" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -172,7 +172,7 @@ resource "buildkite_pipeline" "bcsgh-tbd-http" {
 resource "buildkite_pipeline" "bcsgh-stl-to-ps" {
   name = "bcsgh/stl-to-ps"
   repository = "https://github.com/bcsgh/stl-to-ps"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bcsgh" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -187,7 +187,7 @@ resource "buildkite_pipeline" "bcsgh-stl-to-ps" {
 resource "buildkite_pipeline" "bcsgh-bazel-rules" {
   name = "bcsgh/bazel_rules"
   repository = "https://github.com/bcsgh/bazel_rules"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bcsgh" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -203,7 +203,7 @@ resource "buildkite_pipeline" "bcsgh-bazel-rules" {
 resource "buildkite_pipeline" "bcsgh-bash-history-db" {
   name = "bcsgh/bash_history_db"
   repository = "https://github.com/bcsgh/bash_history_db"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bcsgh" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -219,7 +219,7 @@ resource "buildkite_pipeline" "bcsgh-bash-history-db" {
 resource "buildkite_pipeline" "distributed-point-functions" {
   name = "Distributed Point Functions"
   repository = "https://github.com/google/distributed_point_functions.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -236,7 +236,7 @@ resource "buildkite_pipeline" "distributed-point-functions" {
 resource "buildkite_pipeline" "google-bazel-docs-staging" {
   name = "Google Bazel Docs Staging"
   repository = "https://bazel.googlesource.com/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | buildkite-agent pipeline upload --replace"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   default_branch = "master"
   team = [{ access_level = "READ_ONLY", slug = "bazel" }, { access_level = "BUILD_AND_READ", slug = "googlers" }]
 }
@@ -244,7 +244,7 @@ resource "buildkite_pipeline" "google-bazel-docs-staging" {
 resource "buildkite_pipeline" "cargo-raze" {
   name = "Cargo-Raze"
   repository = "https://github.com/google/cargo-raze.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   skip_intermediate_builds = true
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -263,7 +263,7 @@ resource "buildkite_pipeline" "cargo-raze" {
 resource "buildkite_pipeline" "rules-qt" {
   name = "rules_qt"
   repository = "https://github.com/justbuchanan/bazel_rules_qt"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "rules-qt" }]
   provider_settings {
@@ -281,7 +281,7 @@ resource "buildkite_pipeline" "rules-qt" {
 resource "buildkite_pipeline" "grpc-grpc-web" {
   name = "grpc/grpc-web"
   repository = "https://github.com/grpc/grpc-web"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "grpc" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
 }
@@ -289,7 +289,7 @@ resource "buildkite_pipeline" "grpc-grpc-web" {
 resource "buildkite_pipeline" "grpc-grpc" {
   name = "grpc/grpc"
   repository = "https://github.com/grpc/grpc"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "grpc" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -305,7 +305,7 @@ resource "buildkite_pipeline" "grpc-grpc" {
 resource "buildkite_pipeline" "dagger-query" {
   name = "dagger-query"
   repository = "https://github.com/googleinterns/dagger-query.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = ":dagger_knife:"
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "dagger-query" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -322,7 +322,7 @@ resource "buildkite_pipeline" "dagger-query" {
 resource "buildkite_pipeline" "rules-pkg" {
   name = "rules_pkg"
   repository = "https://github.com/bazelbuild/rules_pkg.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"], label = "setup", artifact_paths = ["**/distro/rules_pkg*tar.tz"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"], label = "setup", artifact_paths = ["**/distro/rules_pkg*tar.tz"] } })
   default_branch = "main"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "rules-pkg" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -348,7 +348,7 @@ resource "buildkite_pipeline" "bazel-auto-sheriff-face-with-cowboy-hat" {
 resource "buildkite_pipeline" "github-dot-com-jmillikin-rules-ragel" {
   name = "github.com/jmillikin/rules_ragel"
   repository = "https://github.com/jmillikin/rules_ragel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "trunk"
   team = [{ access_level = "BUILD_AND_READ", slug = "jmillikinrules-ragel" }]
   provider_settings {
@@ -366,7 +366,7 @@ resource "buildkite_pipeline" "github-dot-com-jmillikin-rules-ragel" {
 resource "buildkite_pipeline" "github-dot-com-jmillikin-rules-flex" {
   name = "github.com/jmillikin/rules_flex"
   repository = "https://github.com/jmillikin/rules_flex.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "trunk"
   team = [{ access_level = "BUILD_AND_READ", slug = "jmillikinrules-flex" }]
   provider_settings {
@@ -385,7 +385,7 @@ resource "buildkite_pipeline" "github-dot-com-jmillikin-rules-flex" {
 resource "buildkite_pipeline" "github-dot-com-jmillikin-rules-bison" {
   name = "github.com/jmillikin/rules_bison"
   repository = "https://github.com/jmillikin/rules_bison.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "trunk"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "jmillikinrules-bison" }]
   provider_settings {
@@ -404,7 +404,7 @@ resource "buildkite_pipeline" "github-dot-com-jmillikin-rules-bison" {
 resource "buildkite_pipeline" "rules-postcss" {
   name = "rules_postcss"
   repository = "https://github.com/bazelbuild/rules_postcss.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "rules-postcss" }]
   provider_settings {
@@ -422,7 +422,7 @@ resource "buildkite_pipeline" "rules-postcss" {
 resource "buildkite_pipeline" "github-dot-com-googleapis-google-cloud-cpp" {
   name = "github.com/googleapis/google-cloud-cpp"
   repository = "https://github.com/googleapis/google-cloud-cpp.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   branch_configuration = "!gh-pages"
   team = [{ access_level = "BUILD_AND_READ", slug = "github-dot-comgoogleapisgoogle-cloud-cpp" }]
@@ -441,7 +441,7 @@ resource "buildkite_pipeline" "github-dot-com-googleapis-google-cloud-cpp" {
 resource "buildkite_pipeline" "github-dot-com-brightspace-rules-csharp" {
   name = "github.com/brightspace/rules_csharp"
   repository = "https://github.com/Brightspace/rules_csharp.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "github-dot-combrightspacerules-csharp" }]
   provider_settings {
@@ -459,7 +459,7 @@ resource "buildkite_pipeline" "github-dot-com-brightspace-rules-csharp" {
 resource "buildkite_pipeline" "github-dot-com-jmillikin-rules-m4" {
   name = "github.com/jmillikin/rules_m4"
   repository = "https://github.com/jmillikin/rules_m4.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "trunk"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "github-dot-comjmillikinrules-m4" }]
   provider_settings {
@@ -479,7 +479,7 @@ resource "buildkite_pipeline" "github-dot-com-jmillikin-rules-m4" {
 resource "buildkite_pipeline" "stardoc" {
   name = "Stardoc"
   repository = "https://github.com/bazelbuild/stardoc.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -497,7 +497,7 @@ resource "buildkite_pipeline" "stardoc" {
 resource "buildkite_pipeline" "rules-boost" {
   name = "rules_boost"
   repository = "https://github.com/nelhage/rules_boost.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "rules-boost" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -513,7 +513,7 @@ resource "buildkite_pipeline" "rules-boost" {
 resource "buildkite_pipeline" "grpc-ecosystem-grpc-gateway" {
   name = "grpc-ecosystem/grpc-gateway"
   repository = "https://github.com/grpc-ecosystem/grpc-gateway.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "grpc-ecosystem" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -530,7 +530,7 @@ resource "buildkite_pipeline" "grpc-ecosystem-grpc-gateway" {
 resource "buildkite_pipeline" "rules-proto" {
   name = "rules_proto"
   repository = "https://github.com/bazelbuild/rules_proto.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "rules-proto" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -548,7 +548,7 @@ resource "buildkite_pipeline" "rules-proto" {
 resource "buildkite_pipeline" "bazel-gazelle" {
   name = "Bazel Gazelle"
   repository = "https://github.com/bazelbuild/bazel-gazelle.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -566,7 +566,7 @@ resource "buildkite_pipeline" "bazel-gazelle" {
 resource "buildkite_pipeline" "rules-proto-grpc-rules-proto-grpc" {
   name = "rules-proto-grpc/rules_proto_grpc"
   repository = "https://github.com/rules-proto-grpc/rules_proto_grpc.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "rules-proto-grpcrules-proto-grpc" }]
   provider_settings {
@@ -583,7 +583,7 @@ resource "buildkite_pipeline" "rules-proto-grpc-rules-proto-grpc" {
 resource "buildkite_pipeline" "rules-haskell-haskell" {
   name = "rules_haskell :haskell:"
   repository = "https://github.com/tweag/rules_haskell.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "rules-haskell" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -601,7 +601,7 @@ resource "buildkite_pipeline" "rules-haskell-haskell" {
 resource "buildkite_pipeline" "google-bazel-platforms-presubmit" {
   name = "Google Bazel Platforms Presubmit"
   repository = "https://bazel.googlesource.com/platforms.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
 }
@@ -609,7 +609,7 @@ resource "buildkite_pipeline" "google-bazel-platforms-presubmit" {
 resource "buildkite_pipeline" "bazel-platforms-bazel" {
   name = "Bazel Platforms :bazel:"
   repository = "https://github.com/bazelbuild/platforms.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -626,7 +626,7 @@ resource "buildkite_pipeline" "bazel-platforms-bazel" {
 resource "buildkite_pipeline" "sandboxed-api" {
   name = "Sandboxed API"
   repository = "https://github.com/google/sandboxed-api.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -642,7 +642,7 @@ resource "buildkite_pipeline" "sandboxed-api" {
 resource "buildkite_pipeline" "google-rules-java-presubmit" {
   name = "Google rules_java Presubmit"
   repository = "https://bazel.googlesource.com/rules_java.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
 }
@@ -650,7 +650,7 @@ resource "buildkite_pipeline" "google-rules-java-presubmit" {
 resource "buildkite_pipeline" "starlark" {
   name = "Starlark"
   repository = "https://github.com/bazelbuild/starlark.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazelbuildstarlark" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -666,7 +666,7 @@ resource "buildkite_pipeline" "starlark" {
 resource "buildkite_pipeline" "rules-java-java" {
   name = "rules_java :java:"
   repository = "https://github.com/bazelbuild/rules_java.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -684,7 +684,7 @@ resource "buildkite_pipeline" "rules-java-java" {
 resource "buildkite_pipeline" "remote-apis-sdks" {
   name = "remote-apis-sdks"
   repository = "https://github.com/bazelbuild/remote-apis-sdks.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -704,7 +704,7 @@ resource "buildkite_pipeline" "remote-apis-sdks" {
 resource "buildkite_pipeline" "ash2k-bazel-tools" {
   name = "ash2k/bazel-tools"
   repository = "https://github.com/ash2k/bazel-tools.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   skip_intermediate_builds = true
   team = [{ access_level = "BUILD_AND_READ", slug = "ash2kbazel-tools" }]
@@ -726,7 +726,7 @@ resource "buildkite_pipeline" "ash2k-bazel-tools" {
 resource "buildkite_pipeline" "bazel-codelabs" {
   name = "Bazel Codelabs"
   repository = "https://github.com/bazelbuild/codelabs.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -743,7 +743,7 @@ resource "buildkite_pipeline" "bazel-codelabs" {
 resource "buildkite_pipeline" "abseil-python" {
   name = "Abseil Python"
   repository = "https://github.com/abseil/abseil-py.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/abseil-py.yml?$(date +%s) | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/abseil-py.yml?$(date +%s) | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
 }
@@ -751,7 +751,7 @@ resource "buildkite_pipeline" "abseil-python" {
 resource "buildkite_pipeline" "abseil-c-plus-plus" {
   name = "Abseil C++"
   repository = "https://github.com/abseil/abseil-cpp.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/abseil-cpp.yml?$(date +%s) | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/abseil-cpp.yml?$(date +%s) | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
 }
@@ -759,7 +759,7 @@ resource "buildkite_pipeline" "abseil-c-plus-plus" {
 resource "buildkite_pipeline" "flogger" {
   name = "Flogger"
   repository = "https://github.com/google/flogger.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/flogger.yml?$(date +%s) | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/flogger.yml?$(date +%s) | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
 }
@@ -767,7 +767,7 @@ resource "buildkite_pipeline" "flogger" {
 resource "buildkite_pipeline" "upb" {
   name = "upb"
   repository = "https://github.com/protocolbuffers/upb.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "upb" }]
   provider_settings {
@@ -783,7 +783,7 @@ resource "buildkite_pipeline" "upb" {
 resource "buildkite_pipeline" "envoy" {
   name = "Envoy"
   repository = "https://github.com/envoyproxy/envoy.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   team = [{ access_level = "BUILD_AND_READ", slug = "envoy" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
 }
@@ -791,7 +791,7 @@ resource "buildkite_pipeline" "envoy" {
 resource "buildkite_pipeline" "kythe" {
   name = "Kythe"
   repository = "https://github.com/kythe/kythe.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -808,7 +808,7 @@ resource "buildkite_pipeline" "kythe" {
 resource "buildkite_pipeline" "bazel-bench" {
   name = "bazel-bench"
   repository = "https://github.com/bazelbuild/bazel-bench.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -826,7 +826,7 @@ resource "buildkite_pipeline" "bazel-bench" {
 resource "buildkite_pipeline" "continuous-integration" {
   name = "continuous-integration"
   repository = "https://github.com/bazelbuild/continuous-integration.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/continuous-integration.yml?$(date +%s)\" | buildkite-agent pipeline upload --replace"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/continuous-integration.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }]
   provider_settings {
@@ -844,7 +844,7 @@ resource "buildkite_pipeline" "continuous-integration" {
 resource "buildkite_pipeline" "rules-jvm-external-examples" {
   name = "rules_jvm_external - examples"
   repository = "https://github.com/bazelbuild/rules_jvm_external.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/rules_jvm_external/master/.bazelci/examples.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/rules_jvm_external/master/.bazelci/examples.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Example projects in rules_jvm_external"
   default_branch = "master"
   skip_intermediate_builds = true
@@ -864,7 +864,7 @@ resource "buildkite_pipeline" "rules-jvm-external-examples" {
 resource "buildkite_pipeline" "vscode-bazel-vs-bazel" {
   name = "vscode-bazel :vs: :bazel:"
   repository = "https://github.com/bazelbuild/vscode-bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }]
   provider_settings {
@@ -883,7 +883,7 @@ resource "buildkite_pipeline" "vscode-bazel-vs-bazel" {
 resource "buildkite_pipeline" "apple-support-darwin" {
   name = "apple_support :darwin:"
   repository = "https://github.com/bazelbuild/apple_support.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   branch_configuration = "!test_* !upstream"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "apple-team" }, { access_level = "BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -903,7 +903,7 @@ resource "buildkite_pipeline" "apple-support-darwin" {
 resource "buildkite_pipeline" "bazelisk-plus-incompatible-flags" {
   name = "Bazelisk + Incompatible flags"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = jsondecode("{\"USE_BAZELISK_MIGRATE\": \"true\"}"), steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --test_incompatible_flags --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = jsondecode("{\"USE_BAZELISK_MIGRATE\": \"true\"}"), steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --test_incompatible_flags --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Use bazelisk --migrate to test incompatible flags with downstream projects@last_green_commit"
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }, { access_level = "BUILD_AND_READ", slug = "downstream-pipeline-triggerers" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }]
@@ -920,7 +920,7 @@ resource "buildkite_pipeline" "bazelisk-plus-incompatible-flags" {
 resource "buildkite_pipeline" "bazel-bazel-examples" {
   name = "Bazel :bazel: Examples"
   repository = "https://github.com/bazelbuild/examples.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }]
   provider_settings {
@@ -937,7 +937,7 @@ resource "buildkite_pipeline" "bazel-bazel-examples" {
 resource "buildkite_pipeline" "mobile-devx-tools" {
   name = "Mobile DevX Tools"
   repository = "https://github.com/google/devx-tools.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/google/devx-tools/master/.continuous_integration/postsubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/google/devx-tools/master/.continuous_integration/postsubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Tools used at Google for mobile development and testing"
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "android-team" }]
@@ -954,7 +954,7 @@ resource "buildkite_pipeline" "mobile-devx-tools" {
 resource "buildkite_pipeline" "stackb-rules-proto" {
   name = "stackb/rules_proto"
   repository = "https://github.com/stackb/rules_proto.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "v2_prerelease"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }, { access_level = "BUILD_AND_READ", slug = "googlers" }]
   provider_settings {
@@ -972,7 +972,7 @@ resource "buildkite_pipeline" "stackb-rules-proto" {
 resource "buildkite_pipeline" "flatbuffers" {
   name = "FlatBuffers"
   repository = "https://github.com/google/flatbuffers.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }]
   provider_settings {
@@ -989,7 +989,7 @@ resource "buildkite_pipeline" "flatbuffers" {
 resource "buildkite_pipeline" "cloud-robotics-core" {
   name = "Cloud Robotics Core"
   repository = "https://github.com/googlecloudrobotics/core.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/cloud-robotics.yml?$(date +%s) | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/cloud-robotics.yml?$(date +%s) | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
 }
@@ -997,7 +997,7 @@ resource "buildkite_pipeline" "cloud-robotics-core" {
 resource "buildkite_pipeline" "bazelisk" {
   name = "Bazelisk"
   repository = "https://github.com/bazelbuild/bazelisk.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/config.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/config.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1013,7 +1013,7 @@ resource "buildkite_pipeline" "bazelisk" {
 resource "buildkite_pipeline" "tulsi-bazel-darwin" {
   name = "Tulsi :bazel: :darwin:"
   repository = "https://github.com/bazelbuild/tulsi.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   branch_configuration = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "apple-team" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1032,7 +1032,7 @@ resource "buildkite_pipeline" "tulsi-bazel-darwin" {
 resource "buildkite_pipeline" "rules-cc" {
   name = "rules_cc"
   repository = "https://github.com/bazelbuild/rules_cc.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1050,7 +1050,7 @@ resource "buildkite_pipeline" "rules-cc" {
 resource "buildkite_pipeline" "google-rules-cc-presubmit" {
   name = "Google rules_cc Presubmit"
   repository = "https://bazel.googlesource.com/rules_cc.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }, { access_level = "BUILD_AND_READ", slug = "googlers" }]
 }
@@ -1058,7 +1058,7 @@ resource "buildkite_pipeline" "google-rules-cc-presubmit" {
 resource "buildkite_pipeline" "rules-swift-swift" {
   name = "rules_swift :swift:"
   repository = "https://github.com/bazelbuild/rules_swift.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   branch_configuration = "!test_* !upstream"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "apple-team" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1078,7 +1078,7 @@ resource "buildkite_pipeline" "rules-swift-swift" {
 resource "buildkite_pipeline" "bazel-at-head-plus-disabled" {
   name = "Bazel@HEAD + Disabled"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml --test_disabled_projects | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml --test_disabled_projects | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Test disabled downstream projects to see if they are already fixed."
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }, { access_level = "BUILD_AND_READ", slug = "downstream-pipeline-triggerers" }, { access_level = "READ_ONLY", slug = "bazel" }]
@@ -1087,7 +1087,7 @@ resource "buildkite_pipeline" "bazel-at-head-plus-disabled" {
 resource "buildkite_pipeline" "culprit-finder" {
   name = "Culprit Finder"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = jsondecode("{\"NEEDS_CLEAN\": \"1\"}"), steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/culprit_finder.py?$(date +%s)\" -o culprit_finder.py", "python3.6 culprit_finder.py culprit_finder | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = jsondecode("{\"NEEDS_CLEAN\": \"1\"}"), steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/culprit_finder.py?$(date +%s)\" -o culprit_finder.py", "python3.6 culprit_finder.py culprit_finder | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Find out which commit broke a project on specific platform"
   default_branch = "master"
   team = [{ access_level = "READ_ONLY", slug = "bazel" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }]
@@ -1096,7 +1096,7 @@ resource "buildkite_pipeline" "culprit-finder" {
 resource "buildkite_pipeline" "rules-dotnet-edge" {
   name = "rules_dotnet :edge:"
   repository = "https://github.com/bazelbuild/rules_dotnet.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1115,7 +1115,7 @@ resource "buildkite_pipeline" "rules-dotnet-edge" {
 resource "buildkite_pipeline" "rules-webtesting-saucelabs" {
   name = "rules_webtesting :saucelabs:"
   repository = "https://github.com/bazelbuild/rules_webtesting.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "rules-webtesting" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1131,7 +1131,7 @@ resource "buildkite_pipeline" "rules-webtesting-saucelabs" {
 resource "buildkite_pipeline" "bazel-bazel-github-presubmit" {
   name = "Bazel :bazel: Github Presubmit"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   branch_configuration = "!master !release-*"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1150,7 +1150,7 @@ resource "buildkite_pipeline" "bazel-bazel-github-presubmit" {
 resource "buildkite_pipeline" "rules-android" {
   name = "rules_android"
   repository = "https://github.com/bazelbuild/rules_android.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/rules_android/master/.bazelci/postsubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/rules_android/master/.bazelci/postsubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Android rules for Bazel"
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "android-team" }]
@@ -1167,7 +1167,7 @@ resource "buildkite_pipeline" "rules-android" {
 resource "buildkite_pipeline" "rules-foreign-cc" {
   name = "rules_foreign_cc"
   repository = "https://github.com/bazelbuild/rules_foreign_cc.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/config.yaml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/config.yaml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   branch_configuration = "main"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1188,7 +1188,7 @@ resource "buildkite_pipeline" "rules-foreign-cc" {
 resource "buildkite_pipeline" "cartographer" {
   name = "Cartographer"
   repository = "https://github.com/googlecartographer/cartographer.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1203,7 +1203,7 @@ resource "buildkite_pipeline" "cartographer" {
 resource "buildkite_pipeline" "rules-jvm-external" {
   name = "rules_jvm_external"
   repository = "https://github.com/bazelbuild/rules_jvm_external.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Resolve and fetch artifacts transitively from Maven repositories"
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "android-team" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1222,7 +1222,7 @@ resource "buildkite_pipeline" "rules-jvm-external" {
 resource "buildkite_pipeline" "android-testing" {
   name = "Android Testing"
   repository = "https://github.com/googlesamples/android-testing.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=bazelci/buildkite-pipeline.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=bazelci/buildkite-pipeline.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "https://github.com/googlesamples/android-testing#experimental-bazel-support"
   default_branch = "main"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "android-team" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1242,7 +1242,7 @@ resource "buildkite_pipeline" "android-testing" {
 resource "buildkite_pipeline" "intellij-plugin-aspect" {
   name = "IntelliJ Plugin Aspect"
   repository = "https://github.com/bazelbuild/intellij.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/aspect.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/aspect.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1258,7 +1258,7 @@ resource "buildkite_pipeline" "intellij-plugin-aspect" {
 resource "buildkite_pipeline" "android-studio-plugin" {
   name = "Android Studio Plugin"
   repository = "https://github.com/bazelbuild/intellij.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/android-studio.yml --monitor_flaky_tests=true | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/android-studio.yml --monitor_flaky_tests=true | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1274,7 +1274,7 @@ resource "buildkite_pipeline" "android-studio-plugin" {
 resource "buildkite_pipeline" "bazel-remote-cache" {
   name = "Bazel Remote Cache"
   repository = "https://github.com/buchgr/bazel-remote.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "buchgrbazel-remote" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1290,7 +1290,7 @@ resource "buildkite_pipeline" "bazel-remote-cache" {
 resource "buildkite_pipeline" "rules-apple-darwin" {
   name = "rules_apple :darwin:"
   repository = "https://github.com/bazelbuild/rules_apple.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   branch_configuration = "!test_* !upstream"
   skip_intermediate_builds = true
@@ -1316,7 +1316,7 @@ resource "buildkite_pipeline" "rules-apple-darwin" {
 resource "buildkite_pipeline" "bazel-integration-testing" {
   name = "Bazel integration testing"
   repository = "https://github.com/bazelbuild/bazel-integration-testing.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1332,7 +1332,7 @@ resource "buildkite_pipeline" "bazel-integration-testing" {
 resource "buildkite_pipeline" "bazel-skylib" {
   name = "Bazel skylib"
   repository = "https://github.com/bazelbuild/bazel-skylib.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1349,7 +1349,7 @@ resource "buildkite_pipeline" "bazel-skylib" {
 resource "buildkite_pipeline" "buildfarm-farmer" {
   name = "Buildfarm :farmer:"
   repository = "https://github.com/bazelbuild/bazel-buildfarm.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1366,7 +1366,7 @@ resource "buildkite_pipeline" "buildfarm-farmer" {
 resource "buildkite_pipeline" "rules-kotlin-kotlin" {
   name = "rules_kotlin :kotlin:"
   repository = "https://github.com/bazelbuild/rules_kotlin.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "rules-kotlin" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1382,7 +1382,7 @@ resource "buildkite_pipeline" "rules-kotlin-kotlin" {
 resource "buildkite_pipeline" "google-bazel-presubmit" {
   name = "Google Bazel Presubmit"
   repository = "https://bazel.googlesource.com/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }, { access_level = "BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
 }
@@ -1390,7 +1390,7 @@ resource "buildkite_pipeline" "google-bazel-presubmit" {
 resource "buildkite_pipeline" "rules-docker-docker" {
   name = "rules_docker :docker:"
   repository = "https://github.com/bazelbuild/rules_docker.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1406,7 +1406,7 @@ resource "buildkite_pipeline" "rules-docker-docker" {
 resource "buildkite_pipeline" "rules-sass" {
   name = "rules_sass"
   repository = "https://github.com/bazelbuild/rules_sass.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1422,7 +1422,7 @@ resource "buildkite_pipeline" "rules-sass" {
 resource "buildkite_pipeline" "rules-rust-rustlang" {
   name = "rules_rust :rustlang:"
   repository = "https://github.com/bazelbuild/rules_rust.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "rust" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1439,7 +1439,7 @@ resource "buildkite_pipeline" "rules-rust-rustlang" {
 resource "buildkite_pipeline" "rules-d" {
   name = "rules_d"
   repository = "https://github.com/bazelbuild/rules_d.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1455,7 +1455,7 @@ resource "buildkite_pipeline" "rules-d" {
 resource "buildkite_pipeline" "google-logging" {
   name = "Google Logging"
   repository = "https://github.com/google/glog.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/presubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1472,7 +1472,7 @@ resource "buildkite_pipeline" "google-logging" {
 resource "buildkite_pipeline" "gerrit" {
   name = "Gerrit"
   repository = "https://gerrit.googlesource.com/gerrit.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/gerrit.yml?$(date +%s) | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/gerrit.yml?$(date +%s) | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Triggered every 4 hours"
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1481,7 +1481,7 @@ resource "buildkite_pipeline" "gerrit" {
 resource "buildkite_pipeline" "bazel-toolchains" {
   name = "Bazel toolchains"
   repository = "https://github.com/bazelbuild/bazel-toolchains.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1499,7 +1499,7 @@ resource "buildkite_pipeline" "bazel-toolchains" {
 resource "buildkite_pipeline" "clion-plugin" {
   name = "CLion plugin"
   repository = "https://github.com/bazelbuild/intellij.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/clion.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/clion.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1515,7 +1515,7 @@ resource "buildkite_pipeline" "clion-plugin" {
 resource "buildkite_pipeline" "intellij-plugin" {
   name = "IntelliJ plugin"
   repository = "https://github.com/bazelbuild/intellij.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Tests the Bazel IntelliJ plugin with IntelliJ IDEA Community Edition"
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1533,7 +1533,7 @@ resource "buildkite_pipeline" "intellij-plugin" {
 resource "buildkite_pipeline" "tensorflow" {
   name = "TensorFlow"
   repository = "https://github.com/tensorflow/tensorflow.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/tensorflow.yml?$(date +%s) | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/tensorflow.yml?$(date +%s) | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Triggered every 4 hours"
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "tensorflow" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1542,7 +1542,7 @@ resource "buildkite_pipeline" "tensorflow" {
 resource "buildkite_pipeline" "bazel-at-head-plus-downstream" {
   name = "Bazel@HEAD + Downstream"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --file_config=.bazelci/postsubmit.yml | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py bazel_downstream_pipeline --file_config=.bazelci/postsubmit.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Test Bazel@HEAD + downstream projects@last_green_commit"
   default_branch = "master"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }, { access_level = "BUILD_AND_READ", slug = "downstream-pipeline-triggerers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1551,7 +1551,7 @@ resource "buildkite_pipeline" "bazel-at-head-plus-downstream" {
 resource "buildkite_pipeline" "rules-scala-scala" {
   name = "rules_scala :scala:"
   repository = "https://github.com/bazelbuild/rules_scala.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1567,7 +1567,7 @@ resource "buildkite_pipeline" "rules-scala-scala" {
 resource "buildkite_pipeline" "rules-jsonnet" {
   name = "rules_jsonnet"
   repository = "https://github.com/bazelbuild/rules_jsonnet.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1583,7 +1583,7 @@ resource "buildkite_pipeline" "rules-jsonnet" {
 resource "buildkite_pipeline" "rules-gwt" {
   name = "rules_gwt"
   repository = "https://github.com/bazelbuild/rules_gwt.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1599,7 +1599,7 @@ resource "buildkite_pipeline" "rules-gwt" {
 resource "buildkite_pipeline" "rules-groovy" {
   name = "rules_groovy"
   repository = "https://github.com/bazelbuild/rules_groovy.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1615,7 +1615,7 @@ resource "buildkite_pipeline" "rules-groovy" {
 resource "buildkite_pipeline" "rules-nodejs-nodejs" {
   name = "rules_nodejs :nodejs:"
   repository = "https://github.com/bazelbuild/rules_nodejs.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "stable"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1631,7 +1631,7 @@ resource "buildkite_pipeline" "rules-nodejs-nodejs" {
 resource "buildkite_pipeline" "re2" {
   name = "re2"
   repository = "https://github.com/google/re2.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/re2.yml?$(date +%s) | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/re2.yml?$(date +%s) | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Triggered every 4 hours"
   default_branch = "main"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1648,7 +1648,7 @@ resource "buildkite_pipeline" "re2" {
 resource "buildkite_pipeline" "buildtools" {
   name = "Buildtools"
   repository = "https://github.com/bazelbuild/buildtools.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1665,7 +1665,7 @@ resource "buildkite_pipeline" "buildtools" {
 resource "buildkite_pipeline" "protobuf" {
   name = "Protobuf"
   repository = "https://github.com/google/protobuf.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/protobuf.yml?$(date +%s) | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/protobuf.yml?$(date +%s) | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Triggered every 4 hours"
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1681,7 +1681,7 @@ resource "buildkite_pipeline" "protobuf" {
 resource "buildkite_pipeline" "rules-perl" {
   name = "rules_perl"
   repository = "https://github.com/bazelbuild/rules_perl.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1697,7 +1697,7 @@ resource "buildkite_pipeline" "rules-perl" {
 resource "buildkite_pipeline" "rules-k8s-k8s" {
   name = "rules_k8s :k8s:"
   repository = "https://github.com/bazelbuild/rules_k8s.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1713,7 +1713,7 @@ resource "buildkite_pipeline" "rules-k8s-k8s" {
 resource "buildkite_pipeline" "rules-go-golang" {
   name = "rules_go :golang:"
   repository = "https://github.com/bazelbuild/rules_go.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "rules-go" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1729,7 +1729,7 @@ resource "buildkite_pipeline" "rules-go-golang" {
 resource "buildkite_pipeline" "rules-closure-closure-compiler" {
   name = "rules_closure :closure-compiler:"
   repository = "https://github.com/bazelbuild/rules_closure.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1745,7 +1745,7 @@ resource "buildkite_pipeline" "rules-closure-closure-compiler" {
 resource "buildkite_pipeline" "rules-appengine-appengine" {
   name = "rules_appengine :appengine:"
   repository = "https://github.com/bazelbuild/rules_appengine.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1761,7 +1761,7 @@ resource "buildkite_pipeline" "rules-appengine-appengine" {
 resource "buildkite_pipeline" "bazel-watcher" {
   name = "Bazel watcher"
   repository = "https://github.com/bazelbuild/bazel-watcher.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1777,7 +1777,7 @@ resource "buildkite_pipeline" "bazel-watcher" {
 resource "buildkite_pipeline" "rules-python-python" {
   name = "rules_python :python:"
   repository = "https://github.com/bazelbuild/rules_python.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "main"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
@@ -1794,7 +1794,7 @@ resource "buildkite_pipeline" "rules-python-python" {
 resource "buildkite_pipeline" "subpar" {
   name = "Subpar"
   repository = "https://github.com/google/subpar.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/subpar.yml?$(date +%s) | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/subpar.yml?$(date +%s) | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Triggered every 4 hours"
   default_branch = "master"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
@@ -1809,7 +1809,7 @@ resource "buildkite_pipeline" "subpar" {
 resource "buildkite_pipeline" "bazel-bazel" {
   name = "Bazel :bazel:"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/postsubmit.yml --monitor_flaky_tests=true | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/postsubmit.yml --monitor_flaky_tests=true | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   branch_configuration = "master release-*"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]

--- a/pipelines/publish-bazel-binaries.yml
+++ b/pipelines/publish-bazel-binaries.yml
@@ -1,7 +1,7 @@
 steps:
   - command: |-
       curl -s "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)" -o bazelci.py
-      python3.6 bazelci.py bazel_publish_binaries_pipeline --file_config=.bazelci/build_bazel_binaries.yml | buildkite-agent pipeline upload
+      python3.6 bazelci.py bazel_publish_binaries_pipeline --file_config=.bazelci/build_bazel_binaries.yml | tee /dev/tty | buildkite-agent pipeline upload
     label: "Setup"
     agents:
       - "queue=default"


### PR DESCRIPTION
This PR prefix `| tee /dev/tty ` to various places of `| buildkite-agent pipeline upload` so the generated pipeline is logged before uploaded.

This is useful to debug cases where pipeline is not generated correctly e.g. https://buildkite.com/bazel-trusted/publish-bazel-binaries/builds/11112#686ded52-56e9-4db1-b834-b4baf41a1dd7.

Example run: https://buildkite.com/bazel-testing/bazel-bazel/builds/8468#de500897-b2cc-46b4-9b0d-7e6ab6e94f95