### PR TITLE
feat: Dockerfile for new Bazel releases

### DIFF
--- a/bazel/oci/Dockerfile
+++ b/bazel/oci/Dockerfile
@@ -1,0 +1,42 @@
+# ATTENTION: use the build.sh script to build this image.
+# ./build.sh <OCI_REPOSITORY> <BAZEL_VERSION>
+
+# When upgrading the base OS image, update the SHA as well to keep the image pinned.
+FROM ubuntu:20.04@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322 AS base_image
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" \
+    TZ="Etc/UTC" \
+    apt-get install --yes \
+        build-essential \
+        curl \
+        git \
+        openjdk-11-jdk \
+        unzip \
+        zip
+
+FROM base_image AS downloader
+
+ARG BAZEL_VERSION
+
+WORKDIR /var/bazel
+RUN curl \
+        --fail \
+        --fail-early \
+        --no-progress-meter \
+        --location \
+        --remote-name \
+        "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64"
+RUN curl \
+        --fail \
+        --fail-early \
+        --no-progress-meter \
+        --location \
+        "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64.sha256" \
+    | sha256sum --check \
+    && mv "bazel-${BAZEL_VERSION}-linux-x86_64" bazel \
+    && chmod +x bazel
+
+FROM base_image
+
+COPY --from=downloader /var/bazel/bazel /usr/local/bin/bazel

--- a/bazel/oci/Dockerfile
+++ b/bazel/oci/Dockerfile
@@ -16,5 +16,8 @@ RUN --mount=source=bazel/oci/install_bazel.sh,target=/mnt/install_bazel.sh,type=
 
 FROM base_image
 
+RUN useradd --system --create-home --home-dir=/home/ubuntu --shell=/bin/bash --gid=root --groups=sudo --uid=1000 ubuntu
+USER ubuntu
+WORKDIR /home/ubuntu
 COPY --from=downloader /var/bazel/bazel /usr/local/bin/bazel
 ENTRYPOINT ["/usr/local/bin/bazel"]

--- a/bazel/oci/Dockerfile
+++ b/bazel/oci/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && \
         curl \
         git \
         openjdk-11-jdk \
+        python3 \
+        python3-pip \
         unzip \
         zip
 
@@ -40,3 +42,4 @@ RUN curl \
 FROM base_image
 
 COPY --from=downloader /var/bazel/bazel /usr/local/bin/bazel
+ENTRYPOINT ["/usr/local/bin/bazel"]

--- a/bazel/oci/Dockerfile
+++ b/bazel/oci/Dockerfile
@@ -1,44 +1,18 @@
 # ATTENTION: use the build.sh script to build this image.
 # ./build.sh <OCI_REPOSITORY> <BAZEL_VERSION>
 
-# When upgrading the base OS image, update the SHA as well to keep the image pinned.
-FROM ubuntu:20.04@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322 AS base_image
+FROM ubuntu:16.04@sha256:0f71fa8d4d2d4292c3c617fda2b36f6dabe5c8b6e34c3dc5b0d17d4e704bd39c AS base_image
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" \
-    TZ="Etc/UTC" \
-    apt-get install --yes \
-        build-essential \
-        curl \
-        git \
-        openjdk-11-jdk \
-        python3 \
-        python3-pip \
-        python-is-python3 \
-        unzip \
-        zip
+RUN --mount=source=bazel/oci/install_packages.sh,target=/mnt/install_packages.sh,type=bind \
+    /mnt/install_packages.sh
 
 FROM base_image AS downloader
 
 ARG BAZEL_VERSION
 
 WORKDIR /var/bazel
-RUN curl \
-        --fail \
-        --fail-early \
-        --no-progress-meter \
-        --location \
-        --remote-name \
-        "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64"
-RUN curl \
-        --fail \
-        --fail-early \
-        --no-progress-meter \
-        --location \
-        "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64.sha256" \
-    | sha256sum --check \
-    && mv "bazel-${BAZEL_VERSION}-linux-x86_64" bazel \
-    && chmod +x bazel
+RUN --mount=source=bazel/oci/install_bazel.sh,target=/mnt/install_bazel.sh,type=bind \
+    /mnt/install_bazel.sh
 
 FROM base_image
 

--- a/bazel/oci/Dockerfile
+++ b/bazel/oci/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
         openjdk-11-jdk \
         python3 \
         python3-pip \
+        python-is-python3 \
         unzip \
         zip
 

--- a/bazel/oci/build.sh
+++ b/bazel/oci/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+readonly OCI_REPOSITORY=$1
+readonly BAZEL_VERSION=$2
+
+set -o errexit -o nounset -o pipefail
+
+function print_usage() {
+    >&2 echo "Usage: $0 <OCI_REPOSITORY> <BAZEL_VERSION>"
+}
+
+if [ -z "${OCI_REPOSITORY}" ]; then
+    >&2 echo "ERROR: missing 'OCI_REPOSITORY' argument"
+    print_usage
+    exit 1
+fi
+
+if [ -z "${BAZEL_VERSION}" ]; then
+    >&2 echo "ERROR: missing 'BAZEL_VERSION' argument"
+    print_usage
+    exit 1
+fi
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+readonly GIT_ROOT
+
+if docker buildx version 2>&1 1>/dev/null; then
+    buildx="buildx"
+fi
+
+docker ${buildx:+"${buildx}"} build \
+    --file "${GIT_ROOT}/bazel/oci/Dockerfile" \
+    --tag "${OCI_REPOSITORY}:${BAZEL_VERSION}" \
+    --build-arg BAZEL_VERSION="${BAZEL_VERSION}" \
+    "${GIT_ROOT}"

--- a/bazel/oci/install_bazel.sh
+++ b/bazel/oci/install_bazel.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail
+
+curl \
+    --fail \
+    --location \
+    --remote-name \
+    "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64"
+
+curl \
+    --fail \
+    --location \
+    "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64.sha256" \
+    | sha256sum --check
+
+mv "bazel-${BAZEL_VERSION}-linux-x86_64" bazel
+chmod +x bazel

--- a/bazel/oci/install_packages.sh
+++ b/bazel/oci/install_packages.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail
+
+apt-get update
+
+export DEBIAN_FRONTEND="noninteractive"
+export TZ="Etc/UTC"
+
+apt-get install --yes \
+    build-essential \
+    curl \
+    git \
+    openjdk-8-jdk \
+    python3 \
+    python3-pip \
+    unzip \
+    zip
+
+ln -s "$(which python3)" /usr/bin/python


### PR DESCRIPTION
Part of https://github.com/bazelbuild/continuous-integration/issues/1060.

Used [dive](https://github.com/wagoodman/dive) to analyse the previously released image. There are still some packages that I may be missing from the 3.x release series.

Let me know if you spot any missing packages.