### PR TITLE
Re-enable rules_haskell in downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -325,7 +325,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/tweag/rules_haskell.git",
         "http_config": "https://raw.githubusercontent.com/tweag/rules_haskell/master/.bazelci/presubmit.yml",
         "pipeline_slug": "rules-haskell-haskell",
-        "disabled_reason": "https://github.com/tweag/rules_haskell/issues/1650",
     },
     "rules_jsonnet": {
         "git_repository": "https://github.com/bazelbuild/rules_jsonnet.git",


### PR DESCRIPTION
rules_haskell has been fixed in:
https://github.com/tweag/rules_haskell/issues/1650
https://github.com/tweag/rules_haskell/issues/1657