### PR TITLE
Dsiable Bazel examples and rules_docker in downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -115,6 +115,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/examples.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/examples/master/.bazelci/presubmit.yml",
         "pipeline_slug": "bazel-bazel-examples",
+        "disabled_reason": "https://github.com/bazelbuild/examples/pull/233",     
     },
     "Bazel Federation": {
         "git_repository": "https://github.com/bazelbuild/bazel-federation.git",
@@ -293,6 +294,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/rules_docker.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_docker/master/.bazelci/presubmit.yml",
         "pipeline_slug": "rules-docker-docker",
+        "disabled_reason": "https://github.com/bazelbuild/rules_docker/issues/1988",
     },
     "rules_dotnet": {
         "git_repository": "https://github.com/bazelbuild/rules_dotnet.git",


### PR DESCRIPTION
Due to https://github.com/bazelbuild/examples/pull/233 and https://github.com/bazelbuild/rules_docker/issues/1988