### PR TITLE
Fix Bazel Auto Sheriff for bisecting

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -575,7 +575,7 @@ DEFAULT_PLATFORM = "ubuntu1804"
 # In order to test that "the one Linux binary" that we build for our official releases actually
 # works on all Linux distributions that we test on, we use the Linux binary built on our official
 # release platform for all Linux downstream tests.
-LINUX_BINARY_PLATFORM = "centos7_java11_devtoolset10"
+LINUX_BINARY_PLATFORM = "centos7"
 
 DEFAULT_XCODE_VERSION = "13.0"
 XCODE_VERSION_REGEX = re.compile(r"^\d+\.\d+(\.\d+)?$")

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -730,6 +730,7 @@ P9w8kNhEbw==
             "branch": "master",
             "message": message if message else f"Trigger build at {commit}",
             "env": env,
+            "ignore_pipeline_branch_filters": "true",
         }
         response = requests.post(url + "?access_token=" + self._token, json=data)
         BuildkiteClient._check_response(response, requests.codes.created)


### PR DESCRIPTION
https://buildkite.com/bazel/bazel-auto-sheriff-face-with-cowboy-hat/builds/781
The Bazel Auto Sheriff failed to trigger culprit finder due to
```
requests.exceptions.HTTPError: 422 Client Error: Unprocessable Entity for url: https://api.buildkite.com/v2/organizations/bazel/pipelines/culprit-finder/builds?access_token=005c1e7c3ee4c9dcf74f48ac631778434d09f2cc
 
Exit code: 422
Response:
 {
  "message": "Branches have been disabled for this pipeline"
}
```

This is because the culprit finder turned off build triggers and BuildKite prevents the pipeline from being triggered by API.
Applying a workaround suggested by https://forum.buildkite.community/t/request-build-error-branches-have-been-disabled-for-this-pipeline/1463