### PR TITLE
Update protobuf.yml

### DIFF
--- a/pipelines/protobuf.yml
+++ b/pipelines/protobuf.yml
@@ -22,8 +22,6 @@ platforms:
       - "//java/..."
       - "//:cc_proto_blacklist_test"
       - "-//java/core:conformance_test"
-      - "-//java/kotlin:all"
-      - "-//java/kotlin-lite:all"
       - "-//java/lite:conformance_test"
       - "-//:protobuf_test"
       - "-//:py_descriptor_database_test"


### PR DESCRIPTION
Remove kotlin test exclusions for windows now that they have been fixed for windows: https://github.com/protocolbuffers/protobuf/pull/9428