### PR TITLE
Suggestion to widen up new projects to rules sets

### DIFF
--- a/.github/ISSUE_TEMPLATE/adding-your-project-to-bazel-ci.md
+++ b/.github/ISSUE_TEMPLATE/adding-your-project-to-bazel-ci.md
@@ -9,9 +9,10 @@ assignees: ''
 
 Thank you for your interest in adding your project to Bazel CI.
 
-At the moment we're operating at capacity and cannot add new projects except for rules and projects maintained under the bazelbuild GitHub organization.
+At the moment we're operating at capacity and cannot add new projects except for projects maintained under the bazelbuild GitHub organization and for rules. To request a review for being added to Bazel CI, please follow the instructions below.
 
 - [ ] My project is part of the bazelbuild GitHub organization.
+- [ ] My project is a rules set of a GitHub organization other than bazelbuild.
 - [ ] I want to test the following project on Bazel CI: [URL_TO_GIT_HUB_PROJECT]
 - [ ] I confirm that the project has a `.bazelci/presubmit.yml` file.
 


### PR DESCRIPTION
Following internal discussions, bottlenecks of CI haven't been (smaller) rules projects.