### PR TITLE
Remove 'publish_binary' property from Win ARM64

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -562,7 +562,7 @@ PLATFORMS = {
         "name": "Windows ARM64 (OpenJDK 11, VS2017)",
         "emoji-name": ":windows: arm64 (OpenJDK 11, VS2017)",
         "downstream-root": "c:/b/${BUILDKITE_AGENT_NAME}/${BUILDKITE_ORGANIZATION_SLUG}-downstream-projects",
-        "publish_binary": ["windows_arm64"],
+        "publish_binary": [],
         # TODO(pcloudy): Switch to windows_arm64 queue when Windows ARM64 machines are available,
         # current we just use x86_64 machines to do cross compile.
         "queue": "windows",


### PR DESCRIPTION
The trusted CI pipeline fails since we don't actually publish binaries for this platform yet (https://buildkite.com/bazel-trusted/publish-bazel-binaries/builds/11959#2fd68159-74a5-48d7-b95b-9f1096e67807)