### PR TITLE
Publish Bazel binaries for release branches

### DIFF
--- a/buildkite/terraform/bazel-trusted/main.tf
+++ b/buildkite/terraform/bazel-trusted/main.tf
@@ -205,7 +205,7 @@ resource "buildkite_pipeline" "publish-bazel-binaries" {
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/publish-bazel-binaries.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   description = "Publish Bazel binaries to GCS (http://storage.googleapis.com/bazel-builds/metadata/latest.json)"
   default_branch = "master"
-  branch_configuration = "master"
+  branch_configuration = "master release-*"
   team = [{ access_level = "READ_ONLY", slug = "everyone" }]
   provider_settings {
     trigger_mode = "code"


### PR DESCRIPTION
This will make the publish bazel binaries pipeline also build bazel binaries at commits from the release branches. Making it easier to fetch Bazel binaries at those commits with Bazelisk.