### PR TITLE
Remove DocGen pipelines (docs + website)

### DIFF
--- a/buildkite/terraform/bazel-trusted/main.tf
+++ b/buildkite/terraform/bazel-trusted/main.tf
@@ -33,39 +33,9 @@ resource "buildkite_pipeline" "bazel-arm64" {
   }
 }
 
-resource "buildkite_pipeline" "docgen-bazel-website" {
-  name = "DocGen: Bazel-website"
-  repository = "https://github.com/bazelbuild/bazel-website.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
-  default_branch = "master"
-  branch_configuration = "master"
-  team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-docs" }]
-  provider_settings {
-    trigger_mode = "code"
-    skip_pull_request_builds_for_existing_commits = true
-    prefix_pull_request_fork_branch_names = true
-    build_branches = true
-  }
-}
-
 resource "buildkite_pipeline" "docgen-bazel-blog" {
   name = "DocGen: Bazel-blog"
   repository = "https://github.com/bazelbuild/bazel-blog.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
-  default_branch = "master"
-  branch_configuration = "master"
-  team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-docs" }]
-  provider_settings {
-    trigger_mode = "code"
-    skip_pull_request_builds_for_existing_commits = true
-    prefix_pull_request_fork_branch_names = true
-    build_branches = true
-  }
-}
-
-resource "buildkite_pipeline" "docgen-bazel" {
-  name = "DocGen: Bazel"
-  repository = "https://github.com/bazelbuild/bazel.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
   default_branch = "master"
   branch_configuration = "master"

--- a/buildkite/terraform/bazel/main.tf
+++ b/buildkite/terraform/bazel/main.tf
@@ -233,14 +233,6 @@ resource "buildkite_pipeline" "distributed-point-functions" {
   }
 }
 
-resource "buildkite_pipeline" "google-bazel-docs-staging" {
-  name = "Google Bazel Docs Staging"
-  repository = "https://bazel.googlesource.com/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace"] } })
-  default_branch = "master"
-  team = [{ access_level = "READ_ONLY", slug = "bazel" }, { access_level = "BUILD_AND_READ", slug = "googlers" }]
-}
-
 resource "buildkite_pipeline" "cargo-raze" {
   name = "Cargo-Raze"
   repository = "https://github.com/google/cargo-raze.git"

--- a/docgen/docgen.py
+++ b/docgen/docgen.py
@@ -35,26 +35,8 @@ Settings = collections.namedtuple(
 BUILDKITE_BUILD_NUMBER = os.getenv("BUILDKITE_BUILD_NUMBER")
 
 
-def rewrite_staging_urls(content):
-    new_content = content.replace(
-        "docs.bazel.build", "docs-staging.bazel.build/{}".format(BUILDKITE_BUILD_NUMBER)
-    )
-    # Hack to get search working
-    new_content = new_content.replace("009927877080525621790:2pxlpaexqpc", "12ee759976b5ec02f", 1)
-    return new_content.replace('"/', '"/{}/'.format(BUILDKITE_BUILD_NUMBER))
-
-
 DOCGEN_SETTINGS = {
     "bazel-trusted": {
-        "https://github.com/bazelbuild/bazel.git": Settings(
-            target="//site",
-            build_flags=[],
-            output_dir="bazel-bin/site/site-build",
-            gcs_bucket="docs.bazel.build",
-            gcs_subdir="",
-            landing_page="versions/master/bazel-overview.html",
-            rewrite=None,
-        ),
         "https://github.com/bazelbuild/bazel-blog.git": Settings(
             target="//:site",
             build_flags=[],
@@ -63,26 +45,6 @@ DOCGEN_SETTINGS = {
             gcs_subdir="",
             landing_page="index.html",
             rewrite=None,
-        ),
-        "https://github.com/bazelbuild/bazel-website.git": Settings(
-            target="//:site",
-            build_flags=[],
-            output_dir="bazel-bin/site-build",
-            gcs_bucket="www.bazel.build",
-            gcs_subdir="",
-            landing_page="index.html",
-            rewrite=None,
-        ),
-    },
-    "bazel": {
-        "https://bazel.googlesource.com/bazel.git": Settings(
-            target="//site",
-            build_flags=bazelci.remote_caching_flags(PLATFORM),
-            output_dir="bazel-bin/site/site-build",
-            gcs_bucket="docs-staging.bazel.build",
-            gcs_subdir=BUILDKITE_BUILD_NUMBER,
-            landing_page="versions/master/bazel-overview.html",
-            rewrite=rewrite_staging_urls,
         ),
     },
 }


### PR DESCRIPTION
They are no longer needed since we migrated the website to a new host.

docs.bazel.build will stay around for the near future, but its contents remain frozen (for historical purposes)

We have to keep the blog pipeline for now, though.