### PR TITLE
Release: build release binaries for Windows ARM64 platform

### DIFF
--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -244,6 +244,37 @@ steps:
       cd artifacts
       buildkite-agent artifact upload "*"
 
+  - label: Windows (arm64)
+    agents:
+      # TODO(pcloudy): Switch to windows_arm64 queue if Windows ARM64 machines are available,
+      # current we just use x86_64 machines to do cross compile.
+      - queue=windows
+    command: |
+      set BUILDKITE_MESSAGE=%BUILDKITE_MESSAGE:~0,1000%
+
+      git fetch origin ${BUILDKITE_BRANCH}
+      git checkout ${BUILDKITE_BRANCH}
+
+      buildkite-agent meta-data get "release_name" > release_name.txt
+      SET /p RELEASE_NAME=<release_name.txt
+      DEL /q release_name.txt
+
+      echo Release: %RELEASE_NAME%
+
+      bazel build //src:bazel.exe
+      mkdir output
+      copy bazel-bin\src\bazel.exe output\bazel.exe
+
+      output\bazel build -c opt --cpu=x64_arm64_windows --copt=-w --host_copt=-w --stamp --embed_label %RELEASE_NAME% src/bazel src/bazel_nojdk scripts/packages/bazel.zip
+
+      mkdir artifacts
+      move bazel-bin\src\bazel artifacts\bazel-%RELEASE_NAME%-windows-arm64.exe
+      move bazel-bin\src\bazel_nojdk artifacts\bazel_nojdk-%RELEASE_NAME%-windows-arm64.exe
+      move bazel-bin\scripts\packages\bazel.zip artifacts\bazel-%RELEASE_NAME%-windows-arm64.zip
+
+      cd artifacts
+      buildkite-agent artifact upload "*"
+
   - wait
 
   - label: "Test on CentOS 7"
@@ -371,6 +402,27 @@ steps:
       buildkite-agent artifact download bazel-%RELEASE_NAME%-windows-x86_64.exe .
 
       bazel-%RELEASE_NAME%-windows-x86_64.exe info
+
+  - label: "Test on Windows (arm64)"
+    agents:
+      # TODO(pcloudy): Switch to windows_arm64 queue if Windows ARM64 machines are available,
+      # current we just use x86_64 machines to do cross compile.
+      - queue=windows
+    command: |
+      set BUILDKITE_MESSAGE=%BUILDKITE_MESSAGE:~0,1000%
+
+      git fetch origin ${BUILDKITE_BRANCH}
+      git checkout ${BUILDKITE_BRANCH}
+
+      buildkite-agent meta-data get "release_name" > release_name.txt
+      SET /p RELEASE_NAME=<release_name.txt
+      DEL /q release_name.txt
+
+      echo Release: %RELEASE_NAME%
+
+      buildkite-agent artifact download bazel-%RELEASE_NAME%-windows-arm64.exe .
+
+      file bazel-%RELEASE_NAME%-windows-arm64.exe | grep "Aarch64"
 
   - wait
 


### PR DESCRIPTION
The release pipeline will now build Windows ARM64 binaries by cross-compiling from a x64 Windows VM, we do the same for Apple Silicon right now.

We should add release notes to clarify that ARM64 binaries (for Linux, macOS, Windows) are not tested fully on Bazel CI (but will change for Apple Silicon soon).