### PR TITLE
Disable rules_nodejs in Bazel downstream pipeline

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -359,6 +359,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/rules_nodejs.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_nodejs/stable/.bazelci/presubmit.yml",
         "pipeline_slug": "rules-nodejs-nodejs",
+        "disabled_reason": "https://github.com/bazelbuild/rules_nodejs/issues/3328",
     },
     "rules_perl": {
         "git_repository": "https://github.com/bazelbuild/rules_perl.git",


### PR DESCRIPTION
Due to https://github.com/bazelbuild/rules_nodejs/issues/3328