### PR TITLE
Replace uses of --nomaster_bazelrc

### DIFF
--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -324,7 +324,7 @@ def handle_already_flipped_flags(failed_jobs_per_flag, details_per_flag):
 def get_bazel_major_version():
     # Get bazel major version on CI, eg. 0.21 from "Build label: 0.21.0\n..."
     output = subprocess.check_output(
-        ["bazel", "--ignore_all_rc_files", "--bazelrc=/dev/null", "version"]
+        ["bazel", "--ignore_all_rc_files", "version"]
     ).decode("utf-8")
     return output.split()[2].rsplit(".", 1)[0]
 

--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -324,7 +324,7 @@ def handle_already_flipped_flags(failed_jobs_per_flag, details_per_flag):
 def get_bazel_major_version():
     # Get bazel major version on CI, eg. 0.21 from "Build label: 0.21.0\n..."
     output = subprocess.check_output(
-        ["bazel", "--nomaster_bazelrc", "--bazelrc=/dev/null", "version"]
+        ["bazel", "--ignore_all_rc_files", "--bazelrc=/dev/null", "version"]
     ).decode("utf-8")
     return output.split()[2].rsplit(".", 1)[0]
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2012,7 +2012,7 @@ def calculate_targets(task_config, platform, bazel_binary, build_only, test_only
         output = execute_command_and_get_output(
             [bazel_binary]
             + common_startup_flags(platform)
-            + ["--nosystem_rc", "--nohome_rc", "--bazelrc=/dev/null", "query", index_targets_query],
+            + ["--ignore_all_rc_files", "query", index_targets_query],
             print_output=False,
         )
         index_targets += output.strip().split("\n")
@@ -2055,9 +2055,7 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
         [bazel_binary]
         + common_startup_flags(platform)
         + [
-            "--nosystem_rc",
-            "--nohome_rc",
-            "--bazelrc=/dev/null",
+            "--ignore_all_rc_files",
             "query",
             "tests(set({})){}{}".format(
                 " ".join("'{}'".format(t) for t in included_targets),

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1475,12 +1475,12 @@ def print_bazel_version_info(bazel_binary, platform):
     version_output = execute_command_and_get_output(
         [bazel_binary]
         + common_startup_flags(platform)
-        + ["--nomaster_bazelrc", "--bazelrc=/dev/null", "version"]
+        + ["--ignore_all_rc_files", "--bazelrc=/dev/null", "version"]
     )
     execute_command(
         [bazel_binary]
         + common_startup_flags(platform)
-        + ["--nomaster_bazelrc", "--bazelrc=/dev/null", "info"]
+        + ["--ignore_all_rc_files", "--bazelrc=/dev/null", "info"]
     )
 
     match = BUILD_LABEL_PATTERN.search(version_output)
@@ -2012,7 +2012,7 @@ def calculate_targets(task_config, platform, bazel_binary, build_only, test_only
         output = execute_command_and_get_output(
             [bazel_binary]
             + common_startup_flags(platform)
-            + ["--nomaster_bazelrc", "--bazelrc=/dev/null", "query", index_targets_query],
+            + ["--ignore_all_rc_files", "--bazelrc=/dev/null", "query", index_targets_query],
             print_output=False,
         )
         index_targets += output.strip().split("\n")
@@ -2055,7 +2055,7 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
         [bazel_binary]
         + common_startup_flags(platform)
         + [
-            "--nomaster_bazelrc",
+            "--ignore_all_rc_files",
             "--bazelrc=/dev/null",
             "query",
             "tests(set({})){}{}".format(

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2012,7 +2012,7 @@ def calculate_targets(task_config, platform, bazel_binary, build_only, test_only
         output = execute_command_and_get_output(
             [bazel_binary]
             + common_startup_flags(platform)
-            + ["--ignore_all_rc_files", "--bazelrc=/dev/null", "query", index_targets_query],
+            + ["--nosystem_rc", "--nohome_rc", "--bazelrc=/dev/null", "query", index_targets_query],
             print_output=False,
         )
         index_targets += output.strip().split("\n")
@@ -2055,7 +2055,8 @@ def expand_test_target_patterns(bazel_binary, platform, test_targets):
         [bazel_binary]
         + common_startup_flags(platform)
         + [
-            "--ignore_all_rc_files",
+            "--nosystem_rc",
+            "--nohome_rc",
             "--bazelrc=/dev/null",
             "query",
             "tests(set({})){}{}".format(

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1475,12 +1475,12 @@ def print_bazel_version_info(bazel_binary, platform):
     version_output = execute_command_and_get_output(
         [bazel_binary]
         + common_startup_flags(platform)
-        + ["--ignore_all_rc_files", "--bazelrc=/dev/null", "version"]
+        + ["--ignore_all_rc_files", "version"]
     )
     execute_command(
         [bazel_binary]
         + common_startup_flags(platform)
-        + ["--ignore_all_rc_files", "--bazelrc=/dev/null", "info"]
+        + ["--ignore_all_rc_files", "info"]
     )
 
     match = BUILD_LABEL_PATTERN.search(version_output)

--- a/pipelines/build-embedded-minimized-jdk.yml
+++ b/pipelines/build-embedded-minimized-jdk.yml
@@ -1,6 +1,6 @@
 steps:
   - command: |-
-      bazel --nomaster_bazelrc --bazelrc=/dev/null version
+      bazel --ignore_all_rc_files --bazelrc=/dev/null version
       bazel build //src:embedded_jdk_minimal //src:embedded_jdk_allmodules
       buildkite-agent artifact upload "./bazel-bin/src/*_jdk.tar.gz"
       gsutil cp ./bazel-bin/src/minimal_jdk.tar.gz gs://bazel-mirror/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64-minimal-$(git rev-parse HEAD)-$(date +%s).tar.gz
@@ -31,13 +31,13 @@ steps:
           - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
           - "/var/run/docker.sock:/var/run/docker.sock"
 
-  - command: "powershell -Command \"bazel --nomaster_bazelrc --bazelrc=NUL version ; if (\\$LastExitCode -ne 0) { exit 1 } ; bazel build //src:embedded_jdk_minimal //src:embedded_jdk_allmodules ; if (\\$LastExitCode -ne 0) { exit 1 } ; buildkite-agent artifact upload ./bazel-bin/src/minimal_jdk.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ; buildkite-agent artifact upload ./bazel-bin/src/allmodules_jdk.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ; \\$revision=(git rev-parse HEAD) ; if (\\$LastExitCode -ne 0) { exit 1 } ; \\$epoch=(date +%%s) ; if (\\$LastExitCode -ne 0) { exit 1 } ; gsutil cp ./bazel-bin/src/minimal_jdk.zip gs://bazel-mirror/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64-minimal-\\${revision}-\\${epoch}.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ; gsutil cp ./bazel-bin/src/allmodules_jdk.zip gs://bazel-mirror/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64-allmodules-\\${revision}-\\${epoch}.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ;\""
+  - command: "powershell -Command \"bazel --ignore_all_rc_files --bazelrc=NUL version ; if (\\$LastExitCode -ne 0) { exit 1 } ; bazel build //src:embedded_jdk_minimal //src:embedded_jdk_allmodules ; if (\\$LastExitCode -ne 0) { exit 1 } ; buildkite-agent artifact upload ./bazel-bin/src/minimal_jdk.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ; buildkite-agent artifact upload ./bazel-bin/src/allmodules_jdk.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ; \\$revision=(git rev-parse HEAD) ; if (\\$LastExitCode -ne 0) { exit 1 } ; \\$epoch=(date +%%s) ; if (\\$LastExitCode -ne 0) { exit 1 } ; gsutil cp ./bazel-bin/src/minimal_jdk.zip gs://bazel-mirror/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64-minimal-\\${revision}-\\${epoch}.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ; gsutil cp ./bazel-bin/src/allmodules_jdk.zip gs://bazel-mirror/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64-allmodules-\\${revision}-\\${epoch}.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ;\""
     label: ":windows:"
     agents:
       - "queue=windows"
 
   - command: |-
-      bazel --nomaster_bazelrc --bazelrc=/dev/null version
+      bazel --ignore_all_rc_files --bazelrc=/dev/null version
       bazel build //src:embedded_jdk_minimal //src:embedded_jdk_allmodules
       buildkite-agent artifact upload "./bazel-bin/src/*_jdk.tar.gz"
       gsutil cp ./bazel-bin/src/minimal_jdk.tar.gz gs://bazel-mirror/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64-minimal-$(git rev-parse HEAD)-$(date +%s).tar.gz

--- a/pipelines/build-embedded-minimized-jdk.yml
+++ b/pipelines/build-embedded-minimized-jdk.yml
@@ -1,6 +1,6 @@
 steps:
   - command: |-
-      bazel --ignore_all_rc_files --bazelrc=/dev/null version
+      bazel --ignore_all_rc_files version
       bazel build //src:embedded_jdk_minimal //src:embedded_jdk_allmodules
       buildkite-agent artifact upload "./bazel-bin/src/*_jdk.tar.gz"
       gsutil cp ./bazel-bin/src/minimal_jdk.tar.gz gs://bazel-mirror/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64-minimal-$(git rev-parse HEAD)-$(date +%s).tar.gz
@@ -31,13 +31,13 @@ steps:
           - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
           - "/var/run/docker.sock:/var/run/docker.sock"
 
-  - command: "powershell -Command \"bazel --ignore_all_rc_files --bazelrc=NUL version ; if (\\$LastExitCode -ne 0) { exit 1 } ; bazel build //src:embedded_jdk_minimal //src:embedded_jdk_allmodules ; if (\\$LastExitCode -ne 0) { exit 1 } ; buildkite-agent artifact upload ./bazel-bin/src/minimal_jdk.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ; buildkite-agent artifact upload ./bazel-bin/src/allmodules_jdk.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ; \\$revision=(git rev-parse HEAD) ; if (\\$LastExitCode -ne 0) { exit 1 } ; \\$epoch=(date +%%s) ; if (\\$LastExitCode -ne 0) { exit 1 } ; gsutil cp ./bazel-bin/src/minimal_jdk.zip gs://bazel-mirror/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64-minimal-\\${revision}-\\${epoch}.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ; gsutil cp ./bazel-bin/src/allmodules_jdk.zip gs://bazel-mirror/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64-allmodules-\\${revision}-\\${epoch}.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ;\""
+  - command: "powershell -Command \"bazel --ignore_all_rc_files version ; if (\\$LastExitCode -ne 0) { exit 1 } ; bazel build //src:embedded_jdk_minimal //src:embedded_jdk_allmodules ; if (\\$LastExitCode -ne 0) { exit 1 } ; buildkite-agent artifact upload ./bazel-bin/src/minimal_jdk.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ; buildkite-agent artifact upload ./bazel-bin/src/allmodules_jdk.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ; \\$revision=(git rev-parse HEAD) ; if (\\$LastExitCode -ne 0) { exit 1 } ; \\$epoch=(date +%%s) ; if (\\$LastExitCode -ne 0) { exit 1 } ; gsutil cp ./bazel-bin/src/minimal_jdk.zip gs://bazel-mirror/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64-minimal-\\${revision}-\\${epoch}.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ; gsutil cp ./bazel-bin/src/allmodules_jdk.zip gs://bazel-mirror/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64-allmodules-\\${revision}-\\${epoch}.zip ; if (\\$LastExitCode -ne 0) { exit 1 } ;\""
     label: ":windows:"
     agents:
       - "queue=windows"
 
   - command: |-
-      bazel --ignore_all_rc_files --bazelrc=/dev/null version
+      bazel --ignore_all_rc_files version
       bazel build //src:embedded_jdk_minimal //src:embedded_jdk_allmodules
       buildkite-agent artifact upload "./bazel-bin/src/*_jdk.tar.gz"
       gsutil cp ./bazel-bin/src/minimal_jdk.tar.gz gs://bazel-mirror/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64-minimal-$(git rev-parse HEAD)-$(date +%s).tar.gz

--- a/pipelines/java_tools-binaries.yml
+++ b/pipelines/java_tools-binaries.yml
@@ -1,6 +1,6 @@
 steps:
   - command: |-
-      bazel --ignore_all_rc_files --bazelrc=/dev/null version
+      bazel --ignore_all_rc_files version
       ./src/upload_all_java_tools.sh
     label: ":ubuntu:"
     agents:
@@ -28,13 +28,13 @@ steps:
           - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
           - "/var/run/docker.sock:/var/run/docker.sock"
 
-  - command: "powershell -Command \"bazel --ignore_all_rc_files --bazelrc=NUL version ; if (\\$LastExitCode -ne 0) { exit 1 } ; sh ./src/upload_all_java_tools.sh ; if (\\$LastExitCode -ne 0) { exit 1 } ;\""
+  - command: "powershell -Command \"bazel --ignore_all_rc_files version ; if (\\$LastExitCode -ne 0) { exit 1 } ; sh ./src/upload_all_java_tools.sh ; if (\\$LastExitCode -ne 0) { exit 1 } ;\""
     label: ":windows:"
     agents:
       - "queue=windows"
 
   - command: |-
-      bazel --ignore_all_rc_files --bazelrc=/dev/null version
+      bazel --ignore_all_rc_files version
       ./src/upload_all_java_tools.sh
     env:
       BAZEL_USE_CPP_ONLY_TOOLCHAIN: "1"

--- a/pipelines/java_tools-binaries.yml
+++ b/pipelines/java_tools-binaries.yml
@@ -1,6 +1,6 @@
 steps:
   - command: |-
-      bazel --nomaster_bazelrc --bazelrc=/dev/null version
+      bazel --ignore_all_rc_files --bazelrc=/dev/null version
       ./src/upload_all_java_tools.sh
     label: ":ubuntu:"
     agents:
@@ -28,13 +28,13 @@ steps:
           - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
           - "/var/run/docker.sock:/var/run/docker.sock"
 
-  - command: "powershell -Command \"bazel --nomaster_bazelrc --bazelrc=NUL version ; if (\\$LastExitCode -ne 0) { exit 1 } ; sh ./src/upload_all_java_tools.sh ; if (\\$LastExitCode -ne 0) { exit 1 } ;\""
+  - command: "powershell -Command \"bazel --ignore_all_rc_files --bazelrc=NUL version ; if (\\$LastExitCode -ne 0) { exit 1 } ; sh ./src/upload_all_java_tools.sh ; if (\\$LastExitCode -ne 0) { exit 1 } ;\""
     label: ":windows:"
     agents:
       - "queue=windows"
 
   - command: |-
-      bazel --nomaster_bazelrc --bazelrc=/dev/null version
+      bazel --ignore_all_rc_files --bazelrc=/dev/null version
       ./src/upload_all_java_tools.sh
     env:
       BAZEL_USE_CPP_ONLY_TOOLCHAIN: "1"


### PR DESCRIPTION
This was removed by https://github.com/bazelbuild/bazel/commit/96c8a9073807c9e97635ddafe2ed0365a9318d6f

Example failure: https://buildkite.com/bazel/rules-apple-darwin/builds/5205#8d2e5417-165b-4921-a03a-5a4fde2f9e40