### PR TITLE
Run Bazel test suite on Linux ARM64 machine with ubuntu 2004 docker container

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -507,6 +507,15 @@ PLATFORMS = {
         "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/ubuntu2004-java11",
         "python": "python3.8",
     },
+    "ubuntu2004_arm64": {
+        "name": "Ubuntu 20.04 LTS ARM64 (OpenJDK 11, gcc 9.3.0)",
+        "emoji-name": ":ubuntu: 20.04 LTS (OpenJDK 11, gcc 9.3.0)",
+        "downstream-root": "/var/lib/buildkite-agent/builds/${BUILDKITE_AGENT_NAME}/${BUILDKITE_ORGANIZATION_SLUG}-downstream-projects",
+        "publish_binary": [],
+        "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/ubuntu2004-java11",
+        "python": "python3.8",
+        "queue": "arm64",
+    },
     "kythe_ubuntu2004": {
         "name": "Kythe (Ubuntu 20.04 LTS, OpenJDK 11, gcc 9.3.0)",
         "emoji-name": "Kythe (:ubuntu: 20.04 LTS, OpenJDK 11, gcc 9.3.0)",

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1712,6 +1712,9 @@ def remote_caching_flags(platform, accept_cached=True):
     # Whenever the remote cache was known to have been poisoned increase the number below
     platform_cache_key += ["cache-poisoning-20210811".encode("utf-8")]
 
+    if platform == "ubuntu2004_arm64":
+        return []
+
     if platform == "macos":
         platform_cache_key += [
             # macOS version:

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2290,7 +2290,7 @@ def create_docker_step(label, image, commands=None, additional_env_vars=None, qu
         "agents": {"queue": queue},
         "plugins": {
             "docker#v3.8.0": {
-                "always-pull": True,
+                # "always-pull": True,
                 "environment": env,
                 "image": image,
                 "network": "host",

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -51,7 +51,7 @@ THIS_IS_SPARTA = True
 
 CLOUD_PROJECT = "bazel-public" if THIS_IS_TRUSTED else "bazel-untrusted"
 
-GITHUB_BRANCH = {"bazel": "pcloudy-test", "bazel-trusted": "master", "bazel-testing": "testing"}[
+GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "testing"}[
     BUILDKITE_ORG
 ]
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -509,7 +509,7 @@ PLATFORMS = {
     },
     "ubuntu2004_arm64": {
         "name": "Ubuntu 20.04 LTS ARM64 (OpenJDK 11, gcc 9.3.0)",
-        "emoji-name": ":ubuntu: 20.04 LTS (OpenJDK 11, gcc 9.3.0)",
+        "emoji-name": ":ubuntu: 20.04 LTS ARM64 (OpenJDK 11, gcc 9.3.0)",
         "downstream-root": "/var/lib/buildkite-agent/builds/${BUILDKITE_AGENT_NAME}/${BUILDKITE_ORGANIZATION_SLUG}-downstream-projects",
         "publish_binary": [],
         "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/ubuntu2004-java11",

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -51,7 +51,7 @@ THIS_IS_SPARTA = True
 
 CLOUD_PROJECT = "bazel-public" if THIS_IS_TRUSTED else "bazel-untrusted"
 
-GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "testing"}[
+GITHUB_BRANCH = {"bazel": "pcloudy-test", "bazel-trusted": "master", "bazel-testing": "testing"}[
     BUILDKITE_ORG
 ]
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2247,7 +2247,8 @@ def terminate_background_process(process):
 def create_step(label, commands, platform, shards=1, soft_fail=None):
     if "docker-image" in PLATFORMS[platform]:
         step = create_docker_step(
-            label, image=PLATFORMS[platform]["docker-image"], commands=commands
+            label, image=PLATFORMS[platform]["docker-image"], commands=commands,
+            queue = PLATFORMS[platform].get("queue", "default")
         )
     else:
         step = {
@@ -2278,7 +2279,7 @@ def create_step(label, commands, platform, shards=1, soft_fail=None):
     return step
 
 
-def create_docker_step(label, image, commands=None, additional_env_vars=None):
+def create_docker_step(label, image, commands=None, additional_env_vars=None, queue="default"):
     env = ["ANDROID_HOME", "ANDROID_NDK_HOME", "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"]
     if additional_env_vars:
         env += ["{}={}".format(k, v) for k, v in additional_env_vars.items()]
@@ -2286,7 +2287,7 @@ def create_docker_step(label, image, commands=None, additional_env_vars=None):
     step = {
         "label": label,
         "command": commands,
-        "agents": {"queue": "default"},
+        "agents": {"queue": queue},
         "plugins": {
             "docker#v3.8.0": {
                 "always-pull": True,

--- a/buildkite/terraform/bazel/main.tf
+++ b/buildkite/terraform/bazel/main.tf
@@ -1872,3 +1872,31 @@ resource "buildkite_pipeline" "rules-license" {
     separate_pull_request_statuses = false
   }
 }
+
+resource "buildkite_pipeline" "bazel-arm64" {
+  name           = "Bazel (arm64)"
+  repository     = "https://github.com/bazelbuild/bazel.git"
+  description    = "Run Bazel test suite on Linux ARM64 platform"
+  steps          = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-linux-arm64.yml?$(date +%s) | tee /dev/tty | buildkite-agent pipeline upload"] } })
+  default_branch = "master"
+  team           = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }]
+  provider_settings {
+    build_branches                                = true
+    build_pull_request_forks                      = true
+    build_pull_request_ready_for_review           = false
+    build_pull_requests                           = true
+    build_tags                                    = false
+    cancel_deleted_branch_builds                  = false
+    filter_condition                              = "build.pull_request.labels includes \"linux-arm64-presubmit\""
+    filter_enabled                                = true
+    prefix_pull_request_fork_branch_names         = true
+    publish_blocked_as_pending                    = false
+    publish_commit_status                         = false
+    publish_commit_status_per_step                = false
+    pull_request_branch_filter_enabled            = false
+    separate_pull_request_statuses                = false
+    skip_pull_request_builds_for_existing_commits = true
+    trigger_mode                                  = "code"
+  }
+}
+

--- a/pipelines/bazel-linux-arm64.yml
+++ b/pipelines/bazel-linux-arm64.yml
@@ -43,6 +43,25 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/bazel/rules/android/..."
       - "-//src/test/java/com/google/devtools/build/lib/rules/android/..."
       - "-//src/test/shell/bazel:bazel_android_tools_test"
+      # TODO: Re-enable the following tests on Linux ARM64 if possible
+      - "-//src/test/java/com/google/devtools/build/lib/buildtool:CompileOneDependencyIntegrationTest"
+      - "-//src/test/java/com/google/devtools/build/lib/buildtool:DanglingSymlinkTest"
+      - "-//src/test/java/com/google/devtools/build/lib/buildtool:KeepGoingTest"
+      - "-//src/test/java/com/google/devtools/build/lib/buildtool:MiscAnalysisTest"
+      - "-//src/test/java/com/google/devtools/build/lib/remote:remote"
+      - "-//src/test/java/com/google/devtools/build/lib/rules/objc:BazelJ2ObjcLibraryTest"
+      - "-//src/test/java/com/google/devtools/build/lib/skyframe/serialization:SerializationTests"
+      - "-//src/test/java/net/starlark/java/eval:ScriptTest"
+      - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
+      - "-//src/test/shell/bazel:bazel_java17_test"
+      - "-//src/test/shell/bazel:bazel_java_test_defaults"
+      - "-//src/test/shell/bazel:bazel_java_test_jdk17_toolchain_head"
+      - "-//src/test/shell/bazel:bazel_with_jdk_test"
+      - "-//src/test/shell/bazel/remote:remote_execution_mtls_test"
+      - "-//src/test/shell/bazel/remote:remote_execution_tls_test"
+      - "-//src/test/shell/integration:bazel_java_test"
+      - "-//src/test/shell/integration:minimal_jdk_test"
+      - "-//src/test/java/com/google/devtools/build/lib/rules/objc:ObjcRulesTests"
     include_json_profile:
       - build
       - test

--- a/pipelines/bazel-linux-arm64.yml
+++ b/pipelines/bazel-linux-arm64.yml
@@ -1,0 +1,42 @@
+---
+tasks:
+  ubuntu2004_arm64:
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE
+      - rm -f WORKSPACE.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+    build_flags:
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
+      - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
+      - "--noremote_accept_cached"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+    test_flags:
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
+      # Configure and enable tests that require access to the network.
+      - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
+    test_targets:
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/android/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
+      - "-//src/java_tools/import_deps_checker/..."
+    include_json_profile:
+      - build
+      - test
+

--- a/pipelines/bazel-linux-arm64.yml
+++ b/pipelines/bazel-linux-arm64.yml
@@ -2,9 +2,10 @@
 tasks:
   ubuntu2004_arm64:
     shell_commands:
-      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
-        android_ndk_repository/android_ndk_repository/' WORKSPACE
-      - rm -f WORKSPACE.bak
+      # Android SDK NDK not available on Linux ARM64
+      # - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+      #   android_ndk_repository/android_ndk_repository/' WORKSPACE
+      # - rm -f WORKSPACE.bak
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
     build_flags:
@@ -31,11 +32,17 @@ tasks:
       - "//src/tools/singlejar/..."
       - "//src/tools/workspacelog/..."
       - "//third_party/ijar/..."
-      - "//tools/android/..."
+      # - "//tools/android/..."
       - "//tools/aquery_differ/..."
       - "//tools/python/..."
       # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
       - "-//src/java_tools/import_deps_checker/..."
+      # Disable Android tests on Linux ARM64
+      - "-//src/test/shell/bazel/android/..."
+      - "-//src/test/java/com/google/devtools/build/android/..."
+      - "-//src/test/java/com/google/devtools/build/lib/bazel/rules/android/..."
+      - "-//src/test/java/com/google/devtools/build/lib/rules/android/..."
+      - "-//src/test/shell/bazel:bazel_android_tools_test"
     include_json_profile:
       - build
       - test


### PR DESCRIPTION
We recently received an additional Works-on-ARM machine that we can add to the bazel-untrusted environment to run Bazel tests. This PR adds necessary changes to enable the pipeline.