### PR TITLE
Account for default branch rename in `rules_sass` repository

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -384,7 +384,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     },
     "rules_sass": {
         "git_repository": "https://github.com/bazelbuild/rules_sass.git",
-        "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_sass/master/.bazelci/presubmit.yml",
+        "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_sass/main/.bazelci/presubmit.yml",
         "pipeline_slug": "rules-sass",
     },
     "rules_scala": {

--- a/buildkite/terraform/bazel/main.tf
+++ b/buildkite/terraform/bazel/main.tf
@@ -1407,7 +1407,7 @@ resource "buildkite_pipeline" "rules-sass" {
   name = "rules_sass"
   repository = "https://github.com/bazelbuild/rules_sass.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
-  default_branch = "master"
+  default_branch = "main"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
     trigger_mode = "code"


### PR DESCRIPTION
It looks like buildkite is failing the nightly schedule for `rules_sass` due to the branch rename.