### PR TITLE
Remove bazel from gitsync

### DIFF
--- a/gitsync/gitsync.sh
+++ b/gitsync/gitsync.sh
@@ -22,7 +22,6 @@
 # where
 #   direction can be ==> or <=>
 REPOSITORIES=(
-    "https://bazel.googlesource.com/bazel ==> git@github.com:bazelbuild/bazel.git bazel master"
     "https://bazel.googlesource.com/tulsi ==> git@github.com:bazelbuild/tulsi.git tulsi upstream"
 )
 


### PR DESCRIPTION
The master branch of the Bazel repo is now being synced by Copybara.