### PR TITLE
Add pipelines for IntelliJ plugin "google" branch

### DIFF
--- a/buildkite/terraform/bazel/main.tf
+++ b/buildkite/terraform/bazel/main.tf
@@ -108,7 +108,7 @@ resource "buildkite_pipeline" "intellij-ue-plugin" {
   }
 }
 
-resource "buildkite_pipeline" "intellij-ue-plugin" {
+resource "buildkite_pipeline" "intellij-ue-plugin-google" {
   name = "IntelliJ UE plugin Google"
   repository = "https://github.com/bazelbuild/intellij.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij-ue.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
@@ -1279,7 +1279,7 @@ resource "buildkite_pipeline" "intellij-plugin-aspect" {
   }
 }
 
-resource "buildkite_pipeline" "intellij-plugin-aspect" {
+resource "buildkite_pipeline" "intellij-plugin-aspect-google" {
   name = "IntelliJ Plugin Aspect Google"
   repository = "https://github.com/bazelbuild/intellij.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/aspect.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
@@ -1315,7 +1315,7 @@ resource "buildkite_pipeline" "android-studio-plugin" {
   }
 }
 
-resource "buildkite_pipeline" "android-studio-plugin" {
+resource "buildkite_pipeline" "android-studio-plugin-google" {
   name = "Android Studio Plugin Google"
   repository = "https://github.com/bazelbuild/intellij.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/android-studio.yml --monitor_flaky_tests=true | tee /dev/tty | buildkite-agent pipeline upload"] } })
@@ -1576,7 +1576,7 @@ resource "buildkite_pipeline" "clion-plugin" {
   }
 }
 
-resource "buildkite_pipeline" "clion-plugin" {
+resource "buildkite_pipeline" "clion-plugin-google" {
   name = "CLion plugin Google"
   repository = "https://github.com/bazelbuild/intellij.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/clion.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
@@ -1614,7 +1614,7 @@ resource "buildkite_pipeline" "intellij-plugin" {
   }
 }
 
-resource "buildkite_pipeline" "intellij-plugin" {
+resource "buildkite_pipeline" "intellij-plugin-google" {
   name = "IntelliJ plugin Google"
   repository = "https://github.com/bazelbuild/intellij.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })

--- a/buildkite/terraform/bazel/main.tf
+++ b/buildkite/terraform/bazel/main.tf
@@ -103,6 +103,28 @@ resource "buildkite_pipeline" "intellij-ue-plugin" {
     prefix_pull_request_fork_branch_names = true
     build_branches = true
     publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch != \"google\""
+  }
+}
+
+resource "buildkite_pipeline" "intellij-ue-plugin" {
+  name = "IntelliJ UE plugin Google"
+  repository = "https://github.com/bazelbuild/intellij.git"
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij-ue.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
+  description = "Tests the Bazel IntelliJ plugin from google branch with IntelliJ IDEA Ultimate"
+  default_branch = "google"
+  team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
+  provider_settings {
+    trigger_mode = "code"
+    build_pull_requests = true
+    skip_pull_request_builds_for_existing_commits = true
+    build_pull_request_forks = true
+    prefix_pull_request_fork_branch_names = true
+    build_branches = true
+    publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch == \"google\""
   }
 }
 
@@ -1252,6 +1274,26 @@ resource "buildkite_pipeline" "intellij-plugin-aspect" {
     build_pull_request_forks = true
     prefix_pull_request_fork_branch_names = true
     publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch != \"google\""
+  }
+}
+
+resource "buildkite_pipeline" "intellij-plugin-aspect" {
+  name = "IntelliJ Plugin Aspect Google"
+  repository = "https://github.com/bazelbuild/intellij.git"
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/aspect.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
+  default_branch = "google"
+  team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
+  provider_settings {
+    trigger_mode = "code"
+    build_pull_requests = true
+    skip_pull_request_builds_for_existing_commits = true
+    build_pull_request_forks = true
+    prefix_pull_request_fork_branch_names = true
+    publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch == \"google\""
   }
 }
 
@@ -1268,6 +1310,26 @@ resource "buildkite_pipeline" "android-studio-plugin" {
     build_pull_request_forks = true
     prefix_pull_request_fork_branch_names = true
     publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch != \"google\""
+  }
+}
+
+resource "buildkite_pipeline" "android-studio-plugin" {
+  name = "Android Studio Plugin Google"
+  repository = "https://github.com/bazelbuild/intellij.git"
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/android-studio.yml --monitor_flaky_tests=true | tee /dev/tty | buildkite-agent pipeline upload"] } })
+  default_branch = "google"
+  team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
+  provider_settings {
+    trigger_mode = "code"
+    build_pull_requests = true
+    skip_pull_request_builds_for_existing_commits = true
+    build_pull_request_forks = true
+    prefix_pull_request_fork_branch_names = true
+    publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch == \"google\""
   }
 }
 
@@ -1509,6 +1571,26 @@ resource "buildkite_pipeline" "clion-plugin" {
     build_pull_request_forks = true
     prefix_pull_request_fork_branch_names = true
     publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch != \"google\""
+  }
+}
+
+resource "buildkite_pipeline" "clion-plugin" {
+  name = "CLion plugin Google"
+  repository = "https://github.com/bazelbuild/intellij.git"
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/clion.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
+  default_branch = "google"
+  team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
+  provider_settings {
+    trigger_mode = "code"
+    build_pull_requests = true
+    skip_pull_request_builds_for_existing_commits = true
+    build_pull_request_forks = true
+    prefix_pull_request_fork_branch_names = true
+    publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch == \"google\""
   }
 }
 
@@ -1527,6 +1609,28 @@ resource "buildkite_pipeline" "intellij-plugin" {
     prefix_pull_request_fork_branch_names = true
     build_branches = true
     publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch != \"google\""
+  }
+}
+
+resource "buildkite_pipeline" "intellij-plugin" {
+  name = "IntelliJ plugin Google"
+  repository = "https://github.com/bazelbuild/intellij.git"
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
+  description = "Tests the Bazel IntelliJ plugin from google branch with IntelliJ IDEA Community Edition"
+  default_branch = "google"
+  team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
+  provider_settings {
+    trigger_mode = "code"
+    build_pull_requests = true
+    skip_pull_request_builds_for_existing_commits = true
+    build_pull_request_forks = true
+    prefix_pull_request_fork_branch_names = true
+    build_branches = true
+    publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch == \"google\""
   }
 }
 


### PR DESCRIPTION
- Add new pipelines for the IntelliJ plugin tests from the newly created "google" branch.
- Only enable the "google" pipelines for PRs with "google" as the base branch.
- Update the existing pipelines for the IntelliJ plugin from "master" branch to run for PRs with any base branch except "google".