### PR TITLE
Add bazel/* branches for apple repos

### DIFF
--- a/buildkite/terraform/bazel/main.tf
+++ b/buildkite/terraform/bazel/main.tf
@@ -878,7 +878,11 @@ resource "buildkite_pipeline" "apple-support-darwin" {
   repository = "https://github.com/bazelbuild/apple_support.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
-  branch_configuration = "master"
+  branch_configuration = "master bazel/*"
+  skip_intermediate_builds = true
+  skip_intermediate_builds_branch_filter = "!master !bazel/*"
+  cancel_intermediate_builds = true
+  cancel_intermediate_builds_branch_filter = "!master !bazel/*"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "apple-team" }, { access_level = "BUILD_AND_READ", slug = "googlers" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
     trigger_mode = "code"
@@ -1008,7 +1012,11 @@ resource "buildkite_pipeline" "tulsi-bazel-darwin" {
   repository = "https://github.com/bazelbuild/tulsi.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
-  branch_configuration = "master"
+  branch_configuration = "master bazel/*"
+  skip_intermediate_builds = true
+  skip_intermediate_builds_branch_filter = "!master !bazel/*"
+  cancel_intermediate_builds = true
+  cancel_intermediate_builds_branch_filter = "!master !bazel/*"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "apple-team" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
     trigger_mode = "code"
@@ -1053,7 +1061,11 @@ resource "buildkite_pipeline" "rules-swift-swift" {
   repository = "https://github.com/bazelbuild/rules_swift.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
-  branch_configuration = "master"
+  branch_configuration = "master bazel/*"
+  skip_intermediate_builds = true
+  skip_intermediate_builds_branch_filter = "!master !bazel/*"
+  cancel_intermediate_builds = true
+  cancel_intermediate_builds_branch_filter = "!master !bazel/*"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "apple-team" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
     trigger_mode = "code"
@@ -1307,11 +1319,11 @@ resource "buildkite_pipeline" "rules-apple-darwin" {
   repository = "https://github.com/bazelbuild/rules_apple.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
-  branch_configuration = "master"
+  branch_configuration = "master bazel/*"
   skip_intermediate_builds = true
-  skip_intermediate_builds_branch_filter = "!master"
+  skip_intermediate_builds_branch_filter = "!master !bazel/*"
   cancel_intermediate_builds = true
-  cancel_intermediate_builds_branch_filter = "!master"
+  cancel_intermediate_builds_branch_filter = "!master !bazel/*"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "apple-team" }, { access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
     trigger_mode = "code"


### PR DESCRIPTION
We're going to use this format for branches for old bazel versions that
we want to run CI on still.