### PR TITLE
Update IntelliJ plugin google branch pipelines

### DIFF
--- a/buildkite/terraform/bazel/main.tf
+++ b/buildkite/terraform/bazel/main.tf
@@ -75,6 +75,7 @@ resource "buildkite_pipeline" "intellij-ue-plugin" {
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij-ue.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Tests the Bazel IntelliJ plugin with IntelliJ IDEA Ultimate"
   default_branch = "master"
+  branch_configuration = "!google"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
     trigger_mode = "code"
@@ -84,6 +85,8 @@ resource "buildkite_pipeline" "intellij-ue-plugin" {
     prefix_pull_request_fork_branch_names = true
     build_branches = true
     publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch != \"google\""
   }
 }
 
@@ -93,9 +96,18 @@ resource "buildkite_pipeline" "intellij-ue-plugin-google" {
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij-ue.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Tests the Bazel IntelliJ plugin from google branch with IntelliJ IDEA Ultimate"
   default_branch = "google"
+  branch_configuration = "google"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
-    trigger_mode = "none"
+    trigger_mode = "code"
+    build_pull_requests = true
+    skip_pull_request_builds_for_existing_commits = true
+    build_pull_request_forks = true
+    prefix_pull_request_fork_branch_names = true
+    build_branches = true
+    publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch == \"google\""
   }
 }
 
@@ -1249,6 +1261,7 @@ resource "buildkite_pipeline" "intellij-plugin-aspect" {
   repository = "https://github.com/bazelbuild/intellij.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/aspect.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
+  branch_configuration = "!google"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
     trigger_mode = "code"
@@ -1256,7 +1269,10 @@ resource "buildkite_pipeline" "intellij-plugin-aspect" {
     skip_pull_request_builds_for_existing_commits = true
     build_pull_request_forks = true
     prefix_pull_request_fork_branch_names = true
+    build_branches = true
     publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch != \"google\""
   }
 }
 
@@ -1265,9 +1281,18 @@ resource "buildkite_pipeline" "intellij-plugin-aspect-google" {
   repository = "https://github.com/bazelbuild/intellij.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/aspect.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "google"
+  branch_configuration = "google"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
-    trigger_mode = "none"
+    trigger_mode = "code"
+    build_pull_requests = true
+    skip_pull_request_builds_for_existing_commits = true
+    build_pull_request_forks = true
+    prefix_pull_request_fork_branch_names = true
+    build_branches = true
+    publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch == \"google\""
   }
 }
 
@@ -1276,6 +1301,7 @@ resource "buildkite_pipeline" "android-studio-plugin" {
   repository = "https://github.com/bazelbuild/intellij.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/android-studio.yml --monitor_flaky_tests=true | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
+  branch_configuration = "!google"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
     trigger_mode = "code"
@@ -1283,7 +1309,10 @@ resource "buildkite_pipeline" "android-studio-plugin" {
     skip_pull_request_builds_for_existing_commits = true
     build_pull_request_forks = true
     prefix_pull_request_fork_branch_names = true
+    build_branches = true
     publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch != \"google\""
   }
 }
 
@@ -1292,9 +1321,18 @@ resource "buildkite_pipeline" "android-studio-plugin-google" {
   repository = "https://github.com/bazelbuild/intellij.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/android-studio.yml --monitor_flaky_tests=true | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "google"
+  branch_configuration = "google"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
-    trigger_mode = "none"
+    trigger_mode = "code"
+    build_pull_requests = true
+    skip_pull_request_builds_for_existing_commits = true
+    build_pull_request_forks = true
+    prefix_pull_request_fork_branch_names = true
+    build_branches = true
+    publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch == \"google\""
   }
 }
 
@@ -1528,34 +1566,7 @@ resource "buildkite_pipeline" "clion-plugin" {
   repository = "https://github.com/bazelbuild/intellij.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/clion.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
-  team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
-  provider_settings {
-    trigger_mode = "code"
-    build_pull_requests = true
-    skip_pull_request_builds_for_existing_commits = true
-    build_pull_request_forks = true
-    prefix_pull_request_fork_branch_names = true
-    publish_commit_status = true
-  }
-}
-
-resource "buildkite_pipeline" "clion-plugin-google" {
-  name = "CLion plugin Google"
-  repository = "https://github.com/bazelbuild/intellij.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/clion.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
-  default_branch = "google"
-  team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
-  provider_settings {
-    trigger_mode = "none"
-  }
-}
-
-resource "buildkite_pipeline" "intellij-plugin" {
-  name = "IntelliJ plugin"
-  repository = "https://github.com/bazelbuild/intellij.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
-  description = "Tests the Bazel IntelliJ plugin with IntelliJ IDEA Community Edition"
-  default_branch = "master"
+  branch_configuration = "!google"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
     trigger_mode = "code"
@@ -1565,6 +1576,49 @@ resource "buildkite_pipeline" "intellij-plugin" {
     prefix_pull_request_fork_branch_names = true
     build_branches = true
     publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch != \"google\""
+  }
+}
+
+resource "buildkite_pipeline" "clion-plugin-google" {
+  name = "CLion plugin Google"
+  repository = "https://github.com/bazelbuild/intellij.git"
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/clion.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
+  default_branch = "google"
+  branch_configuration = "google"
+  team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
+  provider_settings {
+    trigger_mode = "code"
+    build_pull_requests = true
+    skip_pull_request_builds_for_existing_commits = true
+    build_pull_request_forks = true
+    prefix_pull_request_fork_branch_names = true
+    build_branches = true
+    publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch == \"google\""
+  }
+}
+
+resource "buildkite_pipeline" "intellij-plugin" {
+  name = "IntelliJ plugin"
+  repository = "https://github.com/bazelbuild/intellij.git"
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
+  description = "Tests the Bazel IntelliJ plugin with IntelliJ IDEA Community Edition"
+  default_branch = "master"
+  branch_configuration = "!google"
+  team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
+  provider_settings {
+    trigger_mode = "code"
+    build_pull_requests = true
+    skip_pull_request_builds_for_existing_commits = true
+    build_pull_request_forks = true
+    prefix_pull_request_fork_branch_names = true
+    build_branches = true
+    publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch != \"google\""
   }
 }
 
@@ -1574,9 +1628,18 @@ resource "buildkite_pipeline" "intellij-plugin-google" {
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
   description = "Tests the Bazel IntelliJ plugin from google branch with IntelliJ IDEA Community Edition"
   default_branch = "google"
+  branch_configuration = "google"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
   provider_settings {
-    trigger_mode = "none"
+    trigger_mode = "code"
+    build_pull_requests = true
+    skip_pull_request_builds_for_existing_commits = true
+    build_pull_request_forks = true
+    prefix_pull_request_fork_branch_names = true
+    build_branches = true
+    publish_commit_status = true
+    filter_enabled = true
+    filter_condition = "build.pull_request.base_branch == \"google\""
   }
 }
 


### PR DESCRIPTION
- Allow triggering the `google` branch pipelines from pull-requests against the `google` branch.
- Limit `google` branch pipelines to run only on the commits to the google branch.
- Update the existing pipelines for the IntelliJ plugin to run for PRs with any base branch except "google".