### PR TITLE
Revert "Disable Cloud Robotics Core in downstream"

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -194,7 +194,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/googlecloudrobotics/core.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/cloud-robotics.yml",
         "pipeline_slug": "cloud-robotics-core",
-        "disabled_reason": "https://github.com/googlecloudrobotics/core/issues/90",
     },
     "Envoy": {
         "git_repository": "https://github.com/envoyproxy/envoy.git",


### PR DESCRIPTION
Reverts bazelbuild/continuous-integration#1392

https://github.com/googlecloudrobotics/core/issues/90 is now fixed.