### PR TITLE
Don't specify `USE_BAZEL_VERSION` in tensorflow.yml

### DIFF
--- a/pipelines/tensorflow.yml
+++ b/pipelines/tensorflow.yml
@@ -3,7 +3,6 @@ platforms:
   ubuntu2004:
     environment:
       TF_IGNORE_MAX_BAZEL_VERSION: 1
-      USE_BAZEL_VERSION: latest
     shell_commands:
     # - |-
     #   echo '
@@ -24,7 +23,6 @@ platforms:
   macos:
     environment:
       TF_IGNORE_MAX_BAZEL_VERSION: 1
-      USE_BAZEL_VERSION: latest
     shell_commands:
     # - |-
     #   echo '
@@ -46,7 +44,6 @@ platforms:
   windows:
     environment:
       TF_IGNORE_MAX_BAZEL_VERSION: 1
-      USE_BAZEL_VERSION: latest
       BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC"
     batch_commands:
     - pip3 install packaging


### PR DESCRIPTION
To respect Bazel version handled by https://github.com/bazelbuild/continuous-integration/pull/1391