### PR TITLE
Temporarily disable rules_haskell

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -357,6 +357,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/tweag/rules_haskell.git",
         "http_config": "https://raw.githubusercontent.com/tweag/rules_haskell/master/.bazelci/presubmit.yml",
         "pipeline_slug": "rules-haskell-haskell",
+        "disabled_reason": "https://github.com/bazelbuild/bazel/issues/15916",
     },
     "rules_jsonnet": {
         "git_repository": "https://github.com/bazelbuild/rules_jsonnet.git",


### PR DESCRIPTION
rules_haskell has been failing in the downstream pipeline for several weeks now. The culprit is https://github.com/bazelbuild/bazel/issues/15916, but the fix is non-trivial. As a result I'm temporarily disabling this project in all downstream pipelines.