### PR TITLE
Temporarily disable 'google' flavours of IntelliJ

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -230,6 +230,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/intellij.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/intellij/google/.bazelci/intellij.yml",
         "pipeline_slug": "intellij-plugin-google",
+        "disabled_reason": "https://github.com/bazelbuild/intellij/issues/3813",
     },
     "IntelliJ UE Plugin": {
         "git_repository": "https://github.com/bazelbuild/intellij.git",
@@ -240,6 +241,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/intellij.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/intellij/google/.bazelci/intellij-ue.yml",
         "pipeline_slug": "intellij-ue-plugin-google",
+        "disabled_reason": "https://github.com/bazelbuild/intellij/issues/3813",
     },
     "IntelliJ Plugin Aspect": {
         "git_repository": "https://github.com/bazelbuild/intellij.git",
@@ -250,6 +252,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/intellij.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/intellij/google/.bazelci/aspect.yml",
         "pipeline_slug": "intellij-plugin-aspect-google",
+        "disabled_reason": "https://github.com/bazelbuild/intellij/issues/3813",
     },
     "Kythe": {
         "git_repository": "https://github.com/kythe/kythe.git",


### PR DESCRIPTION
Because of https://github.com/bazelbuild/intellij/issues/3813