### PR TITLE
Use Ubuntu 20.04 for Bazel Docker container

### DIFF
--- a/bazel/oci/Dockerfile
+++ b/bazel/oci/Dockerfile
@@ -1,7 +1,7 @@
 # ATTENTION: use the build.sh script to build this image.
 # ./build.sh <OCI_REPOSITORY> <BAZEL_VERSION>
 
-FROM ubuntu:16.04 AS base_image
+FROM ubuntu:20.04 AS base_image
 
 RUN --mount=source=bazel/oci/install_packages.sh,target=/mnt/install_packages.sh,type=bind \
     /mnt/install_packages.sh


### PR DESCRIPTION
Currently, `gcr.io/bazel-public/bazel` uses Ubuntu 16.04 as a base image. This works great, but unfortunately, this container fails to build gRPC because this container installs GCC 5.4.0, but gRPC requires [GCC 6 or newer](https://github.com/grpc/grpc/pull/29594). It is unfortunate that the Bazel container cannot build gRPC. We can solve this issue if we use Ubuntu 20.04 as a base image and push built containers to `gcr.io/bazel-public/bazel`.
#1290 initially used Ubuntu 20.04 as a base image and rolled back to 16.04, but I think it is good timing to re-consider to update Bazel docker containers before Bazel 5.3 is released.

Part of #1060.