### PR TITLE
Remove bazel-integration-testing from downstream pipeline

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -134,11 +134,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "http_config": "https://raw.githubusercontent.com/buchgr/bazel-remote/master/.bazelci/presubmit.yml",
         "pipeline_slug": "bazel-remote-cache",
     },
-    "Bazel integration testing": {
-        "git_repository": "https://github.com/bazelbuild/bazel-integration-testing.git",
-        "http_config": "https://raw.githubusercontent.com/bazelbuild/bazel-integration-testing/master/.bazelci/presubmit.yml",
-        "pipeline_slug": "bazel-integration-testing",
-    },
     "Bazel skylib": {
         "git_repository": "https://github.com/bazelbuild/bazel-skylib.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/bazel-skylib/main/.bazelci/presubmit.yml",


### PR DESCRIPTION
The project is now read-only (https://github.com/bazelbuild/bazel-integration-testing). The successor (https://github.com/bazel-contrib/rules_bazel_integration_test) doesn't have a presubmit.yml defined.