### PR TITLE
Added configs for bazel skymeld postsubmit

### DIFF
--- a/buildkite/terraform/bazel/main.tf
+++ b/buildkite/terraform/bazel/main.tf
@@ -1936,6 +1936,23 @@ resource "buildkite_pipeline" "bazel-bazel" {
   }
 }
 
+resource "buildkite_pipeline" "bazel-skymeld" {
+  name = "Bazel-Skymeld :bazel:"
+  repository = "https://github.com/bazelbuild/bazel.git"
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/postsubmit-skymeld.yml --monitor_flaky_tests=true | tee /dev/tty | buildkite-agent pipeline upload"] } })
+  default_branch = "master"
+  branch_configuration = "master release-*"
+  team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "bazel" }]
+  provider_settings {
+    trigger_mode = "code"
+    skip_pull_request_builds_for_existing_commits = true
+    build_pull_request_forks = true
+    prefix_pull_request_fork_branch_names = true
+    build_branches = true
+    publish_commit_status = true
+  }
+}
+
 resource "buildkite_pipeline" "bazel-lib" {
   name = "bazel-lib"
   repository = "https://github.com/aspect-build/bazel-lib.git"

--- a/buildkite/terraform/bazel/main.tf
+++ b/buildkite/terraform/bazel/main.tf
@@ -1939,7 +1939,7 @@ resource "buildkite_pipeline" "bazel-bazel" {
 resource "buildkite_pipeline" "bazel-skymeld" {
   name = "Bazel-Skymeld :bazel:"
   repository = "https://github.com/bazelbuild/bazel.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/postsubmit-skymeld.yml --monitor_flaky_tests=true | tee /dev/tty | buildkite-agent pipeline upload"] } })
+  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/postsubmit-skymeld.yml?$(date +%s) --monitor_flaky_tests=true | tee /dev/tty | buildkite-agent pipeline upload"] } })
   default_branch = "master"
   branch_configuration = "master release-*"
   team = [{ access_level = "MANAGE_BUILD_AND_READ", slug = "bazel-sheriffs" }, { access_level = "MANAGE_BUILD_AND_READ", slug = "bazel" }]

--- a/pipelines/postsubmit-skymeld.yml
+++ b/pipelines/postsubmit-skymeld.yml
@@ -1,0 +1,291 @@
+---
+tasks:
+  centos7_java11_devtoolset10:
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE
+      - rm -f WORKSPACE.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+    build_flags:
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
+      - "--noremote_accept_cached"
+      - "--experimental_merged_skyframe_analysis_execution"
+      - "--experimental_skymeld_ui"
+    build_targets:
+      - "//:bazel-distfile.zip"
+      - "//scripts/packages/debian:bazel-debian.deb"
+      - "//scripts/packages:with-jdk/install.sh"
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+    test_flags:
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
+      - "--experimental_merged_skyframe_analysis_execution"
+      - "--experimental_skymeld_ui"
+    test_targets:
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/android/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
+      - "-//src/java_tools/buildjar/..."
+      - "-//src/java_tools/import_deps_checker/..."
+      # These tests are not compatible with the gcov version of CentOS 7.
+      - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
+      - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
+      - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
+      - "-//src/test/shell/bazel:bazel_coverage_sh_test"
+    include_json_profile:
+      - build
+      - test
+  ubuntu1804:
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE
+      - rm -f WORKSPACE.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+    build_flags:
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
+      - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
+      - "--noremote_accept_cached"
+      - "--experimental_merged_skyframe_analysis_execution"
+      - "--experimental_skymeld_ui"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+    test_flags:
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
+      # Configure and enable tests that require access to the network.
+      - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
+      - "--experimental_merged_skyframe_analysis_execution"
+      - "--experimental_skymeld_ui"
+    test_targets:
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/android/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
+      - "-//src/java_tools/import_deps_checker/..."
+    include_json_profile:
+      - build
+      - test
+  ubuntu1804_clang:
+    platform: ubuntu1804
+    environment:
+      CC: clang
+      CC_CONFIGURE_DEBUG: 1
+    name: "Clang"
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE
+      - rm -f WORKSPACE.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+    build_flags:
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
+      - "--noremote_accept_cached"
+      - "--experimental_merged_skyframe_analysis_execution"
+      - "--experimental_skymeld_ui"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+    test_flags:
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
+      - "--experimental_merged_skyframe_analysis_execution"
+      - "--experimental_skymeld_ui"
+    test_targets:
+      - "//src/test/shell/bazel:cc_integration_test"
+    include_json_profile:
+      - build
+      - test
+  ubuntu2004:
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE
+      - rm -f WORKSPACE.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+    build_flags:
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
+      - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
+      - "--noremote_accept_cached"
+      - "--experimental_merged_skyframe_analysis_execution"
+      - "--experimental_skymeld_ui"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+    test_flags:
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
+      # Configure and enable tests that require access to the network.
+      - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
+      - "--experimental_merged_skyframe_analysis_execution"
+      - "--experimental_skymeld_ui"
+    test_targets:
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/android/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
+      - "-//src/java_tools/import_deps_checker/..."
+    include_json_profile:
+      - build
+      - test
+  macos:
+    xcode_version: "13.0"
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE
+      - rm -f WORKSPACE.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+      - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
+    build_flags:
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
+      - "--test_env=TEST_REPOSITORY_HOME=$HOME/bazeltest/external"
+      - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
+      - "--noremote_accept_cached"
+      - "--experimental_merged_skyframe_analysis_execution"
+      - "--experimental_skymeld_ui"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+    test_flags:
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$HOME/bazeltest/external"
+      # Configure and enable tests that require access to the network.
+      - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
+      - "--experimental_merged_skyframe_analysis_execution"
+      - "--experimental_skymeld_ui"
+    test_targets:
+      - "//scripts/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/android/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/osx/crosstool/..."
+      - "//tools/python/..."
+      # C++ coverage is not supported on macOS yet.
+      - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
+    include_json_profile:
+      - build
+      - test
+  windows:
+    batch_commands:
+      - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
+      - mkdir C:\b
+      - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
+    build_flags:
+      - "--copt=-w"
+      - "--host_copt=-w"
+      - "--test_env=JAVA_HOME"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest_install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=C:/b/bazeltest_external"
+      - "--noremote_accept_cached"
+      - "--experimental_merged_skyframe_analysis_execution"
+      - "--experimental_skymeld_ui"
+    build_targets:
+      - "//src:bazel.exe"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+    test_flags:
+      - "--copt=-w"
+      - "--host_copt=-w"
+      - "--test_tag_filters=-no_windows,-slow"
+      - "--test_env=JAVA_HOME"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest_install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=C:/b/bazeltest_external"
+      - "--experimental_merged_skyframe_analysis_execution"
+      - "--experimental_skymeld_ui"
+    test_targets:
+      - "//src:embedded_tools_size_test"
+      - "//src/test/cpp/..."
+      - "//src/test/java/com/google/devtools/build/android/..."
+      - "//src/test/java/com/google/devtools/build/lib/..."
+      - "//src/test/java/com/google/devtools/build/skyframe/..."
+      - "//src/test/java/com/google/devtools/common/options/..."
+      - "//src/test/native/windows/..."
+      - "//src/test/py/bazel/..."
+      - "//src/test/res/..."
+      - "//src/test/shell/..."
+      - "//src/tools/launcher/..."
+      - "//src/tools/singlejar/..."
+      - "//third_party/def_parser/..."
+      - "//tools/android/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/bash/..."
+      - "//tools/build_defs/..."
+      - "//tools/cpp/runfiles/..."
+      - "//tools/java/..."
+      - "//tools/jdk/..."
+      - "//tools/python/..."
+      - "//tools/test/..."
+      # Re-enable the following tests on Windows:
+      # https://github.com/bazelbuild/bazel/issues/4292
+      - "-//src/test/java/com/google/devtools/build/android/r8/..."
+      - "-//src/test/java/com/google/devtools/build/lib/query2/cquery/..."
+      - "-//src/test/java/com/google/devtools/build/lib/query2/engine/..."
+      - "-//src/test/java/com/google/devtools/build/lib/versioning/..."
+      - "-//src/test/java/com/google/devtools/build/lib/rules/java/..."
+      - "-//src/test/java/com/google/devtools/build/lib/worker/..."
+      - "-//src/test/java/com/google/devtools/build/lib/remote/..."
+      - "-//src/test/shell/bazel/remote/..."
+      - "-//tools/python:pywrapper_test"
+    include_json_profile:
+      - build
+      - test
+  kythe_ubuntu2004:
+    shell_commands:
+    - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/'
+      -e 's/^# android_ndk_repository/android_ndk_repository/' WORKSPACE
+    - rm -f WORKSPACE.bak
+    index_flags:
+    - "--define=kythe_corpus=github.com/bazelbuild/bazel"
+    index_targets_query: "kind(\"cc_(binary|library|test|proto_library) rule\", ...) union kind(\"java_(binary|import|library|plugin|test|proto_library) rule\", ...) union kind(\"proto_library rule\", ...)"
+    index_upload_policy: Always
+    index_upload_gcs: True


### PR DESCRIPTION
This PR adds a new postsubmit pipeline (with Skymeld flags enabled) to BazelCI, which is meant to be run in parallel with the existing one.

It's intentional that we're leaving out the rbe platform: `RemoteModule` and Skymeld are currently incompatible.
