### PR TITLE
Update the source image family for Windows

### DIFF
--- a/buildkite/create_images.py
+++ b/buildkite/create_images.py
@@ -53,7 +53,7 @@ IMAGE_CREATION_VMS = {
         "zone": "us-central1-f",
         "network": "default",
         "source_image_project": "windows-cloud",
-        "source_image_family": "windows-2019",
+        "source_image_family": "windows-2022",
         "setup_script": "setup-windows.ps1",
         "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE"],
     },

--- a/buildkite/create_images.py
+++ b/buildkite/create_images.py
@@ -44,7 +44,7 @@ IMAGE_CREATION_VMS = {
         "project": "bazel-public",
         "zone": "us-central1-f",
         "source_image_project": "windows-cloud",
-        "source_image_family": "windows-20h2-core",
+        "source_image_family": "windows-2022-core",
         "setup_script": "setup-windows.ps1",
         "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE"],
     },


### PR DESCRIPTION
`windows-cloud` is EOL, `windows-2022-core` is latest one supported according to https://cloud.google.com/compute/docs/images/os-details#windows_server