### PR TITLE
Don't pin llvm version when setting up Windows VM

### DIFF
--- a/buildkite/setup-windows.ps1
+++ b/buildkite/setup-windows.ps1
@@ -71,7 +71,7 @@ Write-Host "Installing curl..."
 ## Install LLVM/Clang
 Write-Host "Installing llvm..."
 # FYI: choco installs clang in C:\Program Files\LLVM\bin (which is not on the PATH).
-& choco install llvm --version=10.0.0
+& choco install llvm
 [Environment]::SetEnvironmentVariable("BAZEL_LLVM", "C:\Program Files\LLVM", "Machine")
 $env:BAZEL_LLVM = [Environment]::GetEnvironmentVariable("BAZEL_LLVM", "Machine")
 


### PR DESCRIPTION
When using VS 2019, clang 11.0.0 is required.
See https://buildkite.com/bazel/rules-foreign-cc/builds/4283#01832f14-79d3-41b5-8957-af141f02127f
```
n file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\string:9:
C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\yvals_core.h(571,2): error: STL1000: Unexpected compiler version, expected Clang 11.0.0 or newer.
#error STL1000: Unexpected compiler version, expected Clang 11.0.0 or newer.
``` 