### PR TITLE
Install Android NDK r25b

### DIFF
--- a/buildkite/setup-docker.sh
+++ b/buildkite/setup-docker.sh
@@ -166,9 +166,12 @@ EOF
 ### Install Android NDK.
 {
   cd /opt
-  curl -fsSL -o android-ndk.zip https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip
-  unzip android-ndk.zip > /dev/null
-  rm android-ndk.zip
+  curl -fsSL -o android-ndk-r15c.zip https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip
+  unzip android-ndk-r15c.zip > /dev/null
+  rm android-ndk-r15c.zip
+  curl -fsSL -o android-ndk-r25b.zip https://dl.google.com/android/repository/android-ndk-r25b-linux.zip
+  unzip android-ndk-r25b.zip > /dev/null
+  rm android-ndk-r25b.zip
 }
 
 ### Install Android SDK.

--- a/buildkite/terraform/bazel-testing/pipeline.yml.tpl
+++ b/buildkite/terraform/bazel-testing/pipeline.yml.tpl
@@ -30,6 +30,7 @@ steps:
             - "/etc/passwd:/etc/passwd:ro"
             - "/etc/shadow:/etc/shadow:ro"
             - "/opt/android-ndk-r15c:/opt/android-ndk-r15c:ro"
+            - "/opt/android-ndk-r25b:/opt/android-ndk-r25b:ro"
             - "/opt/android-sdk-linux:/opt/android-sdk-linux:ro"
             - "/var/lib/buildkite-agent:/var/lib/buildkite-agent"
             - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"

--- a/buildkite/terraform/bazel-trusted/pipeline.yml.tpl
+++ b/buildkite/terraform/bazel-trusted/pipeline.yml.tpl
@@ -34,6 +34,7 @@ steps:
             - "/etc/passwd:/etc/passwd:ro"
             - "/etc/shadow:/etc/shadow:ro"
             - "/opt/android-ndk-r15c:/opt/android-ndk-r15c:ro"
+            - "/opt/android-ndk-r25b:/opt/android-ndk-r25b:ro"
             - "/opt/android-sdk-linux:/opt/android-sdk-linux:ro"
             - "/var/lib/buildkite-agent:/var/lib/buildkite-agent"
             - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"

--- a/buildkite/terraform/bazel/pipeline.yml.tpl
+++ b/buildkite/terraform/bazel/pipeline.yml.tpl
@@ -30,6 +30,7 @@ steps:
             - "/etc/passwd:/etc/passwd:ro"
             - "/etc/shadow:/etc/shadow:ro"
             - "/opt/android-ndk-r15c:/opt/android-ndk-r15c:ro"
+            - "/opt/android-ndk-r25b:/opt/android-ndk-r25b:ro"
             - "/opt/android-sdk-linux:/opt/android-sdk-linux:ro"
             - "/var/lib/buildkite-agent:/var/lib/buildkite-agent"
             - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"


### PR DESCRIPTION
Required by rules_android_ndk, still keeping the old one since legacy rules may need it.