### PR TITLE
Fix git repo url for rules_android_ndk

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -282,7 +282,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "disabled_reason": "https://github.com/bazelbuild/rules_android/issues/15",
     },
     "rules_android_ndk": {
-        "git_repository": "https://github.com/bazelbuild/rules_android.git",
+        "git_repository": "https://github.com/bazelbuild/rules_android_ndk.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_android_ndk/main/.bazelci/presubmit.yml",
         "pipeline_slug": "rules-android-ndk",
     },


### PR DESCRIPTION
Fixing https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2633#01833ee9-b4f6-4ee9-8ddf-030c81a6d6e7