### PR TITLE
Culprit finder: try to find a good bazel commit when the given one is bad

### DIFF
--- a/buildkite/bazel_auto_sheriff.py
+++ b/buildkite/bazel_auto_sheriff.py
@@ -195,7 +195,7 @@ class BuildInfoAnalyzer(threading.Thread):
                  bisect_log[pos:].replace("\r", ""),
                  "Bisect URL: " + job["web_url"],
             ]), culprit_commit
-        pos = bisect_log.rfind("Given good commit")  # Matching "Given good commit (XXXX) is not actually good, abort bisecting."
+        pos = bisect_log.rfind("Cannot find a good bazel commit, abort bisecting.")
         if pos != -1:
             self.broken_by_infra = True
             return "\n".join([


### PR DESCRIPTION
It works by going back in the commit history to try to find a good commit that builds with the project.

The steps we try are 100, 200, 400, 800 commits...

Fixes https://github.com/bazelbuild/continuous-integration/issues/1438