### PR TITLE
Disable `//javatests/com/google/gerrit/server:server_tests` for gerrit

### DIFF
--- a/pipelines/gerrit.yml
+++ b/pipelines/gerrit.yml
@@ -30,6 +30,5 @@ platforms:
       - "--java_toolchain=@bazel_tools//tools/jdk:toolchain_java8"
       - "--test_tag_filters=-slow,-flaky,-docker"
     test_targets:
-      - "--"
       - "//..."
       - "-//javatests/com/google/gerrit/server:server_tests"

--- a/pipelines/gerrit.yml
+++ b/pipelines/gerrit.yml
@@ -30,4 +30,6 @@ platforms:
       - "--java_toolchain=@bazel_tools//tools/jdk:toolchain_java8"
       - "--test_tag_filters=-slow,-flaky,-docker"
     test_targets:
+      - "--"
       - "//..."
+      - "-//javatests/com/google/gerrit/server:server_tests"


### PR DESCRIPTION
This test is very flaky in Bazel downstream pipeline on macos:
https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2643#018359da-771e-4d6d-b608-386f08f1eeae