### PR TITLE
Re-enable Bazel examples in downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -117,7 +117,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/examples.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/examples/master/.bazelci/presubmit.yml",
         "pipeline_slug": "bazel-bazel-examples",
-        "disabled_reason": "https://github.com/bazelbuild/examples/pull/233",
     },
     "Bazel Remote Cache": {
         "git_repository": "https://github.com/buchgr/bazel-remote.git",


### PR DESCRIPTION
Bazel Examples are now fixed with Bazel@HEAD: https://github.com/bazelbuild/bazel/issues/14361