### PR TITLE
Add Bazel with Bzlmod build in downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -103,6 +103,11 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "http_config": "https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/postsubmit.yml",
         "pipeline_slug": "bazel-bazel",
     },
+    "Bazel (with Bzlmod)": {
+        "git_repository": "https://github.com/bazelbuild/bazel.git",
+        "http_config": "https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/postsubmit_bzlmod.yml",
+        "pipeline_slug": "bazel-bazel-with-bzlmod",
+    },
     "Bazel Bench": {
         "git_repository": "https://github.com/bazelbuild/bazel-bench.git",
         "http_config": "https://raw.githubusercontent.com/bazelbuild/bazel-bench/master/.bazelci/postsubmit.yml",


### PR DESCRIPTION
The https://buildkite.com/bazel/bazel-bazel-with-bzlmod pipeline will switch to build with Bazel@latest_release, and the downstream pipeline will guard Bazel@HEAD build Bazel with Bzlmod enabled.