### PR TITLE
Adding docker-ce to ubuntu2204

### DIFF
--- a/buildkite/docker/ubuntu2204/Dockerfile
+++ b/buildkite/docker/ubuntu2204/Dockerfile
@@ -68,6 +68,15 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     apt-get update -y && apt-get install google-cloud-sdk -y && \
     rm -rf /var/lib/apt/lists/*
 
+### Docker (for rules_docker)
+RUN apt-get -y update && \
+    apt-get -y install apt-transport-https ca-certificates && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    add-apt-repository "deb [arch=$BUILDARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    apt-get -y update && \
+    apt-get -y install docker-ce && \
+    rm -rf /var/lib/apt/lists/*
+
 # Bazelisk
 RUN LATEST_BAZELISK=$(curl -sSI https://github.com/bazelbuild/bazelisk/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
     curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${BUILDARCH} && \


### PR DESCRIPTION
The removal of ubuntu2104 broke the CI for rules_docker (https://github.com/bazelbuild/continuous-integration/pull/1422#issuecomment-1275422478). We had to downgrade to ubuntu2004, which is not ideal.

Adding docker-ce to ubuntu2204 so rules_docker can use it. 