### PR TITLE
Prevent the publish bazel binary pipeline from stamping Bazel version in the binaries

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1522,8 +1522,11 @@ def current_branch_is_main_branch():
 
 
 def get_release_name_from_branch_name():
+    # TODO(pcloudy): Find a better way to do this
+    if os.getenv("BUILDKITE_PIPELINE_SLUG") == "publish-bazel-binaries":
+        return None
     res = re.match(r"release-(\d+\.\d+\.\d+(rc\d+)?).*", os.getenv("BUILDKITE_BRANCH"))
-    return res.group(1) if res else ""
+    return res.group(1) if res else None
 
 
 def is_pull_request():


### PR DESCRIPTION
In https://github.com/bazelbuild/continuous-integration/pull/1195 we add `--stamp --embed_label=<version>` by parsing the branch name to fix https://github.com/bazelbuild/bazel/issues/13712. This is also causing the https://buildkite.com/bazel-trusted/publish-bazel-binaries pipeline to publish binaries with version stamp from commits in release branches. This could be confusing, because commits from `release-6.0.0` will always have version `6.0.0`. This PR tries to prevent that.