### PR TITLE
Add experimental ARM64 Linux support

### DIFF
--- a/buildkite/docker/build_arm64.sh
+++ b/buildkite/docker/build_arm64.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# TODO(fweikert): merge this file into build.sh once ARM64 support is no longer experimental
+
+set -euxo pipefail
+
+case $(git symbolic-ref --short HEAD) in
+    master)
+        PREFIX="bazel-public"
+        ;;
+    testing)
+        PREFIX="bazel-public/testing"
+        ;;
+    *)
+        echo "You must build Docker images either from the master or the testing branch!"
+        exit 1
+esac
+
+docker buildx builder prune -a -f
+docker buildx buildx create --name cibuilder --use
+
+# Containers used by Bazel CI
+docker buildx build -f centos7/Dockerfile    --target centos7           --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/centos7" centos7 &
+docker buildx build -f debian10/Dockerfile   --target debian10-java11   --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/debian10-java11" debian10 &
+docker buildx build -f debian11/Dockerfile   --target debian11-java17   --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/debian11-java17" debian11 &
+docker buildx build -f ubuntu1604/Dockerfile --target ubuntu1604-java8  --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu1604-java8" ubuntu1604 &
+docker buildx build -f ubuntu1804/Dockerfile --target ubuntu1804-java11 --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu1804-java11" ubuntu1804 &
+docker buildx build -f ubuntu2004/Dockerfile --target ubuntu2004-java11 --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu2004-java11" ubuntu2004 &
+docker buildx build -f ubuntu2204/Dockerfile --target ubuntu2204-java17 --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu2204-java17" ubuntu2204 &
+wait
+
+docker buildx build -f centos7/Dockerfile    --target centos7-java8               --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/centos7-java8" centos7
+docker buildx build -f centos7/Dockerfile    --target centos7-java11              --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/centos7-java11" centos7
+docker buildx build -f centos7/Dockerfile    --target centos7-java11-devtoolset10 --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/centos7-java11-devtoolset10" centos7
+docker buildx build -f centos7/Dockerfile    --target centos7-releaser            --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/centos7-releaser" centos7
+docker buildx build -f ubuntu1604/Dockerfile --target ubuntu1604-bazel-java8      --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu1604-bazel-java8" ubuntu1604
+docker buildx build -f ubuntu1804/Dockerfile --target ubuntu1804-bazel-java11     --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu1804-bazel-java11" ubuntu1804
+docker buildx build -f ubuntu2004/Dockerfile --target ubuntu2004-bazel-java11     --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu2004-bazel-java11" ubuntu2004
+docker buildx build -f ubuntu2004/Dockerfile --target ubuntu2004-java11-kythe     --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu2004-java11-kythe" ubuntu2004
+docker buildx build -f ubuntu2204/Dockerfile --target ubuntu2204-bazel-java17     --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu2204-bazel-java17" ubuntu2204

--- a/buildkite/docker/centos7/Dockerfile
+++ b/buildkite/docker/centos7/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7 as centos7
-ARG BUILDARCH
+ARG TARGETARCH
 
 # Install required packages.
 COPY google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
@@ -48,13 +48,13 @@ RUN localedef -i en_US -f ISO-8859-1 en_US.ISO-8859-1
 
 # Bazelisk
 RUN LATEST_BAZELISK=$(curl -sSI https://github.com/bazelbuild/bazelisk/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/bazel && \
     chmod 0755 /usr/local/bin/bazel
 
 # Buildifier
 RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/buildifier && \
     chmod 0755 /usr/local/bin/buildifier
 
@@ -64,9 +64,15 @@ RUN yum install -y java-1.8.0-openjdk-devel && yum clean all
 FROM centos7 AS centos7-java11
 
 # Unfortunately Azul doesn't publish an RPM package for zulu11 on aarch64, so we have to use the tar.gz version.
+RUN
 RUN mkdir -p /usr/lib/jvm/zulu-11 && \
     pushd /usr/lib/jvm/zulu-11 && \
-    curl "https://cdn.azul.com/zulu/bin/zulu11.58.23-ca-jdk11.0.16.1-linux_x64.tar.gz" | tar xvz --strip-components=1 && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+    export DOWNLOAD_URL="https://cdn.azul.com/zulu-embedded/bin/zulu11.58.23-ca-jdk11.0.16.1-linux_aarch64.tar.gz" ; \
+    else \
+    export DOWNLOAD_URL="https://cdn.azul.com/zulu/bin/zulu11.58.23-ca-jdk11.0.16.1-linux_x64.tar.gz" ; \
+    fi; \
+    curl "$DOWNLOAD_URL" | tar xvz --strip-components=1 && \
     update-alternatives \
         --install /usr/bin/java java /usr/lib/jvm/zulu-11/bin/java 2115200 \
         --slave /usr/bin/jaotc jaotc /usr/lib/jvm/zulu-11/bin/jaotc \

--- a/buildkite/docker/debian10/Dockerfile
+++ b/buildkite/docker/debian10/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:10 as debian10-java11
-ARG BUILDARCH
+ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV LANG "C.UTF-8"
@@ -56,7 +56,7 @@ RUN apt-get -y update && \
 # Allow using sudo inside the container.
 RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${BUILDARCH}
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${TARGETARCH}
 
 ### Install Google Cloud SDK.
 ### https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
@@ -69,19 +69,19 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 RUN apt-get -y update && \
     apt-get -y install apt-transport-https ca-certificates && \
     curl -sSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=$BUILDARCH] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
+    add-apt-repository "deb [arch=$TARGETARCH] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
     apt-get -y update && \
     apt-get -y install docker-ce && \
     rm -rf /var/lib/apt/lists/*
 
 # Bazelisk
 RUN LATEST_BAZELISK=$(curl -sSI https://github.com/bazelbuild/bazelisk/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/bazel && \
     chmod 0755 /usr/local/bin/bazel
 
 # Buildifier
 RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/buildifier && \
     chmod 0755 /usr/local/bin/buildifier

--- a/buildkite/docker/debian11/Dockerfile
+++ b/buildkite/docker/debian11/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:11 as debian11-java17
-ARG BUILDARCH
+ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV LANG "C.UTF-8"
@@ -56,7 +56,7 @@ RUN apt-get -y update && \
 # Allow using sudo inside the container.
 RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-${BUILDARCH}
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-${TARGETARCH}
 
 ### Install Google Cloud SDK.
 ### https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
@@ -69,19 +69,19 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 RUN apt-get -y update && \
     apt-get -y install apt-transport-https ca-certificates && \
     curl -sSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=$BUILDARCH] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
+    add-apt-repository "deb [arch=$TARGETARCH] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
     apt-get -y update && \
     apt-get -y install docker-ce && \
     rm -rf /var/lib/apt/lists/*
 
 # Bazelisk
 RUN LATEST_BAZELISK=$(curl -sSI https://github.com/bazelbuild/bazelisk/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/bazel && \
     chmod 0755 /usr/local/bin/bazel
 
 # Buildifier
 RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/buildifier && \
     chmod 0755 /usr/local/bin/buildifier

--- a/buildkite/docker/push_arm64.sh
+++ b/buildkite/docker/push_arm64.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# TODO(fweikert): merge this file into push.sh once ARM64 support is no longer experimental
+
+set -euxo pipefail
+
+case $(git symbolic-ref --short HEAD) in
+    master)
+        PREFIX="bazel-public"
+        ;;
+    testing)
+        PREFIX="bazel-public/testing"
+        ;;
+    *)
+        echo "You must build Docker images either from the master or the testing branch!"
+        exit 1
+esac
+
+docker buildx builder prune -a -f
+docker buildx buildx create --name cibuilder --use
+
+# Containers used by Bazel CI
+docker buildx build --push -f centos7/Dockerfile    --target centos7           --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/centos7" centos7 &
+docker buildx build --push -f debian10/Dockerfile   --target debian10-java11   --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/debian10-java11" debian10 &
+docker buildx build --push -f debian11/Dockerfile   --target debian11-java17   --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/debian11-java17" debian11 &
+docker buildx build --push -f ubuntu1604/Dockerfile --target ubuntu1604-java8  --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu1604-java8" ubuntu1604 &
+docker buildx build --push -f ubuntu1804/Dockerfile --target ubuntu1804-java11 --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu1804-java11" ubuntu1804 &
+docker buildx build --push -f ubuntu2004/Dockerfile --target ubuntu2004-java11 --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu2004-java11" ubuntu2004 &
+docker buildx build --push -f ubuntu2204/Dockerfile --target ubuntu2204-java17 --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu2204-java17" ubuntu2204 &
+wait
+
+docker buildx build --push -f centos7/Dockerfile    --target centos7-java8               --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/centos7-java8" centos7
+docker buildx build --push -f centos7/Dockerfile    --target centos7-java11              --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/centos7-java11" centos7
+docker buildx build --push -f centos7/Dockerfile    --target centos7-java11-devtoolset10 --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/centos7-java11-devtoolset10" centos7
+docker buildx build --push -f centos7/Dockerfile    --target centos7-releaser            --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/centos7-releaser" centos7
+docker buildx build --push -f ubuntu1604/Dockerfile --target ubuntu1604-bazel-java8      --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu1604-bazel-java8" ubuntu1604
+docker buildx build --push -f ubuntu1804/Dockerfile --target ubuntu1804-bazel-java11     --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu1804-bazel-java11" ubuntu1804
+docker buildx build --push -f ubuntu2004/Dockerfile --target ubuntu2004-bazel-java11     --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu2004-bazel-java11" ubuntu2004
+docker buildx build --push -f ubuntu2004/Dockerfile --target ubuntu2004-java11-kythe     --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu2004-java11-kythe" ubuntu2004
+docker buildx build --push -f ubuntu2204/Dockerfile --target ubuntu2204-bazel-java17     --platform linux/arm64,linux/amd64 -t "gcr.io/$PREFIX/ubuntu2204-bazel-java17" ubuntu2204

--- a/buildkite/docker/ubuntu1604/Dockerfile
+++ b/buildkite/docker/ubuntu1604/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04 as ubuntu1604-bazel-java8
-ARG BUILDARCH
+ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV LANG "C.UTF-8"
@@ -55,7 +55,7 @@ RUN apt-get -y update && \
 # Allow using sudo inside the container.
 RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-${BUILDARCH}
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-${TARGETARCH}
 
 FROM ubuntu1604-bazel-java8 AS ubuntu1604-java8
 
@@ -87,19 +87,19 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 RUN apt-get -y update && \
     apt-get -y install apt-transport-https ca-certificates && \
     curl -sSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=$BUILDARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    add-apt-repository "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-get -y update && \
     apt-get -y install docker-ce && \
     rm -rf /var/lib/apt/lists/*
 
 # Bazelisk
 RUN LATEST_BAZELISK=$(curl -sSI https://github.com/bazelbuild/bazelisk/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/bazel && \
     chmod 0755 /usr/local/bin/bazel
 
 # Buildifier
 RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/buildifier && \
     chmod 0755 /usr/local/bin/buildifier

--- a/buildkite/docker/ubuntu1804/Dockerfile
+++ b/buildkite/docker/ubuntu1804/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04 as ubuntu1804-bazel-java11
-ARG BUILDARCH
+ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV LANG "C.UTF-8"
@@ -56,7 +56,7 @@ RUN apt-get -y update && \
 # Allow using sudo inside the container.
 RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${BUILDARCH}
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${TARGETARCH}
 
 FROM ubuntu1804-bazel-java11 AS ubuntu1804-java11
 
@@ -71,19 +71,19 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 RUN apt-get -y update && \
     apt-get -y install apt-transport-https ca-certificates && \
     curl -sSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=$BUILDARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    add-apt-repository "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-get -y update && \
     apt-get -y install docker-ce && \
     rm -rf /var/lib/apt/lists/*
 
 # Bazelisk
 RUN LATEST_BAZELISK=$(curl -sSI https://github.com/bazelbuild/bazelisk/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/bazel && \
     chmod 0755 /usr/local/bin/bazel
 
 # Buildifier
 RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/buildifier && \
     chmod 0755 /usr/local/bin/buildifier

--- a/buildkite/docker/ubuntu2004/Dockerfile
+++ b/buildkite/docker/ubuntu2004/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04 as ubuntu2004-bazel-java11
-ARG BUILDARCH
+ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV LANG "C.UTF-8"
@@ -57,7 +57,7 @@ RUN apt-get -y update && \
 # Allow using sudo inside the container.
 RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${BUILDARCH}
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${TARGETARCH}
 
 FROM ubuntu2004-bazel-java11 AS ubuntu2004-java11
 
@@ -72,20 +72,20 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 RUN apt-get -y update && \
     apt-get -y install apt-transport-https ca-certificates && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=$BUILDARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    add-apt-repository "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-get -y update && \
     apt-get -y install docker-ce && \
     rm -rf /var/lib/apt/lists/*
 
 # Bazelisk
 RUN LATEST_BAZELISK=$(curl -sSI https://github.com/bazelbuild/bazelisk/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/bazel && \
     chmod 0755 /usr/local/bin/bazel
 
 # Buildifier
 RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/buildifier && \
     chmod 0755 /usr/local/bin/buildifier
 

--- a/buildkite/docker/ubuntu2204/Dockerfile
+++ b/buildkite/docker/ubuntu2204/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04 as ubuntu2204-bazel-java17
-ARG BUILDARCH
+ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV LANG "C.UTF-8"
@@ -57,7 +57,7 @@ RUN apt-get -y update && \
 # Allow using sudo inside the container.
 RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-${BUILDARCH}
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-${TARGETARCH}
 
 FROM ubuntu2204-bazel-java17 AS ubuntu2204-java17
 
@@ -72,19 +72,19 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 RUN apt-get -y update && \
     apt-get -y install apt-transport-https ca-certificates && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=$BUILDARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    add-apt-repository "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-get -y update && \
     apt-get -y install docker-ce && \
     rm -rf /var/lib/apt/lists/*
 
 # Bazelisk
 RUN LATEST_BAZELISK=$(curl -sSI https://github.com/bazelbuild/bazelisk/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/bazel && \
     chmod 0755 /usr/local/bin/bazel
 
 # Buildifier
 RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/buildifier && \
     chmod 0755 /usr/local/bin/buildifier

--- a/buildkite/gcloud.py
+++ b/buildkite/gcloud.py
@@ -31,7 +31,7 @@ def debug(*args, **kwargs):
 
 
 def is_sequence(seq):
-    return isinstance(seq, collections.Sequence) and not isinstance(seq, str)
+    return isinstance(seq, collections.abc.Sequence) and not isinstance(seq, str)
 
 
 def gcloud(*args, **kwargs):

--- a/buildkite/instances.yml
+++ b/buildkite/instances.yml
@@ -37,6 +37,12 @@ instance_groups:
     service_account: buildkite-testing@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-testing-docker
     metadata_from_file: startup-script=startup-docker-pdssd.sh
+  - name: bk-testing-docker-arm64
+    count: 2
+    project: bazel-untrusted
+    service_account: buildkite-testing@bazel-untrusted.iam.gserviceaccount.com
+    image_family: bk-testing-docker-arm64
+    metadata_from_file: startup-script=startup-docker-pdssd.sh
   - name: bk-trusted-docker
     count: 8
     project: bazel-public

--- a/buildkite/promote_images.py
+++ b/buildkite/promote_images.py
@@ -32,6 +32,15 @@ IMAGE_PROMOTIONS = {
             "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
         ],
     },
+    "bk-docker-arm64": {
+        "project": "bazel-public",
+        "source_image_project": "bazel-public",
+        "source_image_family": "bk-testing-docker-arm64",
+        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE"],
+        "licenses": [
+            "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
+        ],
+    },
     "bk-windows": {
         "project": "bazel-public",
         "source_image_project": "bazel-public",

--- a/buildkite/startup-docker-pdssd.sh
+++ b/buildkite/startup-docker-pdssd.sh
@@ -58,11 +58,18 @@ systemctl start docker
 gcloud auth configure-docker --quiet
 sudo -H -u buildkite-agent gcloud auth configure-docker --quiet
 
+if [[ "$(uname -m)" == "aarch64" ]];
+then
+  AGENT_QUEUE="linux_arm64"
+else
+  AGENT_QUEUE="default"
+fi
+
 ### Write the Buildkite agent configuration.
 cat > /etc/buildkite-agent/buildkite-agent.cfg <<EOF
 token="${BUILDKITE_TOKEN}"
 name="%hostname"
-tags="queue=default,kind=docker,os=linux"
+tags="queue=${AGENT_QUEUE},kind=docker,os=linux"
 experiment="git-mirrors"
 build-path="/var/lib/buildkite-agent/builds"
 git-mirrors-path="/var/lib/gitmirrors"


### PR DESCRIPTION
The basic idea is to publish multi-arch Docker images, and then run the ARM64 images on the newly added Tau T2A VMs.

I'm adding separate build/push scripts to not affect the existing images, since this change needs more testing. That's also why it only adds machines to the testing org, and why I'm merging this commit into the testing branch for now.

Progress towards #1112 and #1402