### PR TITLE
Run macos_arm64 tasks on Apple Silicon (second try)

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -573,9 +573,7 @@ PLATFORMS = {
         "emoji-name": ":darwin: arm64 (OpenJDK 8, Xcode)",
         "downstream-root": "/Users/buildkite/builds/${BUILDKITE_AGENT_NAME}/${BUILDKITE_ORGANIZATION_SLUG}-downstream-projects",
         "publish_binary": ["macos_arm64"],
-        # TODO(pcloudy): Switch to macos_arm64 queue when Apple Silicon machines are available,
-        # current we just use x86_64 machines to do cross compile.
-        "queue": "macos",
+        "queue": "macos_arm64",
         "python": "python3",
     },
     "experimental_macos_arm64": {


### PR DESCRIPTION
This reverts commit 56a24e5e0764cf6b73f1e1e205b086e241d63748.

Can probably fix the breakage in https://github.com/bazelbuild/bazel/pull/16541#issuecomment-1320267168