### PR TITLE
Always run bcr_validation.py even when no specific module version detected

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -371,9 +371,8 @@ def main(argv=None):
             add_presubmit_jobs(module_name, module_version, configs.get("tasks", {}), pipeline_steps)
             configs = get_test_module_task_config(module_name, module_version)
             add_presubmit_jobs(module_name, module_version, configs.get("tasks", {}), pipeline_steps, is_test_module=True)
-        if should_wait_bcr_maintainer_review(modules):
-            if pipeline_steps:
-                pipeline_steps = [{"block": "Wait on BCR maintainer review", "blocked_state": "failed"}] + pipeline_steps
+        if should_wait_bcr_maintainer_review(modules) and pipeline_steps:
+            pipeline_steps = [{"block": "Wait on BCR maintainer review", "blocked_state": "failed"}] + pipeline_steps
         upload_jobs_to_pipeline(pipeline_steps)
     elif args.subparsers_name == "runner":
         repo_location = create_simple_repo(args.module_name, args.module_version, args.task)

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -303,11 +303,9 @@ def validate_files_outside_of_modules_dir_are_not_modified(modules):
 
 
 def should_bcr_validation_block_presubmit(modules):
-    if not modules:
-        return
     bazelci.print_collapsed_group("Running BCR validations:")
     returncode = subprocess.run(
-        ["python3", "./tools/bcr_validation.py"] + [f"--check={name}@{version}" for name, version in modules]
+        ["python3", "./tools/bcr_validation.py", "--check_all_metadata"] + [f"--check={name}@{version}" for name, version in modules]
     ).returncode
     # When a BCR maintainer view is required, the script should return 42.
     if returncode == 42:
@@ -366,15 +364,16 @@ def main(argv=None):
     if args.subparsers_name == "bcr_presubmit":
         modules = get_target_modules()
         if not modules:
-            bazelci.eprint("No target modules detected in this branch!")
+            bazelci.eprint("No target module versions detected in this branch!")
         pipeline_steps = []
         for module_name, module_version in modules:
             configs = get_task_config(module_name, module_version)
             add_presubmit_jobs(module_name, module_version, configs.get("tasks", {}), pipeline_steps)
             configs = get_test_module_task_config(module_name, module_version)
             add_presubmit_jobs(module_name, module_version, configs.get("tasks", {}), pipeline_steps, is_test_module=True)
-        if pipeline_steps and should_wait_bcr_maintainer_review(modules):
-            pipeline_steps = [{"block": "Wait on BCR maintainer review", "blocked_state": "failed"}] + pipeline_steps
+        if should_wait_bcr_maintainer_review(modules):
+            if pipeline_steps:
+                pipeline_steps = [{"block": "Wait on BCR maintainer review", "blocked_state": "failed"}] + pipeline_steps
         upload_jobs_to_pipeline(pipeline_steps)
     elif args.subparsers_name == "runner":
         repo_location = create_simple_repo(args.module_name, args.module_version, args.task)


### PR DESCRIPTION
Because we need to always verify the metadata.json files are valid, wait until https://github.com/bazelbuild/bazel-central-registry/pull/309 is merged first.