### PR TITLE
Build java_tools for darwin arm64

### DIFF
--- a/pipelines/java_tools-binaries.yml
+++ b/pipelines/java_tools-binaries.yml
@@ -46,7 +46,7 @@ steps:
       bazel --ignore_all_rc_files version
       ./src/upload_all_java_tools.sh
     env:
-      BAZEL_USE_CPP_ONLY_TOOLCHAIN: "1"
+      BAZEL_USE_CPP_ONLY_TOOLCHAIN: "0"
     label: ":darwin:"
     agents:
       - "queue=macos_arm64"

--- a/pipelines/java_tools-binaries.yml
+++ b/pipelines/java_tools-binaries.yml
@@ -37,7 +37,7 @@ steps:
       bazel --ignore_all_rc_files version
       ./src/upload_all_java_tools.sh
     env:
-      BAZEL_USE_CPP_ONLY_TOOLCHAIN: "1"
+      BAZEL_USE_CPP_ONLY_TOOLCHAIN: "0"
     label: ":darwin:"
     agents:
       - "queue=macos"

--- a/pipelines/java_tools-binaries.yml
+++ b/pipelines/java_tools-binaries.yml
@@ -40,4 +40,4 @@ steps:
       BAZEL_USE_CPP_ONLY_TOOLCHAIN: "0"
     label: ":darwin:"
     agents:
-      - "queue=macos_arm64"
+      - "queue=macos"

--- a/pipelines/java_tools-binaries.yml
+++ b/pipelines/java_tools-binaries.yml
@@ -41,3 +41,12 @@ steps:
     label: ":darwin:"
     agents:
       - "queue=macos"
+
+  - command: |-
+      bazel --ignore_all_rc_files version
+      ./src/upload_all_java_tools.sh
+    env:
+      BAZEL_USE_CPP_ONLY_TOOLCHAIN: "1"
+    label: ":darwin:"
+    agents:
+      - "queue=macos_arm64"

--- a/pipelines/java_tools-binaries.yml
+++ b/pipelines/java_tools-binaries.yml
@@ -40,13 +40,4 @@ steps:
       BAZEL_USE_CPP_ONLY_TOOLCHAIN: "0"
     label: ":darwin:"
     agents:
-      - "queue=macos"
-
-  - command: |-
-      bazel --ignore_all_rc_files version
-      ./src/upload_all_java_tools.sh
-    env:
-      BAZEL_USE_CPP_ONLY_TOOLCHAIN: "0"
-    label: ":darwin:"
-    agents:
       - "queue=macos_arm64"


### PR DESCRIPTION
java_tools for darwin will be built as a fat universal binary after https://github.com/bazelbuild/bazel/pull/16960 so it needs to use the osx toolchain.