### PR TITLE
Change BCR CI to show pending when blocked

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -372,7 +372,7 @@ def main(argv=None):
             configs = get_test_module_task_config(module_name, module_version)
             add_presubmit_jobs(module_name, module_version, configs.get("tasks", {}), pipeline_steps, is_test_module=True)
         if should_wait_bcr_maintainer_review(modules) and pipeline_steps:
-            pipeline_steps = [{"block": "Wait on BCR maintainer review", "blocked_state": "failed"}] + pipeline_steps
+            pipeline_steps = [{"block": "Wait on BCR maintainer review", "blocked_state": "running"}] + pipeline_steps
         upload_jobs_to_pipeline(pipeline_steps)
     elif args.subparsers_name == "runner":
         repo_location = create_simple_repo(args.module_name, args.module_version, args.task)


### PR DESCRIPTION
As a contributor seeing "failed" in a CI status on your PR implies you should go and fix it, but in this case it just means you're waiting on someone with access to run the job.