### PR TITLE
[agent] Cross compile bazelci-agent to linux aarch64

### DIFF
--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -59,12 +59,16 @@ jobs:
       RUST_BACKTRACE: 1
     strategy:
       matrix:
-        build: [linux, macos-intel, macos-m1, win-msvc]
+        build: [linux, linux-aarch64, macos-intel, macos-m1, win-msvc]
         include:
         - build: linux
-          os: ubuntu-18.04
+          os: ubuntu-latest
           rust: nightly
           target: x86_64-unknown-linux-musl
+        - build: linux-aarch64
+          os: ubuntu-latest
+          rust: nightly
+          target: aarch64-unknown-linux-musl # cross compile to aarch64 on x86_64
         - build: macos-intel
           os: macos-latest
           rust: nightly
@@ -72,13 +76,17 @@ jobs:
         - build: macos-m1
           os: macos-latest
           rust: nightly
-          target: aarch64-apple-darwin # cross compile to M1 on Intel CPU
+          target: aarch64-apple-darwin # cross compile to aarch64 on x86_64
         - build: win-msvc
           os: windows-latest
           rust: nightly
           target: x86_64-pc-windows-msvc
 
     steps:
+    - name: Install deps (linux-aarch64)
+      if: matrix.build == 'linux-aarch64'
+      run: sudo apt-get install g++-aarch64-linux-gnu
+
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
@@ -93,7 +101,7 @@ jobs:
         target: ${{ matrix.target }}
 
     - name: Test release binary
-      if: matrix.build != 'macos-m1' # Can't run M1 binary on Intel CPU
+      if: matrix.build != 'macos-m1' && matrix.build != 'linux-aarch64' # Can't run aarch64 binary on x86_64
       working-directory: agent
       run: cargo test --verbose --release --target ${{ matrix.target }}
 
@@ -105,6 +113,11 @@ jobs:
       if: matrix.build == 'linux' || matrix.build == 'macos-intel' || matrix.build == 'macos-m1'
       working-directory: agent
       run: strip "target/${{ matrix.target }}/release/bazelci-agent"
+
+    - name: Strip release binary (linux-aarch64)
+      if: matrix.build == 'linux-aarch64'
+      working-directory: agent
+      run: aarch64-linux-gnu-strip "target/${{ matrix.target }}/release/bazelci-agent"
 
     - name: Build release asset
       shell: bash

--- a/agent/.cargo/config.toml
+++ b/agent/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
Update Github Action to cross compile `bazelci-agent` to `aarch64` linux on `x86_64` linux.

Example Github Action run: https://github.com/coeuvre/continuous-integration/actions/runs/3931810914/jobs/6723557885
Example release: https://github.com/coeuvre/continuous-integration/releases/tag/agent-0.1.5
Example BazelCI run: https://buildkite.com/bazel-testing/bazel-bazel/builds/8491

Working towards fixing https://github.com/bazelbuild/continuous-integration/issues/1513.