### PR TITLE
Release agent-0.1.4

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -68,7 +68,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bazelci-agent"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bazelci-agent"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Changelog:
* Streaming failed test logs to Buildkite. (https://github.com/bazelbuild/continuous-integration/pull/1531)