### PR TITLE
Fix MacOS version detection

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -56,8 +56,8 @@ GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": 
     BUILDKITE_ORG
 ]
 
-SCRIPT_URL = "https://raw.githubusercontent.com/fweikert/continuous-integration/xcode/buildkite/bazelci.py?{}".format(
-    int(time.time())
+SCRIPT_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/bazelci.py?{}".format(
+    GITHUB_BRANCH, int(time.time())
 )
 
 AGGREGATE_INCOMPATIBLE_TEST_RESULT_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/aggregate_incompatible_flags_test_result.py?{}".format(

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -56,8 +56,8 @@ GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": 
     BUILDKITE_ORG
 ]
 
-SCRIPT_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/bazelci.py?{}".format(
-    GITHUB_BRANCH, int(time.time())
+SCRIPT_URL = "https://raw.githubusercontent.com/fweikert/continuous-integration/xcode/buildkite/bazelci.py?{}".format(
+    int(time.time())
 )
 
 AGGREGATE_INCOMPATIBLE_TEST_RESULT_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/aggregate_incompatible_flags_test_result.py?{}".format(
@@ -1444,7 +1444,8 @@ def execute_commands(
 
 
 def get_default_xcode_version():
-    macos, _, _ = platform_module.mac_ver()
+    # Cannot use platform.mac_ver() since it returns 10.16 on both 12.x and 13.x
+    macos = execute_command_and_get_output(["sw_vers", "-productVersion"], print_output=False)
     major = int(macos.split(".")[0])
     return DEFAULT_XCODE_VERSION_PER_OS.get(major, "13.0")  # we use 13.0 due to legacy reasons
 


### PR DESCRIPTION
https://github.com/bazelbuild/continuous-integration/pull/1542 relied on platform.mac_ver() to detect the MacOS version, which did not work as expected. Consequently, the previous PR led the CI to activate an incorrect version of Xcode. This behavior has been fixed by this change.

Related to #1431.

Users can still request a specific Xcode version in their CI config.