### PR TITLE
Actually skip duplicate downstream jobs...

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2436,6 +2436,8 @@ def print_project_pipeline(
                         task_config.get("bazel", "latest"),
                     )
                 )
+                continue
+
             config_hashes.add(h)
 
         shards = task_config.get("shards", "1")


### PR DESCRIPTION
...instead of just posting a warning about them.

PR #1492 introduced this bug by incorrectly deleting a `continue` statement. As a result, CI did NOT skip duplicate tasks, even though it claimed the opposite.

Found while debugging #1455