### PR TITLE
Add link to supported platforms in README

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -214,6 +214,8 @@ tasks:
     - "..."
 ```
 
+The full list of supported platforms can be found in the PLATFORMS variable in [bazelci.py](./bazelci.py).
+
 ### Setting Environment Variables
 
 You can set environment variables for each individual task via the `environment` field:


### PR DESCRIPTION
Hi wonderful Bazelers,

I was reading the docs to help maintain rules_boost, and thought it might be a good idea to add a like to the list of supported platforms from the README. Otherwise, it's a little hard to track down the platforms' exact names if you don't know where to look.

(I figured I'd quickly propose a change rather than filing an issue to make things easier, but I'm not attached to the language. Feel free to change however you want, ofc. I'm linking rather than listing, figuring that makes the docs more resistant to going out to date at the cost of being somewhat harder to read.)

Cheers,
Chris