### PR TITLE
Enable --remote_download_minimal

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1799,6 +1799,7 @@ def remote_caching_flags(platform, accept_cached=True):
         "--remote_max_connections=200",
         '--remote_default_platform_properties=properties:{name:"cache-silo-key" value:"%s"}'
         % platform_cache_digest.hexdigest(),
+        "--remote_download_minimal",
     ]
 
     if not accept_cached:
@@ -1888,6 +1889,7 @@ def rbe_flags(original_flags, accept_cached):
         "--incompatible_strict_action_env",
         "--google_default_credentials",
         "--toolchain_resolution_debug",
+        "--remote_download_minimal",
     ]
 
     # Enable BES / Build Results reporting.


### PR DESCRIPTION
Enable `--remote_download_minimal` by default for CI jobs when using remote caching or remote execution