### PR TITLE
chore: update default branch of rules_nodejs

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -372,7 +372,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     },
     "rules_nodejs": {
         "git_repository": "https://github.com/bazelbuild/rules_nodejs.git",
-        "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_nodejs/stable/.bazelci/presubmit.yml",
+        "http_config": "https://raw.githubusercontent.com/bazelbuild/rules_nodejs/main/.bazelci/presubmit.yml",
         "pipeline_slug": "rules-nodejs-nodejs",
     },
     "rules_perl": {

--- a/buildkite/terraform/bazel-testing/main.tf
+++ b/buildkite/terraform/bazel-testing/main.tf
@@ -152,7 +152,7 @@ resource "buildkite_pipeline" "rules-nodejs-nodejs" {
   name = "rules_nodejs :nodejs:"
   repository = "https://github.com/bazelbuild/rules_nodejs.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --monitor_flaky_tests=true | tee /dev/tty | buildkite-agent pipeline upload"] } })
-  default_branch = "stable"
+  default_branch = "main"
 }
 
 resource "buildkite_pipeline" "publish-bazel-binaries" {

--- a/buildkite/terraform/bazel/main.tf
+++ b/buildkite/terraform/bazel/main.tf
@@ -1748,7 +1748,7 @@ resource "buildkite_pipeline" "rules-nodejs-nodejs" {
   name = "rules_nodejs :nodejs:"
   repository = "https://github.com/bazelbuild/rules_nodejs.git"
   steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline | tee /dev/tty | buildkite-agent pipeline upload"] } })
-  default_branch = "stable"
+  default_branch = "main"
   team = [{ access_level = "BUILD_AND_READ", slug = "bazel" },  { access_level = "BUILD_AND_READ", slug = "rules-nodejs" }]
   provider_settings {
     trigger_mode = "code"


### PR DESCRIPTION
I'm not sure why these are hardcoded here, when GitHub API provides a way to know the name of the default branch in a repo. rules_nodejs is preparing a 6.0 which is big breaking change, so we're also taking the opportunity to switch to the standard name for default branch.

NOTE: I've left the `stable` branch on the repo, but it still points to the old 5.x branch of code, so this change is needed to start testing the current version.