### PR TITLE
Sort the result of matrix attribute combinations to make sure the expanded config result is stable

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -979,7 +979,7 @@ def get_combinations(matrix, attributes):
         if attr not in matrix:
             raise BuildkiteException("${{ %s }} is not defined in `matrix` section." % attr)
     pairs = [[(attr, value) for value in matrix[attr]] for attr in attributes]
-    return itertools.product(*pairs)
+    return sorted(itertools.product(*pairs))
 
 
 def get_expanded_task(task, combination):


### PR DESCRIPTION

Fixes https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2980#0187b62c-df13-48e9-b08a-f463da00dbfa where the job tried to download Windows Bazel binary on macOS. This happened because the result of 
https://github.com/bazelbuild/continuous-integration/blob/8bbca481121dc0188f816982fa9b1a9dcd44044b/buildkite/bazelci.py#L1010
was not stable, which means `all_tests_workspace_config_05` may point to the Windows config during the "Setup pipeline" job, but points to a Mac config when actually running the job.