### PR TITLE
Remove local test jobs for experiment.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2157,7 +2157,8 @@ def execute_bazel_test(
     aggregated_flags = [
         "--flaky_test_attempts=3",
         "--build_tests_only",
-        "--local_test_jobs=" + concurrent_test_jobs(platform),
+        # TODO(twerth): Remove after experiment.
+        # "--local_test_jobs=" + concurrent_test_jobs(platform),
     ]
     # Don't enable remote caching if the user enabled remote execution / caching themselves
     # or flaky test monitoring is enabled, as remote caching makes tests look less flaky than
@@ -2189,7 +2190,8 @@ def execute_bazel_test(
 def execute_bazel_coverage(bazel_version, bazel_binary, platform, flags, targets):
     aggregated_flags = [
         "--build_tests_only",
-        "--local_test_jobs=" + concurrent_test_jobs(platform),
+        # TODO(twerth): Remove after experiment.
+        # "--local_test_jobs=" + concurrent_test_jobs(platform),
     ]
     print_collapsed_group(":bazel: Computing flags for coverage step")
     aggregated_flags += compute_flags(


### PR DESCRIPTION
We decided five years ago that we need to limit concurrency for tests, especially on Macs. This was hardcoded to 8 for Macs, while we have machines with 36 and 20 cores today.

Best value might actually be in-between but we want to experiment without any restriction for now.