### PR TITLE
Integrate chocolatey build and push to release pipeline

### DIFF
--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -37,12 +37,10 @@ steps:
       if [[ \"\$release_name\" =~ .*rc.* ]]; then
         mode="rc"
       fi
-      
-      echo "mode = \"\$mode\""  
-    
+      echo "mode = \"\$mode\""
       buildkite-agent meta-data set "mode" "\$mode"
       
-      export choco_key=$(gsutil cat gs://bazel-trusted-encrypted-secrets/choco-trusted-token.enc | gcloud kms decrypt --project bazel-public --location global --keyring buildkite --key choco-trusted-token --ciphertext-file - --plaintext-file -)
+      choco_key=$(gsutil cat gs://bazel-trusted-encrypted-secrets/choco-trusted-token.enc | gcloud kms decrypt --project bazel-public --location global --keyring buildkite --key choco-trusted-token --ciphertext-file - --plaintext-file -)
       buildkite-agent meta-data set "choco_key" "\$choco_key"
 
   - wait
@@ -494,9 +492,9 @@ steps:
 
   - wait
 
-  - block: "Update packages"
+  - block: "Update Chocolatey"
 
-  - label: "Update packages"
+  - label: "Update Chocolatey"
     agents:
       - queue=windows
     command: |
@@ -507,13 +505,11 @@ steps:
       buildkite-agent meta-data get "release_name" > release_name.txt
       SET /p RELEASE_NAME=<release_name.txt
       DEL /q release_name.txt
-      
       echo Release: %RELEASE_NAME%
       
       buildkite-agent meta-data get "mode" > mode.txt
       SET /p MODE=<mode.txt
       DEL /q mode.txt
-      
       echo Mode: %MODE%
       
       buildkite-agent meta-data get "choco_key" > choco_key.txt
@@ -529,7 +525,6 @@ steps:
         SET RC=%RELEASE_NAME:~-1%
         SET VERSION=%RELEASE_NAME:~0,-3%
       )
-      
       echo RC: %RC%
       echo VERSION: %VERSION%
       

--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -501,7 +501,9 @@ steps:
       echo Release: %RELEASE_NAME%
 
       echo "+++ Updating Chocolatey"
-      SET KEY_ID=$(gsutil cat gs://bazel-trusted-encrypted-secrets/choco-trusted-token.enc | gcloud kms decrypt --project bazel-public --location global --keyring buildkite --key choco-trusted-token --ciphertext-file - --plaintext-file -)
+      gsutil cat gs://bazel-trusted-encrypted-secrets/choco-trusted-token.enc | gcloud kms decrypt --project bazel-public --location global --keyring buildkite --key choco-trusted-token --ciphertext-file - --plaintext-file key.txt
+      SET /p KEY_ID=<key.txt
+      DEL /q key.txt
 
       choco apikey -k %KEY_ID% -s https://push.chocolatey.org/
 

--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -1,6 +1,6 @@
 ---
 steps:
-  - label: "Get release name"
+  - label: "Set up"
     agents:
       - "queue=default"
     plugins:
@@ -32,6 +32,18 @@ steps:
       release_name=\$(source scripts/release/common.sh; get_full_release_name)
       echo "release_name = \"\$release_name\""
       buildkite-agent meta-data set "release_name" "\$release_name"
+      
+      mode="release"
+      if [[ \"\$release_name\" =~ .*rc.* ]]; then
+        mode="rc"
+      fi
+      
+      echo "mode = \"\$mode\""  
+    
+      buildkite-agent meta-data set "mode" "\$mode"
+      
+      export choco_key=$(gsutil cat gs://bazel-trusted-encrypted-secrets/choco-trusted-token.enc | gcloud kms decrypt --project bazel-public --location global --keyring buildkite --key choco-trusted-token --ciphertext-file - --plaintext-file -)
+      buildkite-agent meta-data set "choco_key" "\$choco_key"
 
   - wait
 
@@ -483,30 +495,43 @@ steps:
   - wait
 
   - block: "Update packages"
-    if: build.branch !~ /rc/i
 
   - label: "Update packages"
     agents:
       - queue=windows
-    if: build.branch !~ /rc/i
     command: |
       echo "+++ Checking out Git branch"
       git fetch origin ${BUILDKITE_BRANCH}
       git checkout ${BUILDKITE_BRANCH}
-
+      
       buildkite-agent meta-data get "release_name" > release_name.txt
       SET /p RELEASE_NAME=<release_name.txt
       DEL /q release_name.txt
-
+      
       echo Release: %RELEASE_NAME%
-
-      echo "+++ Updating Chocolatey"
-      gsutil cat gs://bazel-trusted-encrypted-secrets/choco-trusted-token.enc | gcloud kms decrypt --project bazel-public --location global --keyring buildkite --key choco-trusted-token --ciphertext-file - --plaintext-file key.txt
-      SET /p KEY_ID=<key.txt
-      DEL /q key.txt
-
-      choco apikey -k %KEY_ID% -s https://push.chocolatey.org/
-
-      cd "scripts/packages/chocolatey"
-      powershell -Command "./build.ps1 -version %RELEASE_NAME% -mode \"release\""
+      
+      buildkite-agent meta-data get "mode" > mode.txt
+      SET /p MODE=<mode.txt
+      DEL /q mode.txt
+      
+      echo Mode: %MODE%
+      
+      buildkite-agent meta-data get "choco_key" > choco_key.txt
+      SET /p KEY=<choco_key.txt
+      DEL /q choco_key.txt
+                
+      cd "scripts/packages/chocolatey"    
+      choco apikey -k %KEY% -s https://push.chocolatey.org/
+      
+      SET RC=0
+      SET VERSION=%RELEASE_NAME%
+      if "%MODE%"=="rc" (
+        SET RC=%RELEASE_NAME:~-1%
+        SET VERSION=%RELEASE_NAME:~0,-3%
+      )
+      
+      echo RC: %RC%
+      echo VERSION: %VERSION%
+      
+      powershell -Command "./build.ps1 -version %VERSION% -mode %MODE% -rc %RC%"
       choco push      

--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -479,3 +479,32 @@ steps:
       echo "+++ Deploying release"
       source scripts/ci/build.sh
       deploy_release "\${ARTIFACTS}"
+
+  - wait
+
+  - block: "Update packages"
+    if: build.branch !~ /rc/i
+
+  - label: "Update packages"
+    agents:
+      - queue=windows
+    if: build.branch !~ /rc/i
+    command: |
+      echo "+++ Checking out Git branch"
+      git fetch origin ${BUILDKITE_BRANCH}
+      git checkout ${BUILDKITE_BRANCH}
+
+      buildkite-agent meta-data get "release_name" > release_name.txt
+      SET /p RELEASE_NAME=<release_name.txt
+      DEL /q release_name.txt
+
+      echo Release: %RELEASE_NAME%
+
+      echo "+++ Updating Chocolatey"
+      SET KEY_ID=$(gsutil cat gs://bazel-trusted-encrypted-secrets/choco-trusted-token.enc | gcloud kms decrypt --project bazel-public --location global --keyring buildkite --key choco-trusted-token --ciphertext-file - --plaintext-file -)
+
+      choco apikey -k %KEY_ID% -s https://push.chocolatey.org/
+
+      cd "scripts/packages/chocolatey"
+      powershell -Command "./build.ps1 -version %RELEASE_NAME% -mode \"release\""
+      choco push      


### PR DESCRIPTION
Issue: https://github.com/bazelbuild/continuous-integration/issues/1456

One successful run (without choco push): https://buildkite.com/bazel-trusted/bazel-release/builds/1149#0187e4f2-cde0-43c8-b4ef-4c250c053249

```
StatusCode        : 200
StatusDescription : OK
Content           : {53, 51, 52, 51...}
RawContent        : HTTP/1.1 200 OK
                    X-GUploader-UploadID: ADPycdukvqcJCd4f9KE2dONfu7OoJ-rkJAcXSwFNDbU8tnv9bSE_YzaESHqyOL4OkcEkp-4Uatv1_
                    0uJYJRztxp4Lr9fw0XXqIoJ
                    x-goog-generation: 1682371417868867
                    x-goog-metageneration:...
Headers           : {[X-GUploader-UploadID, ADPycdukvqcJCd4f9KE2dONfu7OoJ-rkJAcXSwFNDbU8tnv9bSE_YzaESHqyOL4OkcEkp-4Uatv
                    1_0uJYJRztxp4Lr9fw0XXqIoJ], [x-goog-generation, 1682371417868867], [x-goog-metageneration, 1],
                    [x-goog-stored-content-encoding, identity]...}
RawContentLength  : 100
 
Copying LICENSE from repo-root to tools directory
Chocolatey v1.2.1
Attempting to build package from 'bazel.nuspec'.
Successfully created package 'C:\b\bk-trusted-windows-15c6\bazel-trusted\bazel-release\scripts\packages\chocolatey\bazel.6.2.0-rc1.nupkg'
```