### PR TITLE
Only run tests that are compatible

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2148,7 +2148,10 @@ def expand_test_target_patterns(bazel_binary, test_targets):
         + [
             "--nosystem_rc",
             "--nohome_rc",
-            "query",
+            "cquery",
+            "--output=starlark",
+            # Print out the label only if the test is compatible.
+            "--starlark:expr=target.label if 'IncompatiblePlatformProvider' not in providers(target) else ''",
             "tests(set({})){}{}".format(
                 " ".join("'{}'".format(t) for t in included_targets),
                 excluded_string,


### PR DESCRIPTION
Normally, when tests are run via something like `bazel test
--build_tests_only //...`, the incompatible tests are skipped.
https://bazel.build/extending/platforms#skipping-incompatible-targets

The approach in `bazelci.py`, however, uses `bazel query` to find all
test targets. This does not account for incompatible tests.

This patch here adjusts the query to filter out incompatible tests for
the current platform. This will prevent errors trying to run tests
that are incompatible with the current platform.
