### PR TITLE
Revert "Only run tests that are compatible (#1618)"

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2147,10 +2147,7 @@ def expand_test_target_patterns(bazel_binary, test_targets):
         + [
             "--nosystem_rc",
             "--nohome_rc",
-            "cquery",
-            "--output=starlark",
-            # Print out the label only if the test is compatible.
-            "--starlark:expr=target.label if 'IncompatiblePlatformProvider' not in providers(target) else ''",
+            "query",
             "tests(set({})){}{}".format(
                 " ".join("'{}'".format(t) for t in included_targets),
                 excluded_string,


### PR DESCRIPTION
This reverts commit 9186d33893204606377d9115405e9ed202ed7662.

The change itself is fine. However, some targets in the Bazel repo are broken (https://buildkite.com/bazel/google-bazel-presubmit/builds/66586#0187e6b3-bb5c-477c-8fb2-f6d802dbfc28).