### PR TITLE
Promote bazel-diff from experimental to GA

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2168,7 +2168,7 @@ def get_test_query(test_targets, test_flags):
     def FormatTargetList(targets):
         return " ".join("'{}'".format(t) for t in targets)
 
-    query = "let t = tests(set({})) in \\$t".format(FormatTargetList(included_targets))
+    query = "let t = tests(set({})) in $t".format(FormatTargetList(included_targets))
 
     if excluded_targets:
         query += " except tests(set({}))".format(FormatTargetList(excluded_targets))
@@ -2176,10 +2176,10 @@ def get_test_query(test_targets, test_flags):
     included_tags, excluded_tags = get_test_tags(test_flags)
 
     for t in excluded_tags:
-        query += " except attr('tags', '\\b{}\\b', \\$t)".format(t)
+        query += " except attr('tags', '\\b{}\\b', $t)".format(t)
 
     if included_tags:
-        parts = ["attr('tags', '\\b{}\\b', \\$tt)".format(t) for t in included_tags]
+        parts = ["attr('tags', '\\b{}\\b', $tt)".format(t) for t in included_tags]
         query = "let tt = {} in {}".format(query, " union ".join(parts))
 
     return query


### PR DESCRIPTION
Progress towards #1605. There is still one minor issue wrt incompatible platforms that we need to fix (#1614, attempted in #1618). However, it does not affect the only pipeline that is using bazel-diff for now.