### PR TITLE
Properly skip manual tests

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2197,7 +2197,7 @@ def get_test_tags(test_flags):
 
         return include, exclude
 
-    return [], []
+    return [], ["manual"]
 
 
 def filter_unchanged_targets(


### PR DESCRIPTION
Fix 
```
(13:24:44) ERROR: /workdir/src/test/shell/bazel/BUILD:897:8: no such package '@m2//': The repository '@m2' could not be resolved: Repository '@m2' is not defined and referenced by '//src/test/shell/bazel:maven_starlark_test'
```

https://buildkite.com/bazel/google-bazel-presubmit/builds/66597#0187e6ee-4cd6-4088-9cf9-9832618867aa