### PR TITLE
Matrix testing: sort the attributes names to make the output deterministic

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -993,6 +993,8 @@ def get_combinations(matrix, attributes):
     if attributes = ['b', 'c'], then returns [[('b', 1), ('c', 1)]]
     if attributes = ['c'], then returns [[('c', 1)]]
     """
+    # Sort the attributes to make the output deterministic.
+    attributes.sort()
     for attr in attributes:
         if attr not in matrix:
             raise BuildkiteException("${{ %s }} is not defined in `matrix` section." % attr)


### PR DESCRIPTION
Fix https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/3007#0187f987-e4ea-4d5b-a6be-2c0a1acda9b2

https://github.com/bazelbuild/continuous-integration/pull/1598 alone didn't fix the whole problem.