### PR TITLE
Roll-forward "Fix annotation about bazel-diff failures (#1641)

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2532,7 +2532,8 @@ def execute_command_and_get_output(args, shell=False, fail_if_nonzero=True, prin
         shell=shell,
         check=fail_if_nonzero,
         env=os.environ,
-        capture_output=True,
+        stdout=subprocess.PIPE,  # We cannot use capture_output since some workers run Python <3.7
+        stderr=subprocess.PIPE,  # We want exceptions to contain stderr
         errors="replace",
         universal_newlines=True,
     )
@@ -2552,7 +2553,7 @@ def execute_command(args, shell=False, fail_if_nonzero=True, cwd=None, print_out
         env=os.environ,
         cwd=cwd,
         errors="replace",
-        capture_output=True,  # We want exceptions to contain stderr
+        stderr=subprocess.PIPE,  # We want exceptions to contain stderr
     ).returncode
 
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2284,7 +2284,7 @@ def filter_unchanged_targets(
                     "--context",
                     "'diff_failed'",
                     "This build runs all test targets even though `{}` is set "
-                    "since bazel-diff failed with an error:\n```{}```".format(
+                    "since bazel-diff failed with an error:\n```\n{}\n```".format(
                         USE_BAZEL_DIFF_ENV_VAR, ex
                     ),
                 ]
@@ -2343,7 +2343,7 @@ def download_bazel_diff(directory):
         execute_command(["curl", "-sSL", BAZEL_DIFF_URL, "-o", local_path])
     except subprocess.CalledProcessError as ex:
         raise BuildkiteInfraException(
-            "Failed to download {}:{}\n{}".format(BAZEL_DIFF_URL, ex, ex.stderr)
+            "Failed to download {}: {}\n{}".format(BAZEL_DIFF_URL, ex, ex.stderr)
         )
     return local_path
 
@@ -2532,7 +2532,7 @@ def execute_command_and_get_output(args, shell=False, fail_if_nonzero=True, prin
         shell=shell,
         check=fail_if_nonzero,
         env=os.environ,
-        stdout=subprocess.PIPE,
+        capture_output=True,
         errors="replace",
         universal_newlines=True,
     )
@@ -2552,6 +2552,7 @@ def execute_command(args, shell=False, fail_if_nonzero=True, cwd=None, print_out
         env=os.environ,
         cwd=cwd,
         errors="replace",
+        capture_output=True,  # We want exceptions to contain stderr
     ).returncode
 
 


### PR DESCRIPTION
This change is a Python <3.7 compatible version of #1641

Should finally fix https://github.com/bazelbuild/continuous-integration/issues/1637