### PR TITLE
Do not fail if diffbase tmpdir cannot be deleted

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2333,7 +2333,11 @@ def filter_unchanged_targets(
         finally:
             return expanded_test_targets
     finally:
-        shutil.rmtree(tmpdir)
+        try:
+            shutil.rmtree(tmpdir)
+        except:
+            pass
+
         os.chdir(workspace_dir)
 
     config_target_set = set(expanded_test_targets)


### PR DESCRIPTION
This should fix https://buildkite.com/bazel/google-bazel-presubmit/builds/66803#0187fc62-25e9-4997-b1b4-f93da9d1ffef

Progress towards https://github.com/bazelbuild/continuous-integration/issues/1643