### PR TITLE
Set env BAZELCI_TASK

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3827,6 +3827,8 @@ def main(argv=None):
                     )
                 )
 
+            os.environ["BAZELCI_TASK"] = args.task
+
             platform = get_platform_for_task(args.task, task_config)
 
             # The value of `BUILDKITE_MESSAGE` defaults to the commit message, which can be too large


### PR DESCRIPTION
so that subprocesses are able to know which task/step BazelCI is currently running.

Working towards Test Analytics integration.