### PR TITLE
Only use BAZELCI_AGENT_REPO and BAZELCI_AGENT_VERSION in testing branch

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1719,10 +1719,10 @@ def download_bazel_nojdk_binary_at_commit(dest_dir, platform, bazel_git_commit):
 
 def download_bazelci_agent(dest_dir):
     repo = "bazelbuild/continuous-integration"
-    if "BAZELCI_AGENT_REPO" in os.environ:
+    if THIS_IS_TESTING and "BAZELCI_AGENT_REPO" in os.environ:
         repo = os.environ["BAZELCI_AGENT_REPO"]
     version = "0.1.4"
-    if "BAZELCI_AGENT_VERSION" in os.environ:
+    if THIS_IS_TESTING and "BAZELCI_AGENT_VERSION" in os.environ:
         version = os.environ["BAZELCI_AGENT_VERSION"]
     postfix = ""
     if is_windows():


### PR DESCRIPTION
To prevent us accidentally use that for production.