### PR TITLE
[agent] Support uploading non Java tests to Test Analytics

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "predicates",
+ "quick-xml",
  "rand",
  "reqwest",
  "serde_json",
@@ -694,6 +695,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -14,6 +14,7 @@ rand = "0.8"
 url = "2.2"
 reqwest = { version = "0.11.17", default-features = false, features = ["rustls-tls", "blocking", "multipart"] }
 sha-1 = "0.10.1"
+quick-xml = "0.28.2"
 
 [dev-dependencies]
 assert_cmd = "2.0"


### PR DESCRIPTION
By providing a fallback classname (based on target label) when it is empty or missing.

Example run: https://buildkite.com/organizations/bazel-testing/analytics/suites/test-suite/runs/f4e10c74-fc79-4f87-bb29-9d3f515e65df.