### PR TITLE
[Dashboard] Integrate build data from Buildkite

### DIFF
--- a/dashboard/server/build.sh
+++ b/dashboard/server/build.sh
@@ -4,8 +4,11 @@ set -euxo pipefail
 
 GIT_REV=$(git rev-parse --short HEAD)
 
-./mvnw -Dproject.version=${GIT_REV} clean package
+mvn -Dproject.version=${GIT_REV} clean package
 
-rm -rf target/dependency && mkdir -p target/dependency && (cd target/dependency; jar -xf ../dashboard-${GIT_REV}.jar)
+rm -rf target/dependency && mkdir -p target/dependency && (
+	cd target/dependency
+	jar -xf ../dashboard-${GIT_REV}.jar
+)
 
 docker build -f Dockerfile -t gcr.io/bazel-public/dashboard/server:$GIT_REV target

--- a/dashboard/server/database.sql
+++ b/dashboard/server/database.sql
@@ -298,35 +298,41 @@ CREATE MATERIALIZED VIEW buildkite_job_mview AS
 WITH buildkite_job AS (WITH buildkite_job_data AS (SELECT org,
                                                           pipeline,
                                                           build_number,
-                                                          data ->> 'branch'                    AS branch,
-                                                          data ->> 'state'                     AS build_state,
-                                                          data ->> 'created_at'                AS build_created_at,
-                                                          JSONB_ARRAY_ELEMENTS(data -> 'jobs') AS data
+                                                          data ->> 'branch'                      AS branch,
+                                                          data ->> 'state'                       AS build_state,
+                                                          (data ->> 'scheduled_at')::timestamptz AS build_scheduled_at,
+                                                          (data ->> 'created_at')::timestamptz   AS build_created_at,
+                                                          (data ->> 'started_at')::timestamptz   AS build_started_at,
+                                                          (data ->> 'finished_at')::timestamptz  AS build_finished_at,
+                                                          JSONB_ARRAY_ELEMENTS(data -> 'jobs')   AS data
                                                    FROM buildkite_build_data)
                        SELECT org,
                               pipeline,
                               build_number,
                               branch,
                               build_state,
+                              build_scheduled_at,
                               build_created_at,
-                              data ->> 'name'                                 AS name,
+                              build_started_at,
+                              build_finished_at,
+                              EXTRACT(EPOCH FROM build_started_at -
+                                                 build_created_at)          AS build_wait_time,
+                              EXTRACT(EPOCH FROM build_finished_at -
+                                                 build_started_at)          AS build_run_time,
+                              data ->> 'name'                               AS name,
                               COALESCE(SUBSTRING(data ->> 'command' FROM
                                                  '--task=(\S+)'),
                                        SUBSTRING(data ->> 'command' FROM
-                                                 '--platform=(\S+)'))         AS bazelci_task,
-                              data ->> 'state'                                AS state,
-                              (data ->> 'scheduled_at')::timestamptz          AS scheduled_at,
-                              (data ->> 'created_at')::timestamptz            AS created_at,
-                              (data ->> 'started_at')::timestamptz            AS started_at,
-                              (data ->> 'finished_at')::timestamptz           AS finished_at,
-                              EXTRACT(EPOCH FROM
-                                      ((data ->> 'started_at')::timestamptz -
-                                       (data ->> 'created_at')::timestamptz)) AS wait_time,
-                              EXTRACT(EPOCH FROM
-                                      ((data ->> 'finished_at')::timestamptz -
-                                       (data ->> 'started_at')::timestamptz)) AS run_time
+                                                 '--platform=(\S+)'))       AS bazelci_task,
+                              data ->> 'state'                              AS state,
+                              (data ->> 'scheduled_at')::timestamptz        AS scheduled_at,
+                              (data ->> 'created_at')::timestamptz          AS created_at,
+                              (data ->> 'started_at')::timestamptz          AS started_at,
+                              (data ->> 'finished_at')::timestamptz         AS finished_at
                        FROM buildkite_job_data)
-SELECT *
+SELECT *,
+       EXTRACT(EPOCH FROM (started_at - created_at))  AS wait_time,
+       EXTRACT(EPOCH FROM (finished_at - started_at)) AS run_time
 FROM buildkite_job
 WHERE bazelci_task is NOT NULL;
 
@@ -338,3 +344,7 @@ CREATE INDEX buildkite_job_mview_state
     on buildkite_job_mview (state);
 CREATE INDEX buildkite_job_mview_branch
     on buildkite_job_mview (branch);
+CREATE INDEX buildkite_job_mview_build_state
+    on buildkite_job_mview (build_state);
+CREATE INDEX buildkite_job_mview_build_created_at
+    on buildkite_job_mview (build_created_at);

--- a/dashboard/server/database.sql
+++ b/dashboard/server/database.sql
@@ -276,3 +276,17 @@ CREATE TABLE github_issue_comment_data
     data         JSONB       NOT NULL,
     PRIMARY KEY (owner, repo, issue_number, page)
 );
+
+--
+-- Table that stores the raw builds data fetched from Buildkite
+--
+CREATE TABLE buildkite_build_data
+(
+    org          TEXT        NOT NULL,
+    pipeline     TEXT        NOT NULL,
+    build_number INTEGER     NOT NULL,
+    timestamp    TIMESTAMPTZ NOT NULL,
+    etag         TEXT        NOT NULL,
+    data         JSONB       NOT NULL,
+    PRIMARY KEY (org, pipeline, build_number)
+);

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/api/BuildkiteRestApiClient.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/api/BuildkiteRestApiClient.java
@@ -1,0 +1,72 @@
+package build.bazel.dashboard.buildkite.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import build.bazel.dashboard.common.RestApiClient;
+import build.bazel.dashboard.common.RestApiResponse;
+import com.google.common.base.Strings;
+import java.net.URI;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec;
+import org.springframework.web.util.UriBuilder;
+
+@Component
+@Slf4j
+public class BuildkiteRestApiClient extends RestApiClient {
+  private final String accessToken;
+
+  public BuildkiteRestApiClient(WebClient webClient, @Value("${buildkite.accessToken:}") String accessToken) {
+    super("https", "api.buildkite.com", webClient);
+    this.accessToken = accessToken;
+  }
+
+  public RestApiResponse listBuilds(ListBuildsRequest request) {
+    log.debug("{}", request);
+
+    checkNotNull(request.org());
+    checkNotNull(request.pipeline());
+
+    var spec =
+        get(
+            uriBuilder ->
+                uriBuilder
+                    .pathSegment("v2", "organizations", request.org(), "pipelines", request.pipeline(), "builds")
+                    .queryParamIfPresent("branch", Optional.ofNullable(request.branch()))
+                    .queryParamIfPresent("page", Optional.ofNullable(request.page()))
+                    .queryParamIfPresent("per_page", Optional.ofNullable(request.perPage()))
+                    .build(), request.etag());
+
+    return exchange(spec);
+  }
+
+  public RestApiResponse fetchBuild(FetchBuildRequest request) {
+    log.debug("{}", request);
+
+    checkNotNull(request.org());
+    checkNotNull(request.pipeline());
+
+    var spec =
+        get(
+            uriBuilder ->
+                uriBuilder
+                    .pathSegment("v2", "organizations", request.org(), "pipelines", request.pipeline(), "builds", String.valueOf(request.buildNumber()))
+                    .build(), request.etag());
+
+    return exchange(spec);
+  }
+
+  @Override
+  protected RequestHeadersSpec<?> get(Function<UriBuilder, URI> uriFunction, @Nullable String etag) {
+    var spec = super.get(uriFunction, etag);
+    if (!Strings.isNullOrEmpty(accessToken)) {
+      spec.header("Authorization", "Bearer " + accessToken);
+    }
+    return spec;
+  }
+}

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/api/FetchBuildRequest.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/api/FetchBuildRequest.java
@@ -1,0 +1,12 @@
+package build.bazel.dashboard.buildkite.api;
+
+public record FetchBuildRequest(
+    String org,
+    String pipeline,
+    int buildNumber,
+    String etag
+) {
+  public static FetchBuildRequest create(String org, String pipeline, int buildNumber, String etag) {
+    return new FetchBuildRequest(org, pipeline, buildNumber, etag);
+  }
+}

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/api/ListBuildsRequest.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/api/ListBuildsRequest.java
@@ -1,0 +1,18 @@
+package build.bazel.dashboard.buildkite.api;
+
+import javax.annotation.Nullable;
+
+public record ListBuildsRequest(
+    String org,
+    String pipeline,
+    @Nullable
+    String branch,
+    @Nullable
+    Integer perPage,
+    @Nullable
+    Integer page,
+    @Nullable
+    String etag
+) {
+
+}

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuild.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuild.java
@@ -1,0 +1,22 @@
+package build.bazel.dashboard.buildkite.build;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.time.Instant;
+
+public record BuildkiteBuild(
+    String org,
+    String pipeline,
+    int buildNumber,
+    Instant timestamp,
+    String etag,
+    JsonNode data
+) {
+
+  public static BuildkiteBuild empty(String org, String pipeline, int buildNumber,
+      ObjectMapper objectMapper) {
+    return new BuildkiteBuild(org, pipeline, buildNumber, Instant.now(), "",
+        objectMapper.createObjectNode());
+  }
+}

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildRepo.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildRepo.java
@@ -1,0 +1,68 @@
+package build.bazel.dashboard.buildkite.build;
+
+import static build.bazel.dashboard.utils.PgJson.toPgJson;
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.r2dbc.postgresql.codec.Json;
+import io.r2dbc.spi.Readable;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BuildkiteBuildRepo {
+
+  private final DatabaseClient databaseClient;
+  private final ObjectMapper objectMapper;
+
+  public Optional<BuildkiteBuild> findOne(String org, String pipeline, int buildNumber) {
+    return Optional.ofNullable(
+        databaseClient
+            .sql(
+                "SELECT org, pipeline, build_number, timestamp, etag, data FROM buildkite_build_data "
+                    + "WHERE org=:org AND pipeline=:pipeline AND build_number=:build_number")
+            .bind("org", org)
+            .bind("pipeline", pipeline)
+            .bind("build_number", buildNumber)
+            .map(this::toBuildkiteBuild)
+            .one()
+            .block());
+  }
+
+  public void save(BuildkiteBuild build) {
+    databaseClient
+        .sql(
+            "INSERT INTO buildkite_build_data (org, pipeline, build_number, timestamp, etag, data)"
+                + " VALUES (:org, :pipeline, :build_number, :timestamp, :etag, :data) ON"
+                + " CONFLICT (org, pipeline, build_number) DO UPDATE SET etag = excluded.etag,"
+                + " timestamp = excluded.timestamp, data = excluded.data")
+        .bind("org", build.org())
+        .bind("pipeline", build.pipeline())
+        .bind("build_number", build.buildNumber())
+        .bind("timestamp", build.timestamp())
+        .bind("etag", build.etag())
+        .bind("data", toPgJson(objectMapper, build.data()))
+        .then()
+        .block();
+  }
+
+  private BuildkiteBuild toBuildkiteBuild(Readable row) {
+    try {
+      return new BuildkiteBuild(
+          requireNonNull(row.get("org", String.class)),
+          requireNonNull(row.get("pipeline", String.class)),
+          requireNonNull(row.get("build_number", Integer.class)),
+          requireNonNull(row.get("timestamp", Instant.class)),
+          requireNonNull(row.get("etag", String.class)),
+          objectMapper.readTree((requireNonNull(row.get("data", Json.class))).asArray())
+      );
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildRepo.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildRepo.java
@@ -65,4 +65,10 @@ public class BuildkiteBuildRepo {
       throw new IllegalStateException(e);
     }
   }
+
+  public void refresh() {
+    databaseClient.sql("REFRESH MATERIALIZED VIEW buildkite_job_mview")
+        .then()
+        .block();
+  }
 }

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildRestController.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildRestController.java
@@ -1,0 +1,27 @@
+package build.bazel.dashboard.buildkite.build;
+
+import static build.bazel.dashboard.utils.RxJavaVirtualThread.maybe;
+
+import io.reactivex.rxjava3.core.Maybe;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BuildkiteBuildRestController {
+  private final BuildkiteBuildService buildkiteBuildService;
+
+  @GetMapping("/internal/buildkite/organizations/{org}/pipelines/{pipeline}/builds/{buildNumber}")
+  public Maybe<BuildkiteBuild> findOneGithubIssue(
+      @PathVariable("org") String org,
+      @PathVariable("pipeline") String pipeline,
+      @PathVariable("buildNumber") Integer buildNumber) {
+    return maybe(
+        () ->
+            Optional.ofNullable(
+                buildkiteBuildService.fetchAndSave(org, pipeline, buildNumber)));
+  }
+}

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildRestController.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildRestController.java
@@ -1,12 +1,17 @@
 package build.bazel.dashboard.buildkite.build;
 
 import static build.bazel.dashboard.utils.RxJavaVirtualThread.maybe;
+import static build.bazel.dashboard.utils.RxJavaVirtualThread.single;
 
+import build.bazel.dashboard.buildkite.build.BuildkiteBuildRepo.BuildStats;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.time.Instant;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,5 +28,16 @@ public class BuildkiteBuildRestController {
         () ->
             Optional.ofNullable(
                 buildkiteBuildService.fetchAndSave(org, pipeline, buildNumber)));
+  }
+
+  @GetMapping("/buildkite/organizations/{org}/pipelines/{pipeline}/stats")
+  public Single<BuildStats> findBuildStats(
+      @PathVariable("org") String org,
+      @PathVariable("pipeline") String pipeline,
+      @RequestParam(value = "branch", required = false) String branch,
+      @RequestParam(value = "from", required = false) Instant from,
+      @RequestParam(value = "to", required = false) Instant to
+  ) {
+    return single(() -> buildkiteBuildService.findBuildStats(org, pipeline, branch, from, to));
   }
 }

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildService.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildService.java
@@ -1,0 +1,52 @@
+package build.bazel.dashboard.buildkite.build;
+
+import build.bazel.dashboard.buildkite.api.BuildkiteRestApiClient;
+import build.bazel.dashboard.buildkite.api.FetchBuildRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BuildkiteBuildService {
+
+  private final BuildkiteRestApiClient buildkiteRestApiClient;
+  private final BuildkiteBuildRepo buildkiteBuildRepo;
+  private final ObjectMapper objectMapper;
+
+  public BuildkiteBuild fetchAndSave(String org, String pipeline, int buildNumber) {
+    var existing = buildkiteBuildRepo.findOne(org, pipeline, buildNumber)
+        .orElse(BuildkiteBuild.empty(org, pipeline, buildNumber, objectMapper));
+
+    var request = FetchBuildRequest.create(org, pipeline, buildNumber, existing.etag());
+    var response = buildkiteRestApiClient.fetchBuild(request);
+    var status = response.getStatus();
+    if (status.is2xxSuccessful()) {
+      var build = new BuildkiteBuild(
+          org,
+          pipeline,
+          buildNumber,
+          Instant.now(),
+          response.getEtag(),
+          response.getBody()
+      );
+      buildkiteBuildRepo.save(build);
+      return build;
+    } else if (status.value() == 304) {
+      // Not modified
+      return existing;
+    }
+
+    log.error(
+        "Failed to fetch {}/{}/builds/{}: {}",
+        org,
+        pipeline,
+        buildNumber,
+        status);
+
+    throw new RuntimeException(status.toString());
+  }
+}

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildService.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildService.java
@@ -67,8 +67,7 @@ public class BuildkiteBuildService {
       var org = match.group(1);
       var pipeline = match.group(2);
       var buildNumber = Integer.parseInt(match.group(3));
-      var build = new BuildkiteBuild(org, pipeline, buildNumber, Instant.now(), "", buildJson);
-      buildkiteBuildRepo.save(build);
+      var unused = fetchAndSave(org, pipeline, buildNumber);
     }
   }
 }

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildService.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildService.java
@@ -2,8 +2,10 @@ package build.bazel.dashboard.buildkite.build;
 
 import build.bazel.dashboard.buildkite.api.BuildkiteRestApiClient;
 import build.bazel.dashboard.buildkite.api.FetchBuildRequest;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -48,5 +50,25 @@ public class BuildkiteBuildService {
         status);
 
     throw new RuntimeException(status.toString());
+  }
+
+  private static final Pattern BUILD_URL_PATTERN = Pattern.compile(
+      "https://api.buildkite.com/v2/organizations/([^/]+)/pipelines/([^/]+)/builds/(\\d+)");
+
+  public void onEvent(JsonNode event) {
+    var eventType = event.get("event").asText();
+    if (eventType.startsWith("build.")) {
+      var buildJson = event.get("build");
+      var buildUrl = buildJson.get("url").asText();
+      var match = BUILD_URL_PATTERN.matcher(buildUrl);
+      if (!match.matches()) {
+        throw new IllegalArgumentException("Invalid build url: " + buildUrl);
+      }
+      var org = match.group(1);
+      var pipeline = match.group(2);
+      var buildNumber = Integer.parseInt(match.group(3));
+      var build = new BuildkiteBuild(org, pipeline, buildNumber, Instant.now(), "", buildJson);
+      buildkiteBuildRepo.save(build);
+    }
   }
 }

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildSyncTask.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildSyncTask.java
@@ -1,0 +1,85 @@
+package build.bazel.dashboard.buildkite.build;
+
+import static build.bazel.dashboard.utils.RxJavaVirtualThread.completable;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import build.bazel.dashboard.utils.JsonStateStore;
+import build.bazel.dashboard.utils.JsonStateStore.JsonState;
+import io.reactivex.rxjava3.core.Completable;
+import java.time.Instant;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class BuildkiteBuildSyncTask {
+
+  private final BuildkiteBuildService buildkiteBuildService;
+  private final JsonStateStore jsonStateStore;
+
+  @PutMapping("/internal/buildkite/organizations/{org}/pipelines/{pipeline}/builds")
+  public Completable saveNewSyncBuildState(
+      @PathVariable("org") String org,
+      @PathVariable("pipeline") String pipeline,
+      @RequestParam(name = "start") Integer start,
+      @RequestParam(name = "count") Integer count) {
+    return completable(() -> saveNewSyncState(org, pipeline, start, start + count, null));
+  }
+
+  // We have a rate limit 100/min.
+  @Scheduled(fixedDelay = 1000)
+  private void sync() {
+    var states = jsonStateStore.findAllLike(SYNC_STATE_KEY_PREFIX + "%", SyncState.class);
+    for (var state : states) {
+      doSync(state);
+      return;
+    }
+  }
+
+  private void doSync(JsonState<SyncState> jsonState) {
+    var data = jsonState.getData();
+    checkNotNull(data);
+
+    if (data.current >= data.end) {
+      jsonStateStore.delete(jsonState.getKey(), jsonState.getTimestamp());
+      return;
+    }
+
+    var unused = buildkiteBuildService.fetchAndSave(data.org(), data.pipeline(), data.current());
+    jsonStateStore.save(
+        jsonState.getKey(), jsonState.getTimestamp(),
+        new SyncState(data.org(), data.pipeline(), data.start(),
+            data.current() + 1, data.end()));
+  }
+
+  private void saveNewSyncState(
+      String org, String pipeline, Integer start, Integer end, @Nullable Instant lastTimestamp) {
+    jsonStateStore.save(
+        buildSyncStateKey(org, pipeline),
+        lastTimestamp,
+        new SyncState(org, pipeline, start, start, end));
+  }
+
+  record SyncState(
+      String org,
+      String pipeline,
+      int start,
+      int current,
+      int end
+  ) {
+
+  }
+
+  private static final String SYNC_STATE_KEY_PREFIX = "sync-buildkite-builds";
+
+  private String buildSyncStateKey(String org, String pipeline) {
+    return String.format("%s/%s/%s", SYNC_STATE_KEY_PREFIX, org, pipeline);
+  }
+}

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildSyncTask.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildSyncTask.java
@@ -34,7 +34,7 @@ public class BuildkiteBuildSyncTask {
   }
 
   // We have a rate limit 100/min.
-  @Scheduled(fixedDelay = 1000)
+  @Scheduled(fixedDelay = 500)
   private void sync() {
     var states = jsonStateStore.findAllLike(SYNC_STATE_KEY_PREFIX + "%", SyncState.class);
     for (var state : states) {

--- a/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildSyncTask.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/buildkite/build/BuildkiteBuildSyncTask.java
@@ -38,8 +38,8 @@ public class BuildkiteBuildSyncTask {
 
   private final BuildkiteBuildService buildkiteBuildService;
   private final JsonStateStore jsonStateStore;
-
   private final ObjectMapper objectMapper;
+  private final BuildkiteBuildRepo buildkiteBuildRepo;
 
   @Value("${buildkite.webhookToken:}")
   private String buildkiteWebhookToken;
@@ -148,5 +148,15 @@ public class BuildkiteBuildSyncTask {
 
   private String buildSyncStateKey(String org, String pipeline) {
     return String.format("%s/%s/%s", SYNC_STATE_KEY_PREFIX, org, pipeline);
+  }
+
+  @PutMapping("/internal/buildkite")
+  public Completable refreshRepo() {
+    return completable(this::doRefreshRepo);
+  }
+
+  @Scheduled(cron = "0 0 0 * * *", zone = "UTC")
+  public void doRefreshRepo() {
+    buildkiteBuildRepo.refresh();
   }
 }

--- a/dashboard/server/src/main/java/build/bazel/dashboard/common/RestApiClient.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/common/RestApiClient.java
@@ -1,0 +1,43 @@
+package build.bazel.dashboard.common;
+
+import com.google.common.base.Strings;
+import java.net.URI;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+
+@Slf4j
+public abstract class RestApiClient {
+  protected final String scheme;
+  protected final String host;
+  protected final WebClient webClient;
+
+  protected RestApiClient(String scheme, String host, WebClient webClient) {
+    this.scheme = scheme;
+    this.host = host;
+    this.webClient = webClient;
+  }
+
+  protected WebClient.RequestHeadersSpec<?> get(Function<UriBuilder, URI> uriFunction, @Nullable String etag) {
+    var spec =
+        webClient
+            .get()
+            .uri(uriBuilder -> uriFunction.apply(uriBuilder.scheme(scheme).host(host)));
+
+    if (!Strings.isNullOrEmpty(etag)) {
+      spec.ifNoneMatch(etag);
+    }
+
+    return spec;
+  }
+
+  protected RestApiResponse exchange(WebClient.RequestHeadersSpec<?> spec) {
+    return spec.exchangeToMono(response -> {
+      log.debug("{} {}", response.statusCode(), response.headers().asHttpHeaders().toSingleValueMap());
+      return RestApiResponse.fromClientResponse(response);
+    }).block();
+  }
+
+}

--- a/dashboard/server/src/main/java/build/bazel/dashboard/common/RestApiResponse.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/common/RestApiResponse.java
@@ -1,4 +1,4 @@
-package build.bazel.dashboard.github.api;
+package build.bazel.dashboard.common;
 
 import static build.bazel.dashboard.utils.HttpHeadersUtils.getAsIntOrZero;
 import static build.bazel.dashboard.utils.HttpHeadersUtils.getOrEmpty;
@@ -12,7 +12,7 @@ import reactor.core.publisher.Mono;
 
 @Builder
 @Value
-public class GithubApiResponse {
+public class RestApiResponse {
   HttpStatusCode status;
   String etag;
   RateLimit rateLimit;
@@ -36,11 +36,11 @@ public class GithubApiResponse {
     }
   }
 
-  public static Mono<GithubApiResponse> fromClientResponse(ClientResponse clientResponse) {
+  public static Mono<RestApiResponse> fromClientResponse(ClientResponse clientResponse) {
     var status = clientResponse.statusCode();
     ClientResponse.Headers headers = clientResponse.headers();
-    GithubApiResponseBuilder builder =
-        GithubApiResponse.builder()
+    var builder =
+        RestApiResponse.builder()
             .status(status)
             .etag(getOrEmpty(headers, "ETag"))
             .rateLimit(RateLimit.fromHeaders(headers));

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/api/GithubApi.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/api/GithubApi.java
@@ -1,15 +1,17 @@
 package build.bazel.dashboard.github.api;
 
+import build.bazel.dashboard.common.RestApiResponse;
+
 public interface GithubApi {
-  GithubApiResponse listRepositoryIssues(ListRepositoryIssuesRequest request);
+  RestApiResponse listRepositoryIssues(ListRepositoryIssuesRequest request);
 
-  GithubApiResponse listRepositoryEvents(ListRepositoryEventsRequest request);
+  RestApiResponse listRepositoryEvents(ListRepositoryEventsRequest request);
 
-  GithubApiResponse listRepositoryIssueEvents(ListRepositoryIssueEventsRequest request);
+  RestApiResponse listRepositoryIssueEvents(ListRepositoryIssueEventsRequest request);
 
-  GithubApiResponse fetchIssue(FetchIssueRequest request);
+  RestApiResponse fetchIssue(FetchIssueRequest request);
 
-  GithubApiResponse listIssueComments(ListIssueCommentsRequest request);
+  RestApiResponse listIssueComments(ListIssueCommentsRequest request);
 
-  GithubApiResponse searchIssues(SearchIssuesRequest request);
+  RestApiResponse searchIssues(SearchIssuesRequest request);
 }

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/sync/event/PollGithubEventsTask.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/sync/event/PollGithubEventsTask.java
@@ -4,7 +4,7 @@ import static build.bazel.dashboard.utils.RxJavaVirtualThread.completable;
 import static com.google.common.base.Preconditions.checkState;
 
 import build.bazel.dashboard.github.api.GithubApi;
-import build.bazel.dashboard.github.api.GithubApiResponse;
+import build.bazel.dashboard.common.RestApiResponse;
 import build.bazel.dashboard.github.api.ListRepositoryEventsRequest;
 import build.bazel.dashboard.github.api.ListRepositoryIssueEventsRequest;
 import build.bazel.dashboard.github.repo.GithubRepoService;
@@ -68,7 +68,7 @@ public class PollGithubEventsTask {
     var poller =
         new PagePoller(owner, repo, stateKey) {
           @Override
-          public GithubApiResponse doRequest(
+          public RestApiResponse doRequest(
               String owner, String repo, int perPage, int page, String etag) {
             var request =
                 ListRepositoryEventsRequest.builder()
@@ -100,7 +100,7 @@ public class PollGithubEventsTask {
     var poller =
         new PagePoller(owner, repo, stateKey) {
           @Override
-          public GithubApiResponse doRequest(
+          public RestApiResponse doRequest(
               String owner, String repo, int perPage, int page, String etag) {
             var request =
                 ListRepositoryIssueEventsRequest.builder()
@@ -132,7 +132,7 @@ public class PollGithubEventsTask {
       this.stateKey = stateKey;
     }
 
-    public abstract GithubApiResponse doRequest(
+    public abstract RestApiResponse doRequest(
         String owner, String repo, int perPage, int page, String etag);
 
     public abstract void onEvent(String owner, String repo, ObjectNode event);
@@ -179,7 +179,7 @@ public class PollGithubEventsTask {
       }
     }
 
-    private static boolean shouldTerminate(PollState state, GithubApiResponse response) {
+    private static boolean shouldTerminate(PollState state, RestApiResponse response) {
       boolean terminate = false;
 
       if (response.getStatus().is2xxSuccessful()) {

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/sync/issue/GithubSyncIssueTask.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/sync/issue/GithubSyncIssueTask.java
@@ -87,8 +87,8 @@ public class GithubSyncIssueTask {
     }
   }
 
-  // We have a rate limit 5000/hour = 1.4/sec. Use a conservative rate 0.5/sec
-  @Scheduled(fixedDelay = 2000)
+  // We have a rate limit 5000/hour = 1.4/sec.
+  @Scheduled(fixedDelay = 1000)
   public void syncGithubIssues() throws Throwable {
     for (var repo : githubRepoService.findAll()) {
       var jsonState =

--- a/dashboard/server/src/main/java/build/bazel/dashboard/utils/JsonStateStore.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/utils/JsonStateStore.java
@@ -1,7 +1,7 @@
 package build.bazel.dashboard.utils;
 
-import io.reactivex.rxjava3.core.Completable;
 import java.time.Instant;
+import java.util.List;
 import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Value;
@@ -20,6 +20,8 @@ public interface JsonStateStore {
   <T> void save(String key, @Nullable Instant lastTimestamp, T data);
 
   <T> JsonState<T> load(String key, Class<T> type);
+
+  <T> List<JsonState<T>> findAllLike(String pattern, Class<T> type);
 
   void delete(String key, Instant lastTimestamp);
 }


### PR DESCRIPTION
Add two ways to load build data from Buildkite:
1. Manually poll. This is useful when we want to load old data from pipelines.
2. Webhook. Buildkite will send realtime status of builds for selected pipelines to the configured webhook.

We use [`HMacSha256`](https://buildkite.com/docs/apis/webhooks#webhook-signature) to verify whether the webhook POST request is from trusted party.

We store all the raw data (in JSON) to database (`buildkite_build_data`) and build a materialized view (`buildkite_job_mview`) on top of that. The materialized view is refreshed daily.

Currently, the materilized view provides followling columns:


|org|pipeline|build_number|bazelci_task|name|created_at|wait_time|run_time|
|---|--------|--------------|------------|------|-----------|---------|---------|
|bazel|bazel-bazel|23338|centos7_java11_devtoolset10|:centos: 7 (OpenJDK 11, gcc 10.2.1)|2023-05-16 16:36:49.489000 +00:00|8.805|4587.521|
|bazel|bazel-bazel|23338|ubuntu1804|:ubuntu: 18.04 LTS (OpenJDK 11, gcc 7.5.0)|2023-05-16 16:36:49.489000 +00:00|9.453|4496.929|

We can easily change the view in the future if we want more data.