### PR TITLE
Enable ResultStore for projects that don't explicitly enable remote cache/remote execution

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1889,6 +1889,12 @@ def remote_caching_flags(platform, accept_cached=True):
             "--remote_cache=remotebuildexecution.googleapis.com",
             "--remote_instance_name=projects/{}/instances/default_instance".format(CLOUD_PROJECT),
         ]
+        # Enable BES / Build Results reporting.
+        flags += [
+            "--bes_backend=buildeventservice.googleapis.com",
+            "--bes_timeout=360s",
+            "--bes_instance_name=bazel-untrusted",
+        ]
 
     platform_cache_digest = hashlib.sha256()
     for key in platform_cache_key:
@@ -1999,7 +2005,7 @@ def rbe_flags(original_flags, accept_cached):
     flags += [
         "--bes_backend=buildeventservice.googleapis.com",
         "--bes_timeout=360s",
-        "--project_id=bazel-untrusted",
+        "--bes_instance_name=bazel-untrusted",
     ]
 
     if not accept_cached:


### PR DESCRIPTION
Currently, for projects that don't explicitly set remote flags, we enable remote caching for them.

On top of that, this PR add BES related flags to streaming the build events to Result Store.

Since we don't have google credentials on our macs, ResultStore is not enabled there.

We can view the result store page for a given invocation at: https://source.cloud.google.com/results/invocations/{INVOCATION_ID}.

I am not sure what is a good way to present the result store link in Buildkite's UI. But it belongs to another PR anyway.

Test Run: https://buildkite.com/bazel-testing/bazel-bazel/builds/8504
Example invocation: https://source.cloud.google.com/results/invocations/041ce807-2ab8-42f7-bec1-9930c41ea486

