### PR TITLE
Replace --bes_instance_name with --project_id

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1893,7 +1893,7 @@ def remote_caching_flags(platform, accept_cached=True):
         flags += [
             "--bes_backend=buildeventservice.googleapis.com",
             "--bes_timeout=360s",
-            "--bes_instance_name=bazel-untrusted",
+            "--project_id=bazel-untrusted",
         ]
 
     platform_cache_digest = hashlib.sha256()
@@ -2005,7 +2005,7 @@ def rbe_flags(original_flags, accept_cached):
     flags += [
         "--bes_backend=buildeventservice.googleapis.com",
         "--bes_timeout=360s",
-        "--bes_instance_name=bazel-untrusted",
+        "--project_id=bazel-untrusted",
     ]
 
     if not accept_cached:


### PR DESCRIPTION
Since we need to support old Bazel versions that don't have `--bes_instance_name`.

A better fix could be detecting the Bazel version and apply `--project_id` or `--bes_instance_name` respectively. But `--project_id` has not been removed, this workaround should be legit.

Test Run: https://buildkite.com/bazel-testing/bazel-bazel/builds/8505

Fixes https://github.com/bazelbuild/continuous-integration/pull/1689#issuecomment-1588226690.