### PR TITLE
Disable pushing Bazel binaries for Windows arm64

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -606,7 +606,7 @@ PLATFORMS = {
         "name": "Windows ARM64 (OpenJDK 11, VS2019)",
         "emoji-name": ":windows: arm64 (OpenJDK 11, VS2019)",
         "downstream-root": "c:/b/${BUILDKITE_AGENT_NAME}/${BUILDKITE_ORGANIZATION_SLUG}-downstream-projects",
-        "publish_binary": ["windows_arm64"],
+        # "publish_binary": ["windows_arm64"],
         # TODO(pcloudy): Switch to windows_arm64 queue when Windows ARM64 machines are available,
         # current we just use x86_64 machines to do cross compile.
         "queue": "windows",


### PR DESCRIPTION
Due to https://buildkite.com/bazel-trusted/publish-bazel-binaries/builds/17551