### PR TITLE
Revert "Disable pushing Bazel binaries for Windows arm64 (#1711)"

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -606,8 +606,7 @@ PLATFORMS = {
         "name": "Windows ARM64 (OpenJDK 11, VS2019)",
         "emoji-name": ":windows: arm64 (OpenJDK 11, VS2019)",
         "downstream-root": "c:/b/${BUILDKITE_AGENT_NAME}/${BUILDKITE_ORGANIZATION_SLUG}-downstream-projects",
-        # Add "windows_arm64" back when it works again
-        "publish_binary": [],
+        "publish_binary": ["windows_arm64"],
         # TODO(pcloudy): Switch to windows_arm64 queue when Windows ARM64 machines are available,
         # current we just use x86_64 machines to do cross compile.
         "queue": "windows",


### PR DESCRIPTION
This reverts commit c168f202f241784bacde7a2d3de35740b299eb21.

The breakage has been fixed.