### PR TITLE
Automate rules_java releases

### DIFF
--- a/pipelines/rules_java-release.yml
+++ b/pipelines/rules_java-release.yml
@@ -47,7 +47,7 @@ steps:
       sudo chown root:root /usr/local/bin/github-release
       sudo chmod 0755 /usr/local/bin/github-release
 
-      echo "+++ Importing GPG release key"
+      echo "+++ Importing GitHub token"
       github_token=$(gsutil cat gs://bazel-trusted-encrypted-secrets/github-trusted-token.enc | gcloud kms decrypt --project bazel-public --location global --keyring buildkite --key github-trusted-token --ciphertext-file - --plaintext-file -)
 
       echo "+++ Creating a release on GitHub"

--- a/pipelines/rules_java-release.yml
+++ b/pipelines/rules_java-release.yml
@@ -1,0 +1,56 @@
+---
+steps:
+  - label: "Release rules_java"
+    agents:
+      - "queue=default"
+    plugins:
+      docker#v3.8.0:
+        always-pull: true
+        environment:
+          - ANDROID_HOME
+          - ANDROID_NDK_HOME 
+          - BUILDKITE_ARTIFACT_UPLOAD_DESTINATION
+        image: gcr.io/bazel-public/ubuntu2004-java11
+        network: host 
+        privileged: true 
+        propagate-environment: true
+        propagate-uid-gid: true
+        shell: ["/bin/bash", "-e", "-c"]
+        volumes:
+          - "/etc/group:/etc/group:ro"
+          - "/etc/passwd:/etc/passwd:ro"
+          - "/etc/shadow:/etc/shadow:ro"
+          - "/opt/android-ndk-r15c:/opt/android-ndk-r15c:ro"
+          - "/opt/android-sdk-linux:/opt/android-sdk-linux:ro"
+          - "/var/lib/buildkite-agent:/var/lib/buildkite-agent"
+          - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
+          - "/var/run/docker.sock:/var/run/docker.sock"
+    command: | 
+      echo "+++ Checking out Git branch"
+      git fetch origin ${BUILDKITE_BRANCH}
+      git checkout ${BUILDKITE_BRANCH}
+
+      echo "+++ Getting the latest rules_java version"
+      contents=$(cat MODULE.bazel)
+      version=$(echo "\${contents}" | grep -m 1 "version")
+      version=$(echo "\${version}" | sed -E 's/[^0-9|\.]//g')
+      echo "version = \"\$version\""
+
+      echo "+++ Building the release"
+      bazel build //distro:rules_java-\${version}
+
+      echo "+++ Preparing release notes"
+      bazel build //distro:relnotes
+
+      echo "+++ Downloading github-release"
+      curl -L https://mirror.bazel.build/github.com/c4milo/github-release/releases/download/v1.1.0/github-release_v1.1.0_linux_amd64.tar.gz | sudo tar xz -C /usr/local/bin
+      sudo chown root:root /usr/local/bin/github-release
+      sudo chmod 0755 /usr/local/bin/github-release
+
+      echo "+++ Importing GPG release key"
+      github_token=$(gsutil cat gs://bazel-trusted-encrypted-secrets/github-trusted-token.enc | gcloud kms decrypt --project bazel-public --location global --keyring buildkite --key github-trusted-token --ciphertext-file - --plaintext-file -)
+
+      echo "+++ Creating a release on GitHub"
+      cd bazel-bin/distro
+      relnotes=$(cat relnotes.txt)
+      GITHUB_TOKEN=\${github_token} github-release "bazelbuild/rules_java" \${version} "master" "\${relnotes}" rules_java-\${version}.tar.gz      


### PR DESCRIPTION
Works on my fork, but needs to be tested with an actual release (in bazelbuild/rules_java, with the bazel-io token, etc.)

