### PR TITLE
Update cache poisoning key

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1889,7 +1889,7 @@ def remote_caching_flags(platform, accept_cached=True):
     platform_cache_key = [
         BUILDKITE_ORG.encode("utf-8"),
         # Whenever the remote cache was known to have been poisoned increase the number below
-        "cache-poisoning-20220912".encode("utf-8"),
+        "cache-poisoning-20230803".encode("utf-8"),
         platform.encode("utf-8"),
     ]
 


### PR DESCRIPTION
Update cache-poisoning key after Windows VM upgraded, which was causing https://github.com/google/glog/issues/938