### PR TITLE
Fix toolchain selection for Windows arm64

### DIFF
--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -275,7 +275,7 @@ steps:
       mkdir output
       copy bazel-bin\src\bazel.exe output\bazel.exe
 
-      output\bazel build -c opt --cpu=x64_arm64_windows --copt=-w --host_copt=-w --stamp --embed_label %RELEASE_NAME% src/bazel src/bazel_nojdk scripts/packages/bazel.zip
+      output\bazel build -c opt --incompatible_enable_cc_toolchain_resolution --extra_toolchains=@local_config_cc//:cc-toolchain-x64_arm_windows  --copt=-w --host_copt=-w --stamp --embed_label %RELEASE_NAME% src/bazel src/bazel_nojdk scripts/packages/bazel.zip
 
       mkdir artifacts
       move bazel-bin\src\bazel artifacts\bazel-%RELEASE_NAME%-windows-arm64.exe

--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -275,7 +275,7 @@ steps:
       mkdir output
       copy bazel-bin\src\bazel.exe output\bazel.exe
 
-      output\bazel build -c opt --incompatible_enable_cc_toolchain_resolution --extra_toolchains=@local_config_cc//:cc-toolchain-arm64_windows  --copt=-w --host_copt=-w --stamp --embed_label %RELEASE_NAME% src/bazel src/bazel_nojdk scripts/packages/bazel.zip
+      output\bazel build -c opt --config=windows_arm64 --copt=-w --host_copt=-w --stamp --embed_label %RELEASE_NAME% src/bazel src/bazel_nojdk scripts/packages/bazel.zip
 
       mkdir artifacts
       move bazel-bin\src\bazel artifacts\bazel-%RELEASE_NAME%-windows-arm64.exe

--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -275,7 +275,7 @@ steps:
       mkdir output
       copy bazel-bin\src\bazel.exe output\bazel.exe
 
-      output\bazel build -c opt --incompatible_enable_cc_toolchain_resolution --extra_toolchains=@local_config_cc//:cc-toolchain-x64_arm_windows  --copt=-w --host_copt=-w --stamp --embed_label %RELEASE_NAME% src/bazel src/bazel_nojdk scripts/packages/bazel.zip
+      output\bazel build -c opt --incompatible_enable_cc_toolchain_resolution --extra_toolchains=@local_config_cc//:cc-toolchain-arm64_windows  --copt=-w --host_copt=-w --stamp --embed_label %RELEASE_NAME% src/bazel src/bazel_nojdk scripts/packages/bazel.zip
 
       mkdir artifacts
       move bazel-bin\src\bazel artifacts\bazel-%RELEASE_NAME%-windows-arm64.exe


### PR DESCRIPTION
After https://github.com/bazelbuild/bazel/commit/5647b26d7152f0a5ebd5d5fec2643d8e0b8dd661, we should select the cross compile toolchain differently.