### PR TITLE
Drop `--exec_constraints` from `rbe-configs/generate.py`

### DIFF
--- a/rbe-configs/generate.py
+++ b/rbe-configs/generate.py
@@ -43,17 +43,12 @@ def generate_configs(output_root: str, bazel_version: str, toolchain_name: str,
   os.makedirs(output_dir, exist_ok=True)
 
   toolchain_container = 'gcr.io/bazel-public/{}:latest'.format(toolchain_name)
-  exec_constraints = [
-      '@platforms//os:linux', '@platforms//cpu:x86_64',
-      '@bazel_tools//tools/cpp:gcc'
-  ]
   subprocess.run(
       [
           'rbe_configs_gen',
           '--bazel_version={}'.format(bazel_version),
           '--toolchain_container={}'.format(toolchain_container),
           '--cpp_env_json={}'.format(cpp_env_json),
-          '--exec_constraints={}'.format(','.join(exec_constraints)),
           '--output_tarball={}'.format(output_tarball),
           '--output_manifest={}'.format(output_manifest),
           '--exec_os=linux',


### PR DESCRIPTION
`rbe_configs_gen` does not and AFAICT never did expose such a flag.

In fact, the flag had a typo from when it was introduced till cfad46da7a17a500792f9799420ed22552de1a5b several months later which makes me think this script was either never used, or if it was, it was used with a custom build of `rbe_configs_gen` that does expose that flag.