### PR TITLE
Allow flags and targets to be specified as sets to allow merging common base configs

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -190,6 +190,40 @@ tasks:
     - ":clwb_tests"
 ```
 
+### Sharing Configuration Between Tasks
+
+You can define common configurations and share them between tasks using `*aliases` and the [`<<:` merge key](https://yaml.org/type/merge.html). YAML allows merging maps and sets, but not lists; to merge flags or targets, represent them as a set instead of a list:
+
+```yaml
+# This is a set, not a list, to allow merging into windows.build_flags and windows.test_flags
+.common_flags: !!set &common_flags
+  ? "--incompatible_disable_starlark_host_transitions"
+  ? "--enable_bzlmod"
+
+.common_task_config: &common_task_config
+  build_flags: *common_flags
+  build_targets:
+    - "//..."
+  test_flags: *common_flags
+  test_targets:
+    - "//tests/..."
+
+tasks:
+  ubuntu1804:
+    <<: *common_task_config
+  ubuntu2004:
+    <<: *common_task_config
+  windows:
+    <<: *common_task_config
+    # These are sets, not lists, to allow merging
+    build_flags: !!set
+      <<: *common_flags
+      ? "--noexperimental_repository_cache_hardlinks"
+    test_flags: !!set
+      <<: *common_flags
+      ? "--noexperimental_repository_cache_hardlinks"
+```
+
 ### Specifying a Display Name
 
 Each task may have an optional display name that can include Emojis. This feature is especially useful if you have several tasks that run on the same platform, but use different Bazel binaries.

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1209,7 +1209,7 @@ def calculate_flags(task_config, task_config_key, action_key, tmpdir, test_env_v
             )
         ]
 
-    flags = task_config.get(task_config_key) or []
+    flags = list(task_config.get(task_config_key)) or []
     flags += json_profile_flags
     flags += capture_corrupted_outputs_flags
     # We have to add --test_env flags to `build`, too, otherwise Bazel
@@ -2191,10 +2191,10 @@ def calculate_targets(
 ):
     print_collapsed_group(":dart: Calculating targets")
 
-    build_targets = [] if test_only else task_config.get("build_targets", [])
-    test_targets = [] if build_only else task_config.get("test_targets", [])
-    coverage_targets = [] if (build_only or test_only) else task_config.get("coverage_targets", [])
-    index_targets = [] if (build_only or test_only) else task_config.get("index_targets", [])
+    build_targets = [] if test_only else list(task_config.get("build_targets", []))
+    test_targets = [] if build_only else list(task_config.get("test_targets", []))
+    coverage_targets = [] if (build_only or test_only) else list(task_config.get("coverage_targets", []))
+    index_targets = [] if (build_only or test_only) else list(task_config.get("index_targets", []))
 
     index_targets_query = (
         None if (build_only or test_only) else task_config.get("index_targets_query", None)


### PR DESCRIPTION
Motivation: https://github.com/bazelbuild/stardoc/pull/184

We often want to specify a base list of flags/targets which can be augmented on "weird" platforms (Windows, perhaps Mac). But to use the YAML `<<:` merge key, the entities merged must be maps or sets, not lists.

To do this, we can allow *_flags and *_targets to be sets - but we must take care to transform them to lists when processing, so that list concatenation etc. operators still work.