### PR TITLE
Fix infinite loop in dashboard server

### DIFF
--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/issuecomment/GithubIssueCommentService.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/issuecomment/GithubIssueCommentService.java
@@ -38,6 +38,7 @@ public class GithubIssueCommentService {
         if (node.size() < PER_PAGE) {
           break;
         }
+        page += 1;
       } catch (IOException e) {
         log.error("Failed to sync issue comments: " + e.getMessage(), e);
         return;


### PR DESCRIPTION
The bug was introduced last time I refactored the code using JDK19 and virtual threads. The infinite loop can happen when the server tries to sync comments data of one issue from Github and if the number of pages is greater than 1. It starves the scheduler thread, preventing the server handles more events and syncing tasks, resulting in the delay of syncing until a restart.