### PR TITLE
Automate creating java_tools releases

### DIFF
--- a/pipelines/java_tools-release.yml
+++ b/pipelines/java_tools-release.yml
@@ -1,0 +1,67 @@
+---
+steps:
+  - input: "Artifacts information"
+    fields:
+      - text: "Artifacts output"
+        key: "artifacts"
+        required: true
+        hint: "Output from create_java_tools_release.sh"  
+
+  - wait 
+        
+  - label: "Release java_tools"
+    agents:
+      - "queue=default"
+    plugins:
+      docker#v3.8.0:
+        always-pull: true
+        environment:
+          - ANDROID_HOME
+          - ANDROID_NDK_HOME 
+          - BUILDKITE_ARTIFACT_UPLOAD_DESTINATION
+        image: gcr.io/bazel-public/ubuntu2004-java11
+        network: host 
+        privileged: true 
+        propagate-environment: true
+        propagate-uid-gid: true
+        shell: ["/bin/bash", "-e", "-c"]
+        volumes:
+          - "/etc/group:/etc/group:ro"
+          - "/etc/passwd:/etc/passwd:ro"
+          - "/etc/shadow:/etc/shadow:ro"
+          - "/opt/android-ndk-r15c:/opt/android-ndk-r15c:ro"
+          - "/opt/android-sdk-linux:/opt/android-sdk-linux:ro"
+          - "/var/lib/buildkite-agent:/var/lib/buildkite-agent"
+          - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
+          - "/var/run/docker.sock:/var/run/docker.sock"      
+    command: | 
+      echo "+++ Checking out Git branch"
+      git fetch origin ${BUILDKITE_BRANCH}
+      git checkout ${BUILDKITE_BRANCH}
+
+      echo "+++ Identifying required variable"      
+      sha=$(buildkite-agent meta-data get "artifacts") 
+      echo "sha = \"\$sha\""
+
+      echo "+++ Getting java_tools version"
+      IFS='/'
+      read -a strarr <<< \${sha}      
+      version="\${strarr[2]}"
+      echo "version = \"\$version\""
+
+      echo "+++ Preparing release notes and .zip files"
+      cd scripts
+      pip3 install wget
+      python3 release.py --artifacts "\$sha"
+
+      echo "+++ Downloading github-release"
+      curl -L https://mirror.bazel.build/github.com/c4milo/github-release/releases/download/v1.1.0/github-release_v1.1.0_linux_amd64.tar.gz | sudo tar xz -C /usr/local/bin
+      sudo chown root:root /usr/local/bin/github-release
+      sudo chmod 0755 /usr/local/bin/github-release
+
+      echo "+++ Importing GitHub token"
+      github_token=$(gsutil cat gs://bazel-trusted-encrypted-secrets/github-trusted-token.enc | gcloud kms decrypt --project bazel-public --location global --keyring buildkite --key github-trusted-token --ciphertext-file - --plaintext-file -)
+
+      echo "+++ Creating a release on GitHub"
+      relnotes=$(cat relnotes.txt)
+      GITHUB_TOKEN=\${github_token} github-release "bazelbuild/java_tools" java_\${version} "master" "\${relnotes}" "*.zip"


### PR DESCRIPTION
Script: https://github.com/bazelbuild/java_tools/pull/78

(This is just the part that creates the release on GitHub. Steps to create RCs, update files, create PRs, etc. are still in progress).

cc @hvadehra 