### PR TITLE
Disable flatbuffer in downstream pipeline

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -186,6 +186,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/google/flatbuffers.git",
         "http_config": "https://raw.githubusercontent.com/google/flatbuffers/master/.bazelci/presubmit.yml",
         "pipeline_slug": "flatbuffers",
+        "disabled_reason": "https://github.com/google/flatbuffers/issues/7992",
     },
     "Flogger": {
         "git_repository": "https://github.com/google/flogger.git",


### PR DESCRIPTION
1.[ [Error: 'apple_common' value has no field or method 'multi_arch_split' with BAZEL@HEAD](https://github.com/google/flatbuffers/issues/8095#top)](https://github.com/google/flatbuffers/issues/8095)
2. [Flatbuffers is failing with bazel@HEAD and should upgrade to the latest rules_js.](https://github.com/google/flatbuffers/issues/7992)