### PR TITLE
Update dashboard

### DIFF
--- a/dashboard/server/Dockerfile
+++ b/dashboard/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:19
+FROM azul/zulu-openjdk-alpine:20
 ARG DEPENDENCY=dependency
 COPY ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY ${DEPENDENCY}/META-INF /app/META-INF

--- a/dashboard/server/database.sql
+++ b/dashboard/server/database.sql
@@ -204,7 +204,6 @@ CREATE TABLE github_team_table
     created_at      TIMESTAMPTZ NOT NULL,
     updated_at      TIMESTAMPTZ NOT NULL,
     name            TEXT        NOT NULL,
-    none_team_owner TEXT        NOT NULL DEFAULT '',
     PRIMARY KEY (owner, repo, id)
 );
 

--- a/dashboard/server/database.sql
+++ b/dashboard/server/database.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS citext;
+
 CREATE TABLE json_state
 (
     key       TEXT PRIMARY KEY,
@@ -55,7 +57,7 @@ CREATE TABLE github_issue
     title           TEXT        NOT NULL,
     body            TEXT        NOT NULL,
     milestone       TEXT        NOT NULL,
-    labels          TEXT[]      NOT NULL,
+    labels          CITEXT[]    NOT NULL,
     created_at      TIMESTAMPTZ NOT NULL,
     updated_at      TIMESTAMPTZ,
     closed_at       TIMESTAMPTZ,

--- a/dashboard/server/database.sql
+++ b/dashboard/server/database.sql
@@ -279,6 +279,20 @@ CREATE TABLE github_issue_comment_data
 );
 
 --
+-- Table that stores the raw pull requests data fetched from Github
+--
+CREATE TABLE github_pull_request_data
+(
+    owner        TEXT        NOT NULL,
+    repo         TEXT        NOT NULL,
+    issue_number INTEGER     NOT NULL,
+    timestamp    TIMESTAMPTZ NOT NULL,
+    etag         TEXT        NOT NULL,
+    data         JSONB       NOT NULL,
+    PRIMARY KEY (owner, repo, issue_number)
+);
+
+--
 -- Table that stores the raw builds data fetched from Buildkite
 --
 CREATE TABLE buildkite_build_data

--- a/dashboard/server/pom.xml
+++ b/dashboard/server/pom.xml
@@ -15,7 +15,7 @@
     <description>The server for the dashboard</description>
 
     <properties>
-        <java.version>19</java.version>
+        <java.version>20</java.version>
         <project.version>DEV</project.version>
     </properties>
 

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/api/FetchPullRequestRequest.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/api/FetchPullRequestRequest.java
@@ -1,0 +1,3 @@
+package build.bazel.dashboard.github.api;
+
+public record FetchPullRequestRequest(String owner, String repo, int issueNumber, String etag) {}

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/api/GithubApi.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/api/GithubApi.java
@@ -11,6 +11,8 @@ public interface GithubApi {
 
   RestApiResponse fetchIssue(FetchIssueRequest request);
 
+  RestApiResponse fetchPullRequest(FetchPullRequestRequest request);
+
   RestApiResponse listIssueComments(ListIssueCommentsRequest request);
 
   RestApiResponse searchIssues(SearchIssuesRequest request);

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/api/WebClientGithubApi.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/api/WebClientGithubApi.java
@@ -105,6 +105,24 @@ public class WebClientGithubApi extends RestApiClient implements GithubApi {
   }
 
   @Override
+  public RestApiResponse fetchPullRequest(FetchPullRequestRequest request) {
+    log.debug("{}", request);
+
+    WebClient.RequestHeadersSpec<?> spec =
+        get(
+            uriBuilder ->
+                uriBuilder
+                    .pathSegment(
+                        "repos",
+                        request.owner(),
+                        request.repo(),
+                        "pulls",
+                        String.valueOf(request.issueNumber()))
+                    .build(), request.etag());
+    return exchange(spec);
+  }
+
+  @Override
   public RestApiResponse listIssueComments(ListIssueCommentsRequest request) {
     log.debug("{}", request);
 

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/issue/GithubIssue.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/issue/GithubIssue.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.Instant;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -21,13 +23,15 @@ public class GithubIssue {
   String etag;
   JsonNode data;
 
-  public static GithubIssue empty(String owner, String repo, int issueNumber) {
+  public static GithubIssue empty(
+      String owner, String repo, int issueNumber, ObjectMapper objectMapper) {
     return GithubIssue.builder()
         .owner(owner)
         .repo(repo)
         .issueNumber(issueNumber)
         .timestamp(Instant.EPOCH)
         .etag("")
+        .data(objectMapper.createObjectNode())
         .build();
   }
 
@@ -48,9 +52,14 @@ public class GithubIssue {
     String title;
     String state;
     List<Label> labels;
-    @Nullable User assignee;
+    List<User> assignees;
     Instant createdAt;
     Instant updatedAt;
+    @Nullable JsonNode pullRequest;
+
+    public boolean isPullRequest() {
+      return pullRequest != null;
+    }
   }
 
   @Builder

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/issue/GithubPullRequest.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/issue/GithubPullRequest.java
@@ -1,0 +1,27 @@
+package build.bazel.dashboard.github.issue;
+
+import build.bazel.dashboard.github.issue.GithubIssue.User;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.time.Instant;
+import java.util.List;
+
+public record GithubPullRequest(
+    String owner, String repo, int issueNumber, Instant timestamp, String etag, JsonNode data) {
+
+  public static GithubPullRequest empty(
+      String owner, String repo, int issueNumber, ObjectMapper objectMapper) {
+    return new GithubPullRequest(
+        owner, repo, issueNumber, Instant.EPOCH, "", objectMapper.createObjectNode());
+  }
+
+  public Data parseData(ObjectMapper objectMapper) throws JsonProcessingException {
+    return objectMapper.treeToValue(data, Data.class);
+  }
+
+  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+  public record Data(List<User> requestedReviewers) {}
+}

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/issue/GithubPullRequestRepo.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/issue/GithubPullRequestRepo.java
@@ -1,0 +1,78 @@
+package build.bazel.dashboard.github.issue;
+
+import static build.bazel.dashboard.utils.PgJson.toPgJson;
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.r2dbc.postgresql.codec.Json;
+import io.r2dbc.spi.Readable;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GithubPullRequestRepo {
+  private final DatabaseClient databaseClient;
+  private final ObjectMapper objectMapper;
+
+  public void save(GithubPullRequest pullRequest) {
+    databaseClient
+        .sql(
+            "INSERT INTO github_pull_request_data (owner, repo, issue_number, timestamp, etag, data)"
+                + " VALUES (:owner, :repo, :issue_number, :timestamp, :etag, :data) ON"
+                + " CONFLICT (owner, repo, issue_number) DO UPDATE SET etag = excluded.etag,"
+                + " timestamp = excluded.timestamp, data = excluded.data")
+        .bind("owner", pullRequest.owner())
+        .bind("repo", pullRequest.repo())
+        .bind("issue_number", pullRequest.issueNumber())
+        .bind("timestamp", pullRequest.timestamp())
+        .bind("etag", pullRequest.etag())
+        .bind("data", toPgJson(objectMapper, pullRequest.data()))
+        .then()
+        .block();
+  }
+
+  public void delete(String owner, String repo, int issueNumber) {
+    databaseClient
+        .sql(
+            "DELETE FROM github_pull_request_data WHERE owner = :owner AND repo = :repo AND"
+                + " issue_number = :issue_number")
+        .bind("owner", owner)
+        .bind("repo", repo)
+        .bind("issue_number", issueNumber)
+        .then()
+        .block();
+  }
+
+  public Optional<GithubPullRequest> findOne(String owner, String repo, int issueNumber) {
+    return Optional.ofNullable(
+        databaseClient
+            .sql(
+                "SELECT owner, repo, issue_number, timestamp, etag, data FROM github_pull_request_data "
+                    + "WHERE owner=:owner AND repo=:repo AND issue_number=:issue_number")
+            .bind("owner", owner)
+            .bind("repo", repo)
+            .bind("issue_number", issueNumber)
+            .map(this::toPullRequest)
+            .one()
+            .block());
+  }
+
+  private GithubPullRequest toPullRequest(Readable row) {
+    try {
+      return new GithubPullRequest(
+          requireNonNull(row.get("owner", String.class)),
+          requireNonNull(row.get("repo", String.class)),
+          requireNonNull(row.get("issue_number", Integer.class)),
+          requireNonNull(row.get("timestamp", Instant.class)),
+          requireNonNull(row.get("etag", String.class)),
+          objectMapper.readTree((requireNonNull(row.get("data", Json.class))).asArray()));
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/issuelist/GithubIssueListRepoPg.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/issuelist/GithubIssueListRepoPg.java
@@ -8,6 +8,8 @@ import build.bazel.dashboard.github.issuestatus.GithubIssueStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.r2dbc.postgresql.codec.Json;
+import io.r2dbc.postgresql.codec.PostgresqlObjectId;
+import io.r2dbc.spi.Parameters;
 import io.r2dbc.spi.Readable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
@@ -76,7 +78,9 @@ public class GithubIssueListRepoPg implements GithubIssueListRepo {
 
     if (params.getLabels() != null && !params.getLabels().isEmpty()) {
       where.append(" AND gi.labels @> :labels");
-      bindings.put("labels", params.getLabels().toArray(new String[0]));
+      bindings.put(
+          "labels",
+          Parameters.in(PostgresqlObjectId.UNSPECIFIED, params.getLabels().toArray(new String[0])));
     }
 
     if (where.length() > 0) {

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/issuequery/GithubIssueQueryExecutorPg.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/issuequery/GithubIssueQueryExecutorPg.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.r2dbc.postgresql.codec.Json;
-import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.core.Single;
+import io.r2dbc.postgresql.codec.PostgresqlObjectId;
+import io.r2dbc.spi.Parameters;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
@@ -129,12 +129,19 @@ public class GithubIssueQueryExecutorPg implements GithubIssueQueryExecutor {
 
     if (!parsedQuery.getLabels().isEmpty()) {
       and(condition, "labels @> :labels");
-      bindings.put("labels", parsedQuery.getLabels().toArray(new String[0]));
+      bindings.put(
+          "labels",
+          Parameters.in(
+              PostgresqlObjectId.UNSPECIFIED, parsedQuery.getLabels().toArray(new String[0])));
     }
 
     if (!parsedQuery.getExcludeLabels().isEmpty()) {
       and(condition, "NOT labels && :excluded_labels");
-      bindings.put("excluded_labels", parsedQuery.getExcludeLabels().toArray(new String[0]));
+      bindings.put(
+          "excluded_labels",
+          Parameters.in(
+              PostgresqlObjectId.UNSPECIFIED,
+              parsedQuery.getExcludeLabels().toArray(new String[0])));
     }
 
     return SqlCondition.builder().condition(condition.toString()).bindings(bindings).build();

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/issuestatus/GithubIssueStatusRestController.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/issuestatus/GithubIssueStatusRestController.java
@@ -3,6 +3,7 @@ package build.bazel.dashboard.github.issuestatus;
 import static build.bazel.dashboard.utils.RxJavaVirtualThread.completable;
 
 import build.bazel.dashboard.github.issue.GithubIssueService;
+import build.bazel.dashboard.github.issue.GithubPullRequestRepo;
 import io.reactivex.rxjava3.core.Completable;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class GithubIssueStatusRestController {
   private final GithubIssueService githubIssueService;
+  private final GithubPullRequestRepo githubPullRequestRepo;
   private final GithubIssueStatusService githubIssueStatusService;
 
   @PutMapping("/internal/github/{owner}/{repo}/issues/status")
@@ -29,8 +31,9 @@ public class GithubIssueStatusRestController {
         () -> {
           for (var number = start; number < start + count; ++number) {
             var issue = githubIssueService.findOne(owner, repo, number);
+            var pullRequest = githubPullRequestRepo.findOne(owner, repo, number).orElse(null);
             if (issue.isPresent()) {
-              githubIssueStatusService.check(issue.get(), Instant.now());
+              githubIssueStatusService.check(issue.get(), pullRequest, Instant.now());
             }
           }
         });

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/issuestatus/GithubIssueStatusService.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/issuestatus/GithubIssueStatusService.java
@@ -195,7 +195,8 @@ public class GithubIssueStatusService {
   }
 
   private static boolean hasMoreDataNeededLabel(List<Label> labels) {
-    return hasLabel(labels, "more data needed");
+    return hasLabel(labels, "more data needed")
+        || hasLabel(labels, "awaiting-user-response");
   }
 
   private static boolean hasPriorityLabel(List<Label> labels) {

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/repo/GithubRepoRepoPg.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/repo/GithubRepoRepoPg.java
@@ -36,7 +36,7 @@ public class GithubRepoRepoPg implements GithubRepoRepo {
     return databaseClient
         .sql(
             "SELECT owner, repo, created_at, updated_at, action_owner, is_team_label_enabled"
-                + " FROM github_repo")
+                + " FROM github_repo ORDER BY owner, repo")
         .map(this::toGithubRepo)
         .all()
         .collect(toImmutableList())

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/sync/issue/GithubSyncIssueTask.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/sync/issue/GithubSyncIssueTask.java
@@ -96,7 +96,6 @@ public class GithubSyncIssueTask {
               buildSyncStateKey(repo.getOwner(), repo.getRepo()), SyncIssueState.class);
       if (jsonState.getData() != null) {
         this.syncGithubIssue(jsonState);
-        return;
       }
     }
   }

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/sync/issue/GithubSyncIssueTask.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/sync/issue/GithubSyncIssueTask.java
@@ -8,6 +8,8 @@ import build.bazel.dashboard.github.issuecomment.GithubIssueCommentService;
 import build.bazel.dashboard.github.repo.GithubRepoService;
 import build.bazel.dashboard.utils.JsonStateStore;
 import build.bazel.dashboard.utils.JsonStateStore.JsonState;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.reactivex.rxjava3.core.Completable;
 import java.time.Instant;
 import javax.annotation.Nullable;
@@ -33,12 +35,14 @@ public class GithubSyncIssueTask {
 
   @Builder
   @Value
+  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
   static class SyncIssueState {
     String owner;
     String repo;
     int start;
     @With int current;
     int end;
+    Instant createdAt;
   }
 
   @PutMapping("/internal/github/{owner}/{repo}/sync/issues")
@@ -67,6 +71,7 @@ public class GithubSyncIssueTask {
             .start(start)
             .current(start)
             .end(end)
+            .createdAt(Instant.now())
             .build());
   }
 
@@ -80,10 +85,9 @@ public class GithubSyncIssueTask {
     for (var repo : githubRepoService.findAll()) {
       String stateKey = buildSyncStateKey(repo.getOwner(), repo.getRepo());
       var jsonState = jsonStateStore.load(stateKey, SyncIssueState.class);
-      if (jsonState.getData() != null) {
-        return;
+      if (jsonState.getData() == null) {
+        saveAllSyncIssueState(repo.getOwner(), repo.getRepo(), jsonState.getTimestamp());
       }
-      saveAllSyncIssueState(repo.getOwner(), repo.getRepo(), jsonState.getTimestamp());
     }
   }
 

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/teamtable/GithubTeamTableRepo.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/teamtable/GithubTeamTableRepo.java
@@ -18,7 +18,6 @@ public interface GithubTeamTableRepo {
     Instant createdAt;
     Instant updatedAt;
     String name;
-    String noneTeamOwner;
     List<Header> headers;
 
     @Builder

--- a/dashboard/server/src/main/java/build/bazel/dashboard/github/teamtable/GithubTeamTableRepoPg.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/github/teamtable/GithubTeamTableRepoPg.java
@@ -20,7 +20,7 @@ public class GithubTeamTableRepoPg implements GithubTeamTableRepo {
         Optional.ofNullable(
             databaseClient
                 .sql(
-                    "SELECT owner, repo, id, created_at, updated_at, name, none_team_owner FROM"
+                    "SELECT owner, repo, id, created_at, updated_at, name FROM"
                         + " github_team_table WHERE owner = :owner AND repo = :repo AND id = :id")
                 .bind("owner", owner)
                 .bind("repo", repo)
@@ -33,8 +33,7 @@ public class GithubTeamTableRepoPg implements GithubTeamTableRepo {
                             .id(row.get("id", String.class))
                             .createdAt(row.get("created_at", Instant.class))
                             .updatedAt(row.get("updated_at", Instant.class))
-                            .name(row.get("name", String.class))
-                            .noneTeamOwner(row.get("none_team_owner", String.class)))
+                            .name(row.get("name", String.class)))
                 .one()
                 .block());
     if (builderOptional.isEmpty()) {


### PR DESCRIPTION
Check in bunch of fixes/updates:

- Sort repo by names when displaying them on the sidebar.
- Use JDK20.
- Remove duplicated `team_owner` field in `github_team_table`. Make it easier to change owners of repo.
- Use case-insensitive text for labels to match the search result on Github.
- Fix a bug that sometimes action owners for an issue are not correctly computed.
- Update the logic for determining whether an issue/PR is triaged according to today's triaging process.
- Update nagging emails to have a separated PRs section.
- Improve sync process.

Fixes #1732.