### PR TITLE
More updates to the java_tools release pipeline

### DIFF
--- a/pipelines/bcr-integrity.yml
+++ b/pipelines/bcr-integrity.yml
@@ -1,0 +1,48 @@
+---
+steps:
+  - input: "Get archive"
+    fields:
+      - text: "rules_java archive file"
+        key: "archive"
+        required: true
+        hint: "e.g. d1196d250c17dfffed52db13c75d4f9b9cd20617.tar.gz"
+           
+  - wait
+
+  - label: "Calculate integrity value" 
+    agents:
+      - "queue=default"
+    plugins:
+      docker#v3.8.0:
+        always-pull: true
+        environment:
+          - ANDROID_HOME
+          - ANDROID_NDK_HOME
+          - BUILDKITE_ARTIFACT_UPLOAD_DESTINATION
+        image: gcr.io/bazel-public/ubuntu2004-java11
+        network: host
+        privileged: true
+        propagate-environment: true
+        propagate-uid-gid: true
+        shell: ["/bin/bash", "-e", "-c"]
+        volumes:
+          - "/etc/group:/etc/group:ro"
+          - "/etc/passwd:/etc/passwd:ro"
+          - "/etc/shadow:/etc/shadow:ro"
+          - "/opt/android-ndk-r15c:/opt/android-ndk-r15c:ro"
+          - "/opt/android-sdk-linux:/opt/android-sdk-linux:ro"
+          - "/var/lib/buildkite-agent:/var/lib/buildkite-agent"
+          - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
+          - "/var/run/docker.sock:/var/run/docker.sock"      
+    command: |
+      echo "+++ Checking out Git branch"   
+      git fetch origin main
+      git checkout main
+
+      echo "+++ Getting rules_java archive"
+      archive=$(buildkite-agent meta-data get "archive")
+      echo "archive = \"\$archive\""
+
+      echo "+++ Running calc_integrity.py"
+      pip3 install validators
+      python3 ./tools/calc_integrity.py https://github.com/bazelbuild/rules_java/archive/\${archive}

--- a/pipelines/java_tools-release.yml
+++ b/pipelines/java_tools-release.yml
@@ -6,6 +6,10 @@ steps:
         key: "artifacts"
         required: true
         hint: "Output from create_java_tools_release.sh"  
+      - text: "Version"
+        key: "version"
+        required: true
+        hint: "E.g. v12.1"          
 
   - wait 
         
@@ -40,19 +44,15 @@ steps:
       git checkout ${BUILDKITE_BRANCH}
 
       echo "+++ Identifying required variable"      
-      sha=$(buildkite-agent meta-data get "artifacts") 
-      echo "sha = \"\$sha\""
-
-      echo "+++ Getting java_tools version"
-      IFS='/'
-      read -a strarr <<< \${sha}      
-      version="\${strarr[2]}"
+      artifacts=$(buildkite-agent meta-data get "artifacts") 
+      echo "artifacts = \"\$artifacts\""
+      version=$(buildkite-agent meta-data get "version") 
       echo "version = \"\$version\""
 
       echo "+++ Preparing release notes and .zip files"
       cd scripts
       pip3 install wget
-      python3 release.py --artifacts "\$sha"
+      python3 release.py --artifacts "\$artifacts"
 
       echo "+++ Downloading github-release"
       curl -L https://mirror.bazel.build/github.com/c4milo/github-release/releases/download/v1.1.0/github-release_v1.1.0_linux_amd64.tar.gz | sudo tar xz -C /usr/local/bin


### PR DESCRIPTION
1. Automate [step 6.2](https://github.com/bazelbuild/java_tools/blob/master/docs/release.md) - calculate the integrity value of the source archive (to test RCs)
2. Minor updates to java_tools release step