### PR TITLE
[Dashboard] Add timeout to block() for HTTP requests to Github

### DIFF
--- a/dashboard/server/src/main/java/build/bazel/dashboard/common/RestApiClient.java
+++ b/dashboard/server/src/main/java/build/bazel/dashboard/common/RestApiClient.java
@@ -2,6 +2,7 @@ package build.bazel.dashboard.common;
 
 import com.google.common.base.Strings;
 import java.net.URI;
+import java.time.Duration;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -37,7 +38,7 @@ public abstract class RestApiClient {
     return spec.exchangeToMono(response -> {
       log.debug("{} {}", response.statusCode(), response.headers().asHttpHeaders().toSingleValueMap());
       return RestApiResponse.fromClientResponse(response);
-    }).block();
+    }).block(Duration.ofSeconds(120));
   }
 
 }


### PR DESCRIPTION
There was an incident at Github on Sep 22 that caused one of the HTTP requests we sent to Github never returned and thus blocked the entire sync process.

No idea why the underlying HTTP client library didn't throw an error in this case, but we should add a timeout to the `block()` anyway.

Fixes #1732.