### PR TITLE
Fix branch for github-release in rules_java-release.yml

### DIFF
--- a/pipelines/rules_java-release.yml
+++ b/pipelines/rules_java-release.yml
@@ -53,4 +53,4 @@ steps:
       echo "+++ Creating a release on GitHub"
       cd bazel-bin/distro
       relnotes=$(cat relnotes.txt)
-      GITHUB_TOKEN=\${github_token} github-release "bazelbuild/rules_java" \${version} "master" "\${relnotes}" rules_java-\${version}.tar.gz      
+      GITHUB_TOKEN=\${github_token} github-release "bazelbuild/rules_java" \${version} "\${BUILDKITE_BRANCH}" "\${relnotes}" rules_java-\${version}.tar.gz      


### PR DESCRIPTION
The release tag should be on the branch we made the release from, which usually is, but may not always be, "master"