### PR TITLE
Don't assume .bazelrc ends in a newline

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -256,6 +256,8 @@ def prepare_test_module_repo(module_name, module_version, task):
     # Write necessary options to the .bazelrc file
     test_module_root = source_root.joinpath(orig_presubmit["bcr_test_module"]["module_path"])
     scratch_file(test_module_root, ".bazelrc", [
+        # .bazelrc may not end with a newline.
+        "",
         "build --experimental_enable_bzlmod",
         "build --registry=%s" % BCR_REPO_DIR.as_uri(),
     ], mode="a")


### PR DESCRIPTION
Work towards https://github.com/bazelbuild/bazel-central-registry/pull/1094#discussion_r1382662234