### PR TITLE
Downstream pipeline improvements

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1170,11 +1170,13 @@ def use_bazelisk_migrate():
     """
     return is_trueish(os.environ.get("USE_BAZELISK_MIGRATE"))
 
+
 def is_downstream_pipeline():
     """
     Return true if BAZELCI_DOWNSTREAM_PIPELINE is set
     """
-    return is_trueish(os.environ.get("BAZELCI_DOWNSTREAM_PIPELINE")
+    return is_trueish(os.environ.get("BAZELCI_DOWNSTREAM_PIPELINE"))
+
 
 def local_run_only():
     """

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1999,9 +1999,11 @@ def common_build_flags(bep_file, platform):
         "--disk_cache=",
     ]
 
-    # If we are in a downstream pipeline, turn off the lockfile update since changing Bazel version could affect the lockfile.
     if is_downstream_pipeline():
+        # If we are in a downstream pipeline, turn off the lockfile update since changing Bazel version could affect the lockfile.
         flags.append("--lockfile_mode=off")
+        # Filter out targets that should not be built in downstream pipelines.
+        flags.append("--build_tag_filters=-no_bazel_downstream")
 
     if is_windows():
         pass
@@ -2559,6 +2561,10 @@ def execute_bazel_test(
         "--build_tests_only",
         "--local_test_jobs=" + concurrent_test_jobs(platform),
     ]
+    if is_downstream_pipeline():
+        # Filter out targets that should not be built in downstream pipelines.
+        aggregated_flags.append("--test_tag_filters=-no_bazel_downstream")
+
     # Don't enable remote caching if the user enabled remote execution / caching themselves
     # or flaky test monitoring is enabled, as remote caching makes tests look less flaky than
     # they are.

--- a/docs/downstream-testing.md
+++ b/docs/downstream-testing.md
@@ -30,6 +30,8 @@ The Bazel team monitors the downstream pipeline status and report issues for bre
 - The downstream project is expected to respond to the issue within 5 working days. Otherwise, the project is eligible to be temporarily disabled in the downstream pipeline. Note that, even if a pipeline is disabled from the [Bazel@HEAD + downstream](https://buildkite.com/bazel/bazel-at-head-plus-downstream) pipeline, the nightly result can still be checked from the [Bazel@HEAD+ Disabled](https://buildkite.com/bazel/bazel-at-head-plus-disabled) pipeline.
 - If a project remains disabled in the downstream pipeline for more than 6 months without any indication of a fix, we will remove the pipeline configuration from Bazel's downstream pipeline.
 
+Note that: if you want to skip some builds in the downstream pipeline, you can specify `skip_in_bazel_downstream_pipeline: <reason>` for a given job in your [Bazel CI configuration file](../buildkite/README.md#configuring-a-pipeline) or add `no_bazel_downstream` tag for certain build and test targets.
+
 As of May 2023, some projects' pipeline config files live under [the "pipeline" directory](https://github.com/bazelbuild/continuous-integration/tree/master/pipelines) of this repository, which means the Bazel team is responsible for their setup for now, ideally they should be moved to their corresponding repository or the project should be removed.
 
 ## Testing Local Changes With All Downstream Projects


### PR DESCRIPTION
- Set `--lockfile_mode=off` for downstream pipelines so that https://github.com/bazelbuild/bazel/pull/20101 won't break Bazel in downstream pipeline.
- Support filterting out build and test targets by `no_bazel_downstream` tag in downstream pipelines, addressing https://github.com/bazelbuild/rules_python/issues/1481#issuecomment-1768077511