### PR TITLE
Add BuildKite Docker image for NixOS

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -482,6 +482,13 @@ PLATFORMS = {
         "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/fedora39-java17",
         "python": "python3",
     },
+    "nixos": {
+        "name": "NixOS",
+        "emoji-name": ":nixos:",
+        "publish_binary": [],
+        "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/nixos",
+        "python": "python3",
+    },
     "macos": {
         "name": "macOS (OpenJDK 11, Xcode)",
         "emoji-name": ":darwin: (OpenJDK 11, Xcode)",

--- a/buildkite/docker/build.sh
+++ b/buildkite/docker/build.sh
@@ -27,6 +27,7 @@ docker build -f ubuntu1804/Dockerfile --target ubuntu1804-java11 -t "gcr.io/$PRE
 docker build -f ubuntu2004/Dockerfile --target ubuntu2004-java11 -t "gcr.io/$PREFIX/ubuntu2004-java11" ubuntu2004 &
 docker build -f ubuntu2204/Dockerfile --target ubuntu2204-java17 -t "gcr.io/$PREFIX/ubuntu2204-java17" ubuntu2204 &
 docker build -f fedora39/Dockerfile   --target fedora39-java17   -t "gcr.io/$PREFIX/fedora39-java17" fedora39 &
+docker build -f nixos/Dockerfile                                 -t "gcr.io/$PREFIX/nixos" nixos &
 wait
 
 docker build -f centos7/Dockerfile    --target centos7-java8               -t "gcr.io/$PREFIX/centos7-java8" centos7

--- a/buildkite/docker/nixos/Dockerfile
+++ b/buildkite/docker/nixos/Dockerfile
@@ -1,0 +1,27 @@
+FROM nixos/nix
+
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV LANG "C.UTF-8"
+ENV LANGUAGE "C.UTF-8"
+ENV LC_ALL "C.UTF-8"
+
+# Enable Nix Flakes and new commands
+RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+
+# Setup nix-ld for prebuilt non-nix binaries (https://github.com/Mic92/nix-ld)
+RUN nix profile install \
+    nixpkgs#glibc.out \ 
+    nixpkgs#nix-ld \
+    nixpkgs#stdenv.cc.cc.lib && \
+    mkdir /lib64 && \
+    ln -s /nix/var/nix/profiles/default/libexec/nix-ld /lib64/ld-linux-x86-64.so.2
+ENV NIX_LD="/nix/var/nix/profiles/default/lib64/ld-linux-x86-64.so.2"
+ENV NIX_LD_LIBRARY_PATH="/nix/var/nix/profiles/default/lib"
+
+### Install packages required by Bazel and its tests
+RUN nix profile install \
+    nixpkgs#bazel-buildtools \
+    nixpkgs#bazelisk \
+    nixpkgs#coreutils-full \
+    nixpkgs#python39 && \
+    ln -s /root/.nix-profile/bin/bazelisk /root/.nix-profile/bin/bazel

--- a/buildkite/docker/push.sh
+++ b/buildkite/docker/push.sh
@@ -32,4 +32,5 @@ docker push "gcr.io/$PREFIX/ubuntu2204-java17" &
 docker push "gcr.io/$PREFIX/ubuntu2204-bazel-java17" &
 docker push "gcr.io/$PREFIX/fedora39-java17" &
 docker push "gcr.io/$PREFIX/fedora39-bazel-java17" &
+docker push "gcr.io/$PREFIX/nixos" &
 wait


### PR DESCRIPTION
Implements #1703.

This uses `nix-ld` so that the Bazel fetched by Bazelisk can run.  I don't think this is very idiomatic, but is hopefully acceptable for matching the behavior of the other images where Bazelisk and Buildifier come already installed.