### PR TITLE
Work around an issue with ubuntu2004

### DIFF
--- a/buildkite/docker/ubuntu2004/Dockerfile
+++ b/buildkite/docker/ubuntu2004/Dockerfile
@@ -54,6 +54,15 @@ RUN apt-get -y update && \
     apt-get -y purge apport && \
     rm -rf /var/lib/apt/lists/*
 
+# Workaround https://bugs.launchpad.net/ubuntu/+source/gcc-9/+bug/2029910
+# TODO: remove when the latest ubuntu:20.04 image has the fix.
+WORKDIR /tempdir
+RUN apt-get -y update && apt-get download libgcc-10-dev
+RUN dpkg -x libgcc-10-dev_10.5.0-1ubuntu1~20.04_amd64.deb .
+RUN cp usr/lib/gcc/x86_64-linux-gnu/10/libtsan_preinit.o /usr/lib/gcc/x86_64-linux-gnu/9/
+RUN rm -rf /tempdir
+WORKDIR /
+
 # Allow using sudo inside the container.
 RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 


### PR DESCRIPTION
Which should fix the build error in https://buildkite.com/bazel-testing/bazel-bazel/builds/8516#018bc92d-840d-46cd-ac4c-702a99c47fe5 when we try to update the docker image.

Related ubuntu issue: https://bugs.launchpad.net/ubuntu/+source/gcc-9/+bug/2029910