### PR TITLE
Fix suppress stdout in execute_command function

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2616,7 +2616,7 @@ def execute_command(
         errors="replace",
         stdout=subprocess.DEVNULL
         if suppress_stdout
-        else subprocess.PIPE,  # suppress_stdout=True when we don't want the output to be printed
+        else None,  # suppress_stdout=True when we don't want the output to be printed
         stderr=subprocess.PIPE
         if capture_stderr
         else None,  # capture_stderr=True when we want exceptions to contain stderr


### PR DESCRIPTION
It should fallback to the default value `None` when suppress_stdout is false

This should restore the missing test summary starting from https://buildkite.com/bazel/bazel-bazel/builds/25524 which is right after https://github.com/bazelbuild/continuous-integration/pull/1778 was merged.