### PR TITLE
Fix auto sheriff

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3100,6 +3100,8 @@ def create_label(platform, project_name, build_only=False, test_only=False, task
     )
 
     if project_name:
+        # Update get_project_name_from_job in bazel_auto_sheriff.py if you change
+        # the expected format of "Project Foo (Task bar on OS)"
         label += "{0} ({1})".format(project_name, platform_label)
     else:
         label += platform_label


### PR DESCRIPTION
https://github.com/bazelbuild/continuous-integration/pull/1776 removed http_config entries for downstream projects, which caused auto sheriff to fail. With this change we no longer use "http_config : project name" mappings. Instead we extract the project name from the job label, which is a bit of a hack.