### PR TITLE
Prevent bazel query commands to change Bzlmod lockfile.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2156,7 +2156,7 @@ def calculate_targets(
         output = execute_command_and_get_output(
             [bazel_binary]
             + common_startup_flags()
-            + ["--nosystem_rc", "--nohome_rc", "query", index_targets_query],
+            + ["--nosystem_rc", "--nohome_rc", "query", "--lockfile_mode=off", index_targets_query],
             print_output=False,
         )
         index_targets += output.strip().split("\n")
@@ -2236,6 +2236,7 @@ def expand_test_target_patterns(bazel_binary, test_targets, test_flags):
             "--nosystem_rc",
             "--nohome_rc",
             "cquery" if os.getenv("EXP_USE_CQUERY") else "query",
+            "--lockfile_mode=off",
             get_test_query(test_targets, test_flags),
         ],
         print_output=False,


### PR DESCRIPTION
So that failures https://github.com/bazelbuild/bazel/commit/d3c3c5db69f253ad8ca6cc38f00f0143b3de6138 addresses can be caught in presubmit.