### PR TITLE
Address CI lab outage

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2822,6 +2822,7 @@ def print_project_pipeline(
         except ValueError:
             raise BuildkiteException("Task {} has invalid shard value '{}'".format(task, shards))
 
+        # TODO(https://github.com/bazelbuild/continuous-integration/issues/1800): enable Mac workers again once they are back online
         if "mac" not in platform:
             step = runner_step(
                 platform=platform,

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2822,21 +2822,22 @@ def print_project_pipeline(
         except ValueError:
             raise BuildkiteException("Task {} has invalid shard value '{}'".format(task, shards))
 
-        step = runner_step(
-            platform=platform,
-            task=task,
-            task_name=task_name,
-            project_name=project_name,
-            http_config=http_config,
-            file_config=file_config,
-            git_repository=git_repository,
-            git_commit=git_commit,
-            monitor_flaky_tests=monitor_flaky_tests,
-            use_but=use_but,
-            shards=shards,
-            soft_fail=soft_fail,
-        )
-        pipeline_steps.append(step)
+        if "mac" not in platform:
+            step = runner_step(
+                platform=platform,
+                task=task,
+                task_name=task_name,
+                project_name=project_name,
+                http_config=http_config,
+                file_config=file_config,
+                git_repository=git_repository,
+                git_commit=git_commit,
+                monitor_flaky_tests=monitor_flaky_tests,
+                use_but=use_but,
+                shards=shards,
+                soft_fail=soft_fail,
+            )
+            pipeline_steps.append(step)
 
     if skipped_downstream_tasks:
         lines = ["\n- {}".format(s) for s in skipped_downstream_tasks]

--- a/buildkite/emergency.yml
+++ b/buildkite/emergency.yml
@@ -17,6 +17,6 @@
 # Please do not clear or delete this file when an incident is over.
 # Instead, simply replace all values with empty strings ("").
 ---
-message: ""
-issue_url: ""
+message: "All Macs are currently offline due to a network issue. We don't expect a resolution before Monday, so we have a workaround in place to not block builds on MacOS tasks."
+issue_url: "https://github.com/bazelbuild/continuous-integration/issues/1800"
 last_good_bazel: ""


### PR DESCRIPTION
1. Skip all MacOS builds
2. Show emergency banner

https://github.com/bazelbuild/continuous-integration/issues/1800