### PR TITLE
Revert "Replace --project_id with --bes_instance_name (#1789)"

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1867,7 +1867,7 @@ def remote_caching_flags(platform, accept_cached=True):
             # Enable BES / Build Results reporting.
             "--bes_backend=buildeventservice.googleapis.com",
             "--bes_timeout=360s",
-            "--bes_instance_name=bazel-untrusted",
+            "--project_id=bazel-untrusted",
         ]
 
     platform_cache_digest = hashlib.sha256()
@@ -1985,7 +1985,7 @@ def rbe_flags(original_flags, accept_cached):
     flags += [
         "--bes_backend=buildeventservice.googleapis.com",
         "--bes_timeout=360s",
-        "--bes_instance_name=bazel-untrusted",
+        "--project_id=bazel-untrusted",
     ]
 
     if not accept_cached:


### PR DESCRIPTION
This reverts commit 6bb0de868e24c5d20a98d511a2e70d1f3f4c70ea.

Fixes https://github.com/bazelbuild/continuous-integration/issues/1810