### PR TITLE
Disable some gerrit tests on Bazel CI

### DIFF
--- a/pipelines/gerrit.yml
+++ b/pipelines/gerrit.yml
@@ -4,29 +4,32 @@ platforms:
     build_targets:
       - "//:release"
       - "//:api"
+    test_flags:
+      - "--test_tag_filters=-git,-git-protocol-v2,-git-upload-archive,-ssh"
     test_targets:
       - "//..."
   ubuntu2204:
-    shell_commands:
-      - "sudo apt -y update && sudo apt -y install openssh-client"
     build_targets:
       - "//:release"
       - "//:api"
+    test_flags:
+      - "--test_tag_filters=-git,-git-protocol-v2,-git-upload-archive,-ssh"
     test_targets:
       - "//..."
   macos:
     build_targets:
       - "//:release"
       - "//:api"
+    test_flags:
+      - "--test_tag_filters=-git,-git-protocol-v2,-git-upload-archive,-ssh"
     test_targets:
       - "//..."
   rbe_ubuntu2204:
-    shell_commands:
-      - "sudo apt -y update && sudo apt -y install openssh-client"
     build_targets:
       - "//:release"
       - "//:api-skip-javadocs"
     test_flags:
       - "--config=remote"
+      - "--test_tag_filters=-git,-git-protocol-v2,-git-upload-archive,-ssh"
     test_targets:
       - "//..."


### PR DESCRIPTION
Some Gerrit tests require special setting, like openssh client with ssh keygen facilitiy, that not present on Bazel CI platforms. We disable those tests to not complicate the setup of Bazel CI.