### PR TITLE
Ubuntu (Nix) container no longer needs to source the Nix initialization script

### DIFF
--- a/buildkite/docker/ubuntu2204-nix/Dockerfile
+++ b/buildkite/docker/ubuntu2204-nix/Dockerfile
@@ -5,27 +5,28 @@ ENV LANG "C.UTF-8"
 ENV LANGUAGE "C.UTF-8"
 ENV LC_ALL "C.UTF-8"
 
-# Nix requires `USER` be set in the `source` script below.
-ENV USER="root"
-
 # Install Nix on Ubuntu and enable Nix Flakes and new commands.
 # (https://github.com/odyslam/ddapptools/blob/e255c2dd48222bf82d881e48f58a6000fcb9f1f7/docker/Dockerfile)
+# ENV values reverse-engineered from `/root/.nix-profile/etc/profile.d/nix.sh` after Nix is installed, so
+# we don't need to worry about every shell `source`ing it.
 RUN apt-get update && apt-get install --no-install-recommends -y  locales curl xz-utils vim  ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && mkdir -m 0755 /nix && groupadd -r nixbld && chown root /nix \
     && for n in $(seq 1 10); do useradd -c "Nix build user $n" -d /var/empty -g nixbld -G nixbld -M -N -r -s "$(command -v nologin)" "nixbld$n"; done
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN (curl -L https://nixos.org/nix/install | bash) && \
-    echo "source /root/.nix-profile/etc/profile.d/nix.sh" >> "/root/.bashrc" && \
     mkdir -p /etc/nix && \
     echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+ENV USER="root"
+ENV NIX_PROFILES="/nix/var/nix/profiles/default /root/.nix-profile"
+ENV NIX_SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt"
+ENV PATH="/root/.nix-profile/bin:$PATH"
 
 ### Install packages required by Bazel and its tests.
 ### All Python dependencies of `bazelci.py`.
 ### Everything from `defaultShellUtils` (https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix)
 ### NOTE 1: Some packages get implicitly pulled in, so conflicts are resolved with `--priority 1` annotations.
 ### NOTE 2: `bash` is specifically replaced by `bashInteractive` as the former is rarely what's actually wanted.
-RUN source /root/.nix-profile/etc/profile.d/nix.sh && \
-    nix profile install \
+RUN nix profile install \
     nixpkgs#bashInteractive \
     nixpkgs#bazel-buildtools \
     nixpkgs#bazelisk \


### PR DESCRIPTION
@meteorcloudy, I tested this by running the failing BuildKite invocation locally, with all the volumes/environment variables stripped out and ensuring it made it into `bazelci.py`.  My previous test used `docker run -it --rm gcr.io/bazel-public/ubuntu2204-nix` which gave me a login shell that sourced `~/.bashrc`, whereas the direct `docker run` invocation with `/bin/sh -e -c <command>` evidently skips that.