### PR TITLE
Remove RBE platform for gerrit pipeline

### DIFF
--- a/pipelines/gerrit.yml
+++ b/pipelines/gerrit.yml
@@ -12,12 +12,8 @@ platforms:
     build_targets:
       - "//:release"
       - "//:api"
-    test_flags:
-      - "--test_tag_filters=-git,-git-protocol-v2,-git-upload-archive,-pgm,-ssh"
     test_targets:
       - "//..."
-      - "-//javatests/com/google/gerrit/acceptance/server/httpd:server_httpd"
-      - "-//plugins/delete-project:delete-project_tests"
   macos:
     build_targets:
       - "//:release"
@@ -26,14 +22,3 @@ platforms:
       - "--test_tag_filters=-git,-git-protocol-v2,-git-upload-archive,-ssh"
     test_targets:
       - "//..."
-  rbe_ubuntu2204:
-    build_targets:
-      - "//:release"
-      - "//:api-skip-javadoc"
-    test_flags:
-      - "--config=remote"
-      - "--test_tag_filters=-git,-git-protocol-v2,-git-upload-archive,-pgm,-ssh"
-    test_targets:
-      - "//..."
-      - "-//javatests/com/google/gerrit/acceptance/server/httpd:server_httpd"
-      - "-//plugins/delete-project:delete-project_tests"


### PR DESCRIPTION
Related: #1820.

Also re-enable more tests un Ubuntu platform, after openssh-client package was installed in base ubuntu docker image.