### PR TITLE
Remove no_bazel_downstream tag filter

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2065,9 +2065,6 @@ def compute_flags(platform, flags, bep_file, bazel_binary, enable_remote_cache=F
     if is_downstream_pipeline():
         # If we are in a downstream pipeline, turn off the lockfile update since changing Bazel version could affect the lockfile.
         aggregated_flags.append("--lockfile_mode=off")
-        # Filter out targets that should not be built and tested in downstream pipelines.
-        aggregated_flags.append("--build_tag_filters=-no_bazel_downstream")
-        aggregated_flags.append("--test_tag_filters=-no_bazel_downstream")
 
     return aggregated_flags
 

--- a/docs/downstream-testing.md
+++ b/docs/downstream-testing.md
@@ -30,7 +30,7 @@ The Bazel team monitors the downstream pipeline status and report issues for bre
 - The downstream project is expected to respond to the issue within 5 working days. Otherwise, the project is eligible to be temporarily disabled in the downstream pipeline. Note that, even if a pipeline is disabled from the [Bazel@HEAD + downstream](https://buildkite.com/bazel/bazel-at-head-plus-downstream) pipeline, the nightly result can still be checked from the [Bazel@HEAD+ Disabled](https://buildkite.com/bazel/bazel-at-head-plus-disabled) pipeline.
 - If a project remains disabled in the downstream pipeline for more than 6 months without any indication of a fix, we will remove the pipeline configuration from Bazel's downstream pipeline.
 
-Note that: if you want to skip some builds in the downstream pipeline, you can specify `skip_in_bazel_downstream_pipeline: <reason>` for a given job in your [Bazel CI configuration file](../buildkite/README.md#configuring-a-pipeline) or add `no_bazel_downstream` tag for certain build and test targets.
+Note that: if you want to skip some builds in the downstream pipeline, you can specify `skip_in_bazel_downstream_pipeline: <reason>` for a given job in your [Bazel CI configuration file](../buildkite/README.md#configuring-a-pipeline).
 
 As of May 2023, some projects' pipeline config files live under [the "pipeline" directory](https://github.com/bazelbuild/continuous-integration/tree/master/pipelines) of this repository, which means the Bazel team is responsible for their setup for now, ideally they should be moved to their corresponding repository or the project should be removed.
 


### PR DESCRIPTION
There is no good way to introduce this tag filter without overriding existing ones in the bazelrc files.

This has been causing a few failures in the downstream pipeline: https://github.com/bazelbuild/bazel/issues/20422, where `//src:src_test` is supposed to be filtered out on Windows by `no_windows` tag.