### PR TITLE
allow usage of `@bazel-io flag <random string>`

### DIFF
--- a/actions/release-helper/index.js
+++ b/actions/release-helper/index.js
@@ -74,7 +74,7 @@ async function run() {
         name: FLAGGED_LABEL,
       });
     }
-  } else if (command === "flag") {
+  } else if (command === "flag" || command.startsWith("flag ")) {
     await octokit.rest.issues.addLabels({
       owner,
       repo,


### PR DESCRIPTION
cc @keertk @iancha1992 