### PR TITLE
Increase RBE timeout

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1888,7 +1888,7 @@ def remote_caching_flags(platform, accept_cached=True):
         platform_cache_digest.update(key)
         platform_cache_digest.update(b":")
 
-    remote_timeout = 600 if is_ipv6_mac() else 60
+    remote_timeout = 3600 if is_ipv6_mac() else 60
     flags += [
         f"--remote_timeout={remote_timeout}",
         "--remote_max_connections=200",


### PR DESCRIPTION
We've seen a higher number of RBE upload failures recently (e.g. https://buildkite.com/bazel/bazel-bazel-macos-ninja/builds/106#018cf836-9663-44b4-b870-7123e518f9ef).

With this change we're increasing the timeout from 600s to 3600s, which is the recommended default value (which we've already been using for rbe_* platform tasks).