### PR TITLE
User agent added to module downloading

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -171,7 +171,8 @@ def create_simple_repo(module_name, module_version):
 
 
 def download(url, file):
-    with urllib.request.urlopen(url) as response:
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    with urllib.request.urlopen(req) as response:
         with open(file, "wb") as f:
             f.write(response.read())
 


### PR DESCRIPTION
User agent added to module downloading to prevent failures on sites that check and 403 against requests that don't have a user agent. For example, https://developer.x-plane.com/wp-content/plugins/code-sample-generation/sample_templates/XPSDK401.zip