### PR TITLE
Disable rules_sass in Downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -342,6 +342,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     "rules_sass": {
         "git_repository": "https://github.com/bazelbuild/rules_sass.git",
         "pipeline_slug": "rules-sass",
+        "disabled_reason": "https://github.com/bazelbuild/rules_sass/issues/153",
     },
     "rules_scala": {
         "git_repository": "https://github.com/bazelbuild/rules_scala.git",


### PR DESCRIPTION
Moving rules_sass to Disabled CI as there is no response https://github.com/bazelbuild/rules_sass/issues/153#issuecomment-1904083065