### PR TITLE
BCR Presubmit: check metadata.json file changes

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -367,7 +367,7 @@ def should_metadata_change_block_presubmit(modules, pr_labels):
 
     bazelci.print_collapsed_group("Checking metadata.json file changes:")
 
-    # Collect changed modules
+    # Collect changed modules from module, version pairs.
     changed_modules = set([module[0] for module in modules])
 
     # If information like, maintainers, homepage, repository is changed, the presubmit should wait for a BCR maintainer review.
@@ -376,11 +376,11 @@ def should_metadata_change_block_presubmit(modules, pr_labels):
     for name in changed_modules:
         # Read the new metadata.json file.
         metadata_json = get_metadata_json(name)
-        metadata_old = json.load(open(metadata_json, "r"))
+        metadata_new = json.load(open(metadata_json, "r"))
 
         # Check out and read the original metadata.json file from the main branch.
         subprocess.run(["git", "checkout", "main", "--", metadata_json], check=True)
-        metadata_new = json.load(open(metadata_json, "r"))
+        metadata_old = json.load(open(metadata_json, "r"))
 
         # Revert the metadata.json file to the HEAD of current branch.
         subprocess.run(["git", "checkout", "HEAD", "--", metadata_json], check=True)

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -411,11 +411,8 @@ def should_wait_bcr_maintainer_review(modules):
     # If files outside of the modules/ directory are changed, fail the presubmit.
     validate_files_outside_of_modules_dir_are_not_modified(modules)
 
-    needs_bcr_maintainer_review = False
-
     # Check if any changes in the metadata.json file need a manual review.
-    if should_metadata_change_block_presubmit():
-        needs_bcr_maintainer_review = True
+    needs_bcr_maintainer_review = should_metadata_change_block_presubmit()
 
     # Run BCR validations on target modules and decide if the presubmit jobs should be blocked.
     if should_bcr_validation_block_presubmit(modules, pr_labels):


### PR DESCRIPTION
If information like, maintainers, homepage, repository is changed in the module's metadata.json file, the presubmit should wait for a BCR maintainer review.

Context https://github.com/bazelbuild/bazel-central-registry/pull/1363#discussion_r1463159612