### PR TITLE
Use a custom bazel-postsubmit.yml file for Bazel in downstream pipeline

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -111,7 +111,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     },
     "Bazel": {
         "git_repository": "https://github.com/bazelbuild/bazel.git",
-        "file_config": ".bazelci/postsubmit.yml",
+        "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-postsubmit.yml",
         "pipeline_slug": "bazel-bazel",
     },
     "Bazel Bench": {

--- a/pipelines/bazel-postsubmit.patch
+++ b/pipelines/bazel-postsubmit.patch
@@ -1,0 +1,66 @@
+diff --git bazel-postsubmit.yml bazel-postsubmit.yml
+index 1ee30a9a94..7995b62de5 100644
+--- bazel-postsubmit.yml
++++ bazel-postsubmit.yml
+@@ -1,4 +1,5 @@
+ ---
++# Update this file by running ./update-bazel-postsubmit.sh under the same directory
+
+ tasks:
+   centos7_java11_devtoolset10:
+@@ -8,6 +9,7 @@ tasks:
+       - rm -f WORKSPACE.bzlmod.bak
+       - rm -rf $HOME/bazeltest
+       - mkdir $HOME/bazeltest
++      - bazel mod deps --lockfile_mode=update
+     build_flags:
+       - "--config=ci-linux"
+     build_targets:
+@@ -73,6 +75,7 @@ tasks:
+       - rm -f WORKSPACE.bzlmod.bak
+       - rm -rf $HOME/bazeltest
+       - mkdir $HOME/bazeltest
++      - bazel mod deps --lockfile_mode=update
+     build_flags:
+       - "--config=ci-linux"
+     build_targets:
+@@ -132,6 +135,7 @@ tasks:
+       - rm -f WORKSPACE.bzlmod.bak
+       - rm -rf $HOME/bazeltest
+       - mkdir $HOME/bazeltest
++      - bazel mod deps --lockfile_mode=update
+     build_flags:
+       - "--config=ci-linux"
+     build_targets:
+@@ -165,6 +169,7 @@ tasks:
+       - rm -rf $HOME/bazeltest
+       - mkdir $HOME/bazeltest
+       - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
++      - bazel mod deps --lockfile_mode=update
+     build_flags:
+       - "--config=ci-macos"
+     build_targets:
+@@ -228,6 +233,7 @@ tasks:
+       - rm -rf $HOME/bazeltest
+       - mkdir $HOME/bazeltest
+       - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
++      - bazel mod deps --lockfile_mode=update
+     build_flags:
+       - "--config=ci-macos"
+     build_targets:
+@@ -289,6 +295,7 @@ tasks:
+       - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
+     batch_commands:
+       - powershell -Command "(Get-Content WORKSPACE.bzlmod) -Replace '# android_', 'android_' | Set-Content WORKSPACE.bzlmod"
++      - bazel mod deps --lockfile_mode=update
+     build_flags:
+       - "--config=ci-windows"
+     build_targets:
+@@ -359,6 +366,7 @@ tasks:
+         -e 's/^# android_sdk_repository/android_sdk_repository/'
+         -e 's/^# android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
+       - rm -f WORKSPACE.bzlmod.bak
++      - bazel mod deps --lockfile_mode=update
+     build_flags:
+       - "--config=ubuntu2004_java11"
+       - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"

--- a/pipelines/bazel-postsubmit.yml
+++ b/pipelines/bazel-postsubmit.yml
@@ -1,0 +1,428 @@
+---
+# Update this file by running ./update-bazel-postsubmit.sh under the same directory
+
+tasks:
+  centos7_java11_devtoolset10:
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
+      - rm -f WORKSPACE.bzlmod.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+      - bazel mod deps --lockfile_mode=update
+    build_flags:
+      - "--config=ci-linux"
+    build_targets:
+      - "//:bazel-distfile.zip"
+      - "//scripts/packages/debian:bazel-debian.deb"
+      - "//scripts/packages:with-jdk/install.sh"
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+      - "//src/main/java/..."
+      - "//src/tools/execlog/..."
+    test_flags:
+      - "--config=ci-linux"
+      # Override REMOTE_NETWORK_ADDRESS since bazel_sandboxing_networking_test doesn't work on this platform
+      - "--test_env=REMOTE_NETWORK_ADDRESS="
+    test_targets:
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/android/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/compliance/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      # These tests are not compatible with the gcov version of CentOS 7.
+      - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
+      - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
+      - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
+      - "-//src/test/shell/bazel:bazel_coverage_sh_test"
+      # Centos7 uses python 2 by default, so these fail: https://github.com/bazelbuild/bazel/issues/18776
+      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
+      - "-//src/test/shell/bazel/android:aapt_integration_test"
+      - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
+    include_json_profile:
+      - build
+      - test
+  fedora39:
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
+      - rm -f WORKSPACE.bzlmod.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+    build_flags:
+      - "--config=ci-linux"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src/main/java/..."
+    include_json_profile:
+      - build
+      - test
+  ubuntu2204:
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
+      - rm -f WORKSPACE.bzlmod.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+      - bazel mod deps --lockfile_mode=update
+    build_flags:
+      - "--config=ci-linux"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+      - "//src/main/java/..."
+    test_flags:
+      - "--config=ci-linux"
+    test_targets:
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/android/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
+    include_json_profile:
+      - build
+      - test
+  ubuntu2004_clang:
+    platform: ubuntu2004
+    environment:
+      CC: clang
+      CC_CONFIGURE_DEBUG: 1
+    name: "Clang"
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
+      - rm -f WORKSPACE.bzlmod.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+    build_flags:
+      - "--config=ci-linux"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+      - "//src/main/java/..."
+    test_flags:
+      - "--config=ci-linux"
+    test_targets:
+      - "//src/test/shell/bazel:cc_integration_test"
+    include_json_profile:
+      - build
+      - test
+  ubuntu2004:
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
+      - rm -f WORKSPACE.bzlmod.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+      - bazel mod deps --lockfile_mode=update
+    build_flags:
+      - "--config=ci-linux"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+      - "//src/main/java/..."
+    test_flags:
+      - "--config=ci-linux"
+    test_targets:
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/android/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+    include_json_profile:
+      - build
+      - test
+  macos:
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
+      - rm -f WORKSPACE.bzlmod.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+      - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
+      - bazel mod deps --lockfile_mode=update
+    build_flags:
+      - "--config=ci-macos"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+      - "//src/main/java/..."
+    test_flags:
+      - "--config=ci-macos"
+      # Fine tune the number of test jobs running in parallel to avoid timeout
+      - "--local_test_jobs=8"
+    test_targets:
+      - "//scripts/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/android/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      # C++ coverage is not supported on macOS yet.
+      - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
+      # MacOS does not have cgroups so it can't support hardened sandbox
+      - "-//src/test/java/com/google/devtools/build/lib/sandbox:CgroupsInfoTest"
+      - "-//src/test/shell/integration:bazel_hardened_sandboxed_worker_test"
+      - "-//src/test/shell/integration:bazel_sandboxed_worker_with_cgroups_test"
+      - "-//src/test/shell/integration:bazel_worker_with_cgroups_test"
+      # https://github.com/bazelbuild/bazel/issues/16526
+      - "-//src/test/shell/bazel:starlark_repository_test"
+      # https://github.com/bazelbuild/bazel/issues/17407
+      - "-//src/test/shell/bazel/apple:bazel_apple_test"
+      # https://github.com/bazelbuild/bazel/issues/17408
+      - "-//src/test/shell/bazel/apple:bazel_objc_test"
+      # https://github.com/bazelbuild/bazel/issues/17410
+      - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
+      # https://github.com/bazelbuild/bazel/issues/17411
+      - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:PatchApiBlackBoxTest"
+      # https://github.com/bazelbuild/bazel/issues/17447
+      - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:GitRepositoryBlackBoxTest"
+      # https://github.com/bazelbuild/bazel/issues/17456
+      - "-//src/test/shell/bazel:bazel_determinism_test"
+      # https://github.com/bazelbuild/bazel/issues/17457
+      - "-//src/test/shell/bazel:jdeps_test"
+      # Macs can't find python, so these fail: https://github.com/bazelbuild/bazel/issues/18776
+      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
+      - "-//src/test/shell/bazel/android:aapt_integration_test"
+      - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
+    include_json_profile:
+      - build
+      - test
+  macos_arm64:
+    xcode_version: "15.1"
+    shell_commands:
+      - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
+        android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
+      - rm -f WORKSPACE.bzlmod.bak
+      - rm -rf $HOME/bazeltest
+      - mkdir $HOME/bazeltest
+      - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
+      - bazel mod deps --lockfile_mode=update
+    build_flags:
+      - "--config=ci-macos"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+      - "//src/main/java/..."
+    test_flags:
+      - "--config=ci-macos"
+    test_targets:
+      - "//scripts/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/android/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      # C++ coverage is not supported on macOS yet.
+      - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
+      # MacOS does not have cgroups so it can't support hardened sandbox
+      - "-//src/test/java/com/google/devtools/build/lib/sandbox:CgroupsInfoTest"
+      - "-//src/test/shell/integration:bazel_hardened_sandboxed_worker_test"
+      - "-//src/test/shell/integration:bazel_sandboxed_worker_with_cgroups_test"
+      - "-//src/test/shell/integration:bazel_worker_with_cgroups_test"
+      # https://github.com/bazelbuild/bazel/issues/16525
+      - "-//src/test/java/com/google/devtools/build/lib/buildtool:KeepGoingTest"
+      - "-//src/test/java/com/google/devtools/build/lib/buildtool:DanglingSymlinkTest"
+      - "-//src/test/java/com/google/devtools/build/lib/buildtool:CompileOneDependencyIntegrationTest"
+      - "-//src/test/java/com/google/devtools/build/lib/buildtool:SkymeldBuildIntegrationTest"
+      - "-//src/test/java/com/google/devtools/build/lib/rules/objc:BazelJ2ObjcLibraryTest"
+      - "-//src/test/java/com/google/devtools/build/lib/skyframe/rewinding:RewindingTest"
+      - "-//src/test/java/com/google/devtools/build/lib/buildtool:MiscAnalysisTest"
+      - "-//src/test/java/com/google/devtools/build/lib/rules/objc:ObjcRulesTests"
+      # https://github.com/bazelbuild/bazel/issues/17007
+      - "-//src/test/java/com/google/devtools/build/lib/platform:SystemMemoryPressureEventTest"
+      # https://github.com/bazelbuild/bazel/issues/16521 & https://github.com/bazelbuild/bazel/issues/18776
+      - "-//src/test/shell/bazel/android/..."
+      - "-//src/tools/android/java/com/google/devtools/build/android/..."
+      - "-//src/test/java/com/google/devtools/build/android/dexer:AllTests"
+      # Macs can't find python, so these fail: https://github.com/bazelbuild/bazel/issues/18776
+      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test"
+      - "-//src/test/shell/bazel/android:android_instrumentation_test_integration_test_with_head_android_tools"
+      - "-//src/test/shell/bazel/android:aapt_integration_test"
+      - "-//src/test/shell/bazel/android:aapt_integration_test_with_head_android_tools"
+      # https://github.com/bazelbuild/bazel/issues/17411
+      - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:PatchApiBlackBoxTest"
+      # https://github.com/bazelbuild/bazel/issues/17447
+      - "-//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:GitRepositoryBlackBoxTest"
+    include_json_profile:
+      - build
+      - test
+  windows:
+    setup:
+      - mkdir C:\b
+      - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
+    batch_commands:
+      - powershell -Command "(Get-Content WORKSPACE.bzlmod) -Replace '# android_', 'android_' | Set-Content WORKSPACE.bzlmod"
+      - bazel mod deps --lockfile_mode=update
+    build_flags:
+      - "--config=ci-windows"
+    build_targets:
+      - "//src:bazel.exe"
+      - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
+      - "//src/main/java/..."
+    test_flags:
+      - "--config=ci-windows"
+    test_targets:
+      - "//src:embedded_tools_size_test"
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/cpp/..."
+      - "//src/test/java/com/google/devtools/build/android/..."
+      - "//src/test/java/com/google/devtools/build/lib/..."
+      - "//src/test/java/com/google/devtools/build/skyframe/..."
+      - "//src/test/java/com/google/devtools/common/options/..."
+      - "//src/test/native/windows/..."
+      - "//src/test/py/bazel/..."
+      - "//src/test/res/..."
+      - "//src/test/shell/..."
+      - "//src/tools/launcher/..."
+      - "//src/tools/singlejar/..."
+      - "//third_party/def_parser/..."
+      - "//tools/android/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/bash/..."
+      - "//tools/build_defs/..."
+      - "//tools/cpp/runfiles/..."
+      - "//tools/java/..."
+      - "//tools/jdk/..."
+      - "//tools/python/..."
+      - "//tools/test/..."
+      # Re-enable the following tests on Windows:
+      # https://github.com/bazelbuild/bazel/issues/4292
+      - "-//src/test/java/com/google/devtools/build/android/r8/..."
+      - "-//src/test/java/com/google/devtools/build/lib/query2/cquery/..."
+      - "-//src/test/java/com/google/devtools/build/lib/query2/engine/..."
+      - "-//src/test/java/com/google/devtools/build/lib/versioning/..."
+      - "-//src/test/java/com/google/devtools/build/lib/worker/..."
+      - "-//src/test/java/com/google/devtools/build/lib/remote:RemoteTests"
+      - "-//src/test/shell/bazel/remote/..."
+      - "-//tools/python:pywrapper_test"
+    include_json_profile:
+      - build
+      - test
+  windows_arm64:
+    platform: windows
+    name: "Windows (arm64)"
+    setup:
+      - mkdir C:\b
+      - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
+    batch_commands:
+      - powershell -Command "(Get-Content WORKSPACE.bzlmod) -Replace '# android_', 'android_' | Set-Content WORKSPACE.bzlmod"
+    build_flags:
+      - "--config=ci-windows"
+      - "--config=windows_arm64"
+    build_targets:
+      - "//src:bazel.exe"
+      - "//src:bazel_nojdk.exe"
+    include_json_profile:
+      - build
+  rbe_ubuntu2004:
+    platform: ubuntu2004
+    name: "RBE"
+    shell_commands:
+      - sed -i.bak
+        -e 's/^# android_sdk_repository/android_sdk_repository/'
+        -e 's/^# android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
+      - rm -f WORKSPACE.bzlmod.bak
+      - bazel mod deps --lockfile_mode=update
+    build_flags:
+      - "--config=ubuntu2004_java11"
+      - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
+      - "--jobs=200"
+      - "--experimental_remote_cache_async"
+      - "--experimental_remote_merkle_tree_cache"
+      - "--remote_download_minimal"
+    build_targets:
+      - "//src:bazel"
+      - "//src:bazel_jdk_minimal"
+      - "//src/main/java/..."
+    test_flags:
+      - "--config=ubuntu2004_java11"
+      - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
+      - "--jobs=200"
+      - "--experimental_remote_cache_async"
+      - "--experimental_remote_merkle_tree_cache"
+      - "--remote_download_minimal"
+    test_targets:
+      - "//scripts/..."
+      - "//src/java_tools/..."
+      - "//src/main/starlark/tests/builtins_bzl/..."
+      - "//src/test/..."
+      - "//src/tools/execlog/..."
+      - "//src/tools/singlejar/..."
+      - "//src/tools/workspacelog/..."
+      - "//third_party/ijar/..."
+      - "//tools/aquery_differ/..."
+      - "//tools/python/..."
+      - "//tools/bash/..."
+      - "//tools/android/..."
+      # See https://github.com/bazelbuild/bazel/issues/8033
+      - "-//src/tools/singlejar:output_jar_simple_test"
+      - "-//src/test/shell/bazel:external_integration_test"
+      - "-//src/test/shell/bazel:bazel_repository_cache_test"
+      - "-//src/test/shell/integration:java_integration_test"
+      - "-//src/test/java/com/google/devtools/build/lib/sandbox/..."
+      # We hit connection timeout error when downloading multiple URLs on RBE, see b/217865760
+      - "-//src/test/py/bazel:bazel_module_test"
+      - "-//src/test/py/bazel:bazel_lockfile_test"
+      - "-//src/test/py/bazel:bazel_overrides_test"
+      - "-//src/test/py/bazel:bazel_repo_mapping_test"
+      - "-//src/test/py/bazel:bazel_yanked_versions_test"
+      - "-//src/test/py/bazel:bzlmod_query_test"
+      - "-//src/test/py/bazel:mod_command_test"
+      - "-//src/test/shell/bazel:verify_workspace"
+    include_json_profile:
+      - build
+      - test
+  kythe_ubuntu2004:
+    shell_commands:
+    - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/'
+      -e 's/^# android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
+    - rm -f WORKSPACE.bzlmod.bak
+    index_flags:
+    - "--define=kythe_corpus=github.com/bazelbuild/bazel"
+    index_targets_query: "kind(\"cc_(binary|library|test|proto_library) rule\", ...) union kind(\"java_(binary|import|library|plugin|test|proto_library) rule\", ...) union kind(\"proto_library rule\", ...)"
+    index_upload_policy: Always
+    index_upload_gcs: True

--- a/pipelines/update-bazel-postsubmit.sh
+++ b/pipelines/update-bazel-postsubmit.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Download the latest postsubmit.yml from the Bazel repository and apply the patch to add `bazel mod deps --lockfile_mode=update` in setup phase.
+curl -o bazel-postsubmit.yml https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/postsubmit.yml
+patch < bazel-postsubmit.patch


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/21292

After https://github.com/bazelbuild/bazel/commit/a54a393d209ab9c8cf5e80b2a0ef092196c17df3, the canonical repo name returned by Bazel@HEAD no longer matches the name in MODULE.bazel.lock, therefore we need to run `bazel mod deps --lockfile_mode=update` to re-generate the lockfile before running the build.

We may revert this change after we update Bazel to 7.1 for building Bazel itself.