### PR TITLE
Pull docker images when building the Linux VM image

### DIFF
--- a/buildkite/setup-docker.sh
+++ b/buildkite/setup-docker.sh
@@ -209,4 +209,28 @@ EOF
   sleep 3
 }
 
+### Configure and start Docker.
+systemctl start docker
+
+### Ensure that Docker images can be downloaded from GCR.
+gcloud auth configure-docker --quiet
+
+### Pull the Docker images that we need.
+docker pull "gcr.io/bazel-public/centos7-java8" &
+docker pull "gcr.io/bazel-public/centos7-java11" &
+docker pull "gcr.io/bazel-public/centos7-java11-devtoolset10" &
+docker pull "gcr.io/bazel-public/centos7-releaser" &
+docker pull "gcr.io/bazel-public/debian10-java11" &
+docker pull "gcr.io/bazel-public/debian11-java17" &
+docker pull "gcr.io/bazel-public/ubuntu1604-bazel-java8" &
+docker pull "gcr.io/bazel-public/ubuntu1604-java8" &
+docker pull "gcr.io/bazel-public/ubuntu1804-bazel-java11" &
+docker pull "gcr.io/bazel-public/ubuntu1804-java11" &
+docker pull "gcr.io/bazel-public/ubuntu2004-bazel-java11" &
+docker pull "gcr.io/bazel-public/ubuntu2004-java11" &
+docker pull "gcr.io/bazel-public/ubuntu2004-java11-kythe" &
+docker pull "gcr.io/bazel-public/ubuntu2204-java17" &
+docker pull "gcr.io/bazel-public/ubuntu2204-bazel-java17" &
+wait
+
 poweroff

--- a/buildkite/setup-docker.sh
+++ b/buildkite/setup-docker.sh
@@ -215,7 +215,7 @@ systemctl start docker
 ### Ensure that Docker images can be downloaded from GCR.
 gcloud auth configure-docker --quiet
 
-### Pull the Docker images that we need.
+### Pull the Docker images that we need in production.
 docker pull "gcr.io/bazel-public/centos7-java8" &
 docker pull "gcr.io/bazel-public/centos7-java11" &
 docker pull "gcr.io/bazel-public/centos7-java11-devtoolset10" &
@@ -231,6 +231,8 @@ docker pull "gcr.io/bazel-public/ubuntu2004-java11" &
 docker pull "gcr.io/bazel-public/ubuntu2004-java11-kythe" &
 docker pull "gcr.io/bazel-public/ubuntu2204-java17" &
 docker pull "gcr.io/bazel-public/ubuntu2204-bazel-java17" &
+docker pull "gcr.io/bazel-public/fedora39-java17" &
+docker pull "gcr.io/bazel-public/fedora39-bazel-java17" &
 wait
 
 poweroff

--- a/buildkite/startup-docker-pdssd.sh
+++ b/buildkite/startup-docker-pdssd.sh
@@ -110,6 +110,8 @@ docker pull "gcr.io/$PREFIX/ubuntu2004-java11" &
 docker pull "gcr.io/$PREFIX/ubuntu2004-java11-kythe" &
 docker pull "gcr.io/$PREFIX/ubuntu2204-java17" &
 docker pull "gcr.io/$PREFIX/ubuntu2204-bazel-java17" &
+docker pull "gcr.io/$PREFIX/fedora39-java17" &
+docker pull "gcr.io/$PREFIX/fedora39-bazel-java17" &
 wait
 
 ### Start the Buildkite agent service.


### PR DESCRIPTION
I noticed the startup time for Linux VMs are very long due to pulling docker images https://github.com/bazelbuild/continuous-integration/blob/ea6e439128fe02244c3537d3895a18c08f055881/buildkite/startup-docker-pdssd.sh#L98

We can pull those images in advance while building the VM image to save startup time and avoid congestion during CI busy time.

