### PR TITLE
chore(bazel): add MODULE.bazel files for bzlmod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 
 # Bazel output files.
 /bazel-*
+MODULE.bazel.lock
 
 # Intermediate files created by the gitbundle tool.
 /gitbundle/bazelbuild/

--- a/rules/.bazelrc
+++ b/rules/.bazelrc
@@ -1,0 +1,1 @@
+common --enable_bzlmod

--- a/rules/MODULE.bazel
+++ b/rules/MODULE.bazel
@@ -1,0 +1,1 @@
+module(name = "bazel_ci_rules", version = "")


### PR DESCRIPTION
This provides bzlmod for `bazel_ci_rules`, see https://bazel.build/external/migration

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
