### PR TITLE
Install JDK21 in containers

### DIFF
--- a/buildkite/docker/centos7/Dockerfile
+++ b/buildkite/docker/centos7/Dockerfile
@@ -132,6 +132,10 @@ RUN mkdir -p /usr/lib/jvm/zulu-11 && \
     java -version && \
     javac -version
 
+RUN mkdir -p /usr/lib/jvm/zulu-21 && \
+    pushd /usr/lib/jvm/zulu-21 && \
+    curl "https://cdn.azul.com/zulu/bin/zulu21.32.17-ca-jdk21.0.2-linux_x64.tar.gz" | tar xvz --strip-components=1
+
 FROM centos7-java11 AS centos7-java11-devtoolset10
 RUN yum install -y centos-release-scl && yum install -y devtoolset-10 && yum clean all
 

--- a/buildkite/docker/ubuntu2004/Dockerfile
+++ b/buildkite/docker/ubuntu2004/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get -y update && \
     lsb-release \
     netcat-openbsd \
     openjdk-11-jdk-headless \
+    openjdk-21-jdk-headless \
     python-is-python3 \
     python2 \
     python2-dev \
@@ -57,6 +58,8 @@ RUN apt-get -y update && \
 # Allow using sudo inside the container.
 RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
+# Use openjdk-11 as the default JDK for backwards compatibility
+RUN update-java-alternatives -s java-1.11.0-openjdk-${BUILDARCH}
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${BUILDARCH}
 
 FROM ubuntu2004-bazel-java11 AS ubuntu2004-java11

--- a/buildkite/docker/ubuntu2204/Dockerfile
+++ b/buildkite/docker/ubuntu2204/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get -y update && \
     lsb-release \
     netcat-openbsd \
     openjdk-17-jdk-headless \
+    openjdk-21-jdk-headless \
     openssh-client \
     python-is-python3 \
     python2 \
@@ -58,6 +59,8 @@ RUN apt-get -y update && \
 # Allow using sudo inside the container.
 RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
+# Use openjdk-17 as the default JDK for backwards compatibility
+RUN update-java-alternatives -s java-1.17.0-openjdk-${BUILDARCH}
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-${BUILDARCH}
 
 FROM ubuntu2204-bazel-java17 AS ubuntu2204-java17


### PR DESCRIPTION
for centos7, ubuntu2004 and ubuntu2204, but still keep the old JDK default for backwards compatibility reason.

Tested on Bazel Testing environment. https://buildkite.com/bazel-testing/google-bazel-presubmit/builds/20