### PR TITLE
Add docker images which doesn't force a java version

### DIFF
--- a/buildkite/docker/build.sh
+++ b/buildkite/docker/build.sh
@@ -25,7 +25,9 @@ docker build -f debian11/Dockerfile   --target debian11-java17   -t "gcr.io/$PRE
 docker build -f ubuntu1604/Dockerfile --target ubuntu1604-java8  -t "gcr.io/$PREFIX/ubuntu1604-java8" ubuntu1604 &
 docker build -f ubuntu1804/Dockerfile --target ubuntu1804-java11 -t "gcr.io/$PREFIX/ubuntu1804-java11" ubuntu1804 &
 docker build -f ubuntu2004/Dockerfile --target ubuntu2004-java11 -t "gcr.io/$PREFIX/ubuntu2004-java11" ubuntu2004 &
+docker build -f ubuntu2204/Dockerfile --target ubuntu2004        -t "gcr.io/$PREFIX/ubuntu2004" ubuntu2004 &
 docker build -f ubuntu2204/Dockerfile --target ubuntu2204-java17 -t "gcr.io/$PREFIX/ubuntu2204-java17" ubuntu2204 &
+docker build -f ubuntu2204/Dockerfile --target ubuntu2204        -t "gcr.io/$PREFIX/ubuntu2204" ubuntu2204 &
 docker build -f fedora39/Dockerfile   --target fedora39-java17   -t "gcr.io/$PREFIX/fedora39-java17" fedora39 &
 wait
 

--- a/buildkite/docker/centos7/Dockerfile
+++ b/buildkite/docker/centos7/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7 as centos7
+FROM centos:7 as centos7-nojdk
 ARG BUILDARCH
 
 # Install required packages.
@@ -58,86 +58,18 @@ RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/relea
     chown root:root /usr/local/bin/buildifier && \
     chmod 0755 /usr/local/bin/buildifier
 
-FROM centos7 AS centos7-java8
+FROM centos7-nojdk AS centos7-nojdk-devtoolset10
+
+RUN yum install -y centos-release-scl && yum install -y devtoolset-10 && yum clean all
+
+FROM centos7-nojdk AS centos7-java8
+
 RUN yum install -y java-1.8.0-openjdk-devel && yum clean all
 
-FROM centos7 AS centos7-java11
+FROM centos7-nojdk AS centos7-java11
 
-# Unfortunately Azul doesn't publish an RPM package for zulu11 on aarch64, so we have to use the tar.gz version.
-RUN mkdir -p /usr/lib/jvm/zulu-11 && \
-    pushd /usr/lib/jvm/zulu-11 && \
-    curl "https://cdn.azul.com/zulu/bin/zulu11.58.23-ca-jdk11.0.16.1-linux_x64.tar.gz" | tar xvz --strip-components=1 && \
-    update-alternatives \
-        --install /usr/bin/java java /usr/lib/jvm/zulu-11/bin/java 2115200 \
-        --slave /usr/bin/jaotc jaotc /usr/lib/jvm/zulu-11/bin/jaotc \
-        --slave /usr/bin/jfr jfr /usr/lib/jvm/zulu-11/bin/jfr \
-        --slave /usr/bin/jjs jjs /usr/lib/jvm/zulu-11/bin/jjs \
-        --slave /usr/bin/keytool keytool /usr/lib/jvm/zulu-11/bin/keytool \
-        --slave /usr/bin/pack200 pack200 /usr/lib/jvm/zulu-11/bin/pack200 \
-        --slave /usr/bin/rmid rmid /usr/lib/jvm/zulu-11/bin/rmid \
-        --slave /usr/bin/rmiregistry rmiregistry /usr/lib/jvm/zulu-11/bin/rmiregistry \
-        --slave /usr/bin/unpack200 unpack200 /usr/lib/jvm/zulu-11/bin/unpack200 \
-        --slave /usr/lib/jvm/jre jre /usr/lib/jvm/zulu-11 \
-        --slave /usr/share/man/man1/java.1.gz java.1.gz /usr/lib/jvm/zulu-11/man/man1/java.1.gz \
-        --slave /usr/share/man/man1/jjs.1.gz jjs.1.gz /usr/lib/jvm/zulu-11/man/man1/jjs.1.gz \
-        --slave /usr/share/man/man1/keytool.1.gz keytool.1.gz /usr/lib/jvm/zulu-11/man/man1/keytool.1.gz \
-        --slave /usr/share/man/man1/pack200.1.gz pack200.1.gz /usr/lib/jvm/zulu-11/man/man1/pack200.1.gz \
-        --slave /usr/share/man/man1/rmid.1.gz rmid.1.gz /usr/lib/jvm/zulu-11/man/man1/rmid.1.gz \
-        --slave /usr/share/man/man1/rmiregistry.1.gz rmiregistry.1.gz /usr/lib/jvm/zulu-11/man/man1/rmiregistry.1.gz \
-        --slave /usr/share/man/man1/unpack200.1.gz unpack200.1.gz /usr/lib/jvm/zulu-11/man/man1/unpack200.1.gz && \
-    update-alternatives \
-        --install /usr/bin/javac javac /usr/lib/jvm/zulu-11/bin/javac 2115200 \
-        --slave /usr/bin/jar jar /usr/lib/jvm/zulu-11/bin/jar \
-        --slave /usr/bin/jarsigner jarsigner /usr/lib/jvm/zulu-11/bin/jarsigner \
-        --slave /usr/bin/javadoc javadoc /usr/lib/jvm/zulu-11/bin/javadoc \
-        --slave /usr/bin/javap javap /usr/lib/jvm/zulu-11/bin/javap \
-        --slave /usr/bin/jcmd jcmd /usr/lib/jvm/zulu-11/bin/jcmd \
-        --slave /usr/bin/jconsole jconsole /usr/lib/jvm/zulu-11/bin/jconsole \
-        --slave /usr/bin/jdb jdb /usr/lib/jvm/zulu-11/bin/jdb \
-        --slave /usr/bin/jdeprscan jdeprscan /usr/lib/jvm/zulu-11/bin/jdeprscan \
-        --slave /usr/bin/jdeps jdeps /usr/lib/jvm/zulu-11/bin/jdeps \
-        --slave /usr/bin/jhsdb jhsdb /usr/lib/jvm/zulu-11/bin/jhsdb \
-        --slave /usr/bin/jimage jimage /usr/lib/jvm/zulu-11/bin/jimage \
-        --slave /usr/bin/jinfo jinfo /usr/lib/jvm/zulu-11/bin/jinfo \
-        --slave /usr/bin/jlink jlink /usr/lib/jvm/zulu-11/bin/jlink \
-        --slave /usr/bin/jmap jmap /usr/lib/jvm/zulu-11/bin/jmap \
-        --slave /usr/bin/jmod jmod /usr/lib/jvm/zulu-11/bin/jmod \
-        --slave /usr/bin/jps jps /usr/lib/jvm/zulu-11/bin/jps \
-        --slave /usr/bin/jrunscript jrunscript /usr/lib/jvm/zulu-11/bin/jrunscript \
-        --slave /usr/bin/jshell jshell /usr/lib/jvm/zulu-11/bin/jshell \
-        --slave /usr/bin/jstack jstack /usr/lib/jvm/zulu-11/bin/jstack \
-        --slave /usr/bin/jstat jstat /usr/lib/jvm/zulu-11/bin/jstat \
-        --slave /usr/bin/jstatd jstatd /usr/lib/jvm/zulu-11/bin/jstatd \
-        --slave /usr/bin/rmic rmic /usr/lib/jvm/zulu-11/bin/rmic \
-        --slave /usr/bin/serialver serialver /usr/lib/jvm/zulu-11/bin/serialver \
-        --slave /usr/share/man/man1/javac.1.gz javac.1.gz /usr/lib/jvm/zulu-11/man/man1/javac.1.gz \
-        --slave /usr/share/man/man1/jar.1.gz jar.1.gz /usr/lib/jvm/zulu-11/man/man1/jar.1.gz \
-        --slave /usr/share/man/man1/jarsigner.1.gz jarsigner.1.gz /usr/lib/jvm/zulu-11/man/man1/jarsigner.1.gz \
-        --slave /usr/share/man/man1/javadoc.1.gz javadoc.1.gz /usr/lib/jvm/zulu-11/man/man1/javadoc.1.gz \
-        --slave /usr/share/man/man1/javap.1.gz javap.1.gz /usr/lib/jvm/zulu-11/man/man1/javap.1.gz \
-        --slave /usr/share/man/man1/jcmd.1.gz jcmd.1.gz /usr/lib/jvm/zulu-11/man/man1/jcmd.1.gz \
-        --slave /usr/share/man/man1/jconsole.1.gz jconsole.1.gz /usr/lib/jvm/zulu-11/man/man1/jconsole.1.gz \
-        --slave /usr/share/man/man1/jdb.1.gz jdb.1.gz /usr/lib/jvm/zulu-11/man/man1/jdb.1.gz \
-        --slave /usr/share/man/man1/jdeps.1.gz jdeps.1.gz /usr/lib/jvm/zulu-11/man/man1/jdeps.1.gz \
-        --slave /usr/share/man/man1/jinfo.1.gz jinfo.1.gz /usr/lib/jvm/zulu-11/man/man1/jinfo.1.gz \
-        --slave /usr/share/man/man1/jmap.1.gz jmap.1.gz /usr/lib/jvm/zulu-11/man/man1/jmap.1.gz \
-        --slave /usr/share/man/man1/jps.1.gz jps.1.gz /usr/lib/jvm/zulu-11/man/man1/jps.1.gz \
-        --slave /usr/share/man/man1/jrunscript.1.gz jrunscript.1.gz /usr/lib/jvm/zulu-11/man/man1/jrunscript.1.gz \
-        --slave /usr/share/man/man1/jstack.1.gz jstack.1.gz /usr/lib/jvm/zulu-11/man/man1/jstack.1.gz \
-        --slave /usr/share/man/man1/jstat.1.gz jstat.1.gz /usr/lib/jvm/zulu-11/man/man1/jstat.1.gz \
-        --slave /usr/share/man/man1/jstatd.1.gz jstatd.1.gz /usr/lib/jvm/zulu-11/man/man1/jstatd.1.gz \
-        --slave /usr/share/man/man1/rmic.1.gz rmic.1.gz /usr/lib/jvm/zulu-11/man/man1/rmic.1.gz \
-        --slave /usr/share/man/man1/serialver.1.gz serialver.1.gz /usr/lib/jvm/zulu-11/man/man1/serialver.1.gz && \
-    popd && \
-    java -version && \
-    javac -version
-
-RUN mkdir -p /usr/lib/jvm/zulu-21 && \
-    pushd /usr/lib/jvm/zulu-21 && \
-    curl "https://cdn.azul.com/zulu/bin/zulu21.32.17-ca-jdk21.0.2-linux_x64.tar.gz" | tar xvz --strip-components=1
-
-FROM centos7-java11 AS centos7-java11-devtoolset10
-RUN yum install -y centos-release-scl && yum install -y devtoolset-10 && yum clean all
+RUN yum install -y https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \
+    yum install -y yum install zulu11-jdk && yum clean all
 
 # These are the variables set by /opt/rh/devtoolset-10/enable and necessary to activate devtoolset-10.
 ENV PATH=/opt/rh/devtoolset-10/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -146,6 +78,16 @@ ENV INFOPATH=/opt/rh/devtoolset-10/root/usr/share/info
 ENV PCP_DIR=/opt/rh/devtoolset-10/root
 ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:/opt/rh/devtoolset-10/root/usr/lib64/dyninst:/opt/rh/devtoolset-10/root/usr/lib/dyninst:/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib
 ENV PKG_CONFIG_PATH=/opt/rh/devtoolset-10/root/usr/lib64/pkgconfig
+
+FROM centos7-nojdk-devtoolset10 AS centos7-java11-devtoolset10
+
+RUN yum install -y https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \
+    yum install -y yum install zulu11-jdk && yum clean all
+
+FROM centos7-nojdk-devtoolset10 AS centos7
+
+RUN yum install -y https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \
+    yum install -y yum install zulu21-jdk && yum clean all
 
 FROM centos7-java11-devtoolset10 AS centos7-releaser
 # dpkg-source needs a newer GNU tar version that supports --sort=name.

--- a/buildkite/docker/push.sh
+++ b/buildkite/docker/push.sh
@@ -15,6 +15,7 @@ case $(git symbolic-ref --short HEAD) in
 esac
 
 # Containers used by Bazel CI
+docker push "gcr.io/$PREFIX/centos7" &
 docker push "gcr.io/$PREFIX/centos7-java8" &
 docker push "gcr.io/$PREFIX/centos7-java11" &
 docker push "gcr.io/$PREFIX/centos7-java11-devtoolset10" &
@@ -28,8 +29,10 @@ docker push "gcr.io/$PREFIX/ubuntu1804-java11" &
 docker push "gcr.io/$PREFIX/ubuntu2004-bazel-java11" &
 docker push "gcr.io/$PREFIX/ubuntu2004-java11" &
 docker push "gcr.io/$PREFIX/ubuntu2004-java11-kythe" &
+docker push "gcr.io/$PREFIX/ubuntu2004" &
 docker push "gcr.io/$PREFIX/ubuntu2204-java17" &
 docker push "gcr.io/$PREFIX/ubuntu2204-bazel-java17" &
+docker push "gcr.io/$PREFIX/ubuntu2204" &
 docker push "gcr.io/$PREFIX/fedora39-java17" &
 docker push "gcr.io/$PREFIX/fedora39-bazel-java17" &
 wait

--- a/buildkite/docker/ubuntu2004/Dockerfile
+++ b/buildkite/docker/ubuntu2004/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as ubuntu2004-bazel-java11
+FROM ubuntu:20.04 as ubuntu2004-bazel-nojdk
 ARG BUILDARCH
 
 ENV DEBIAN_FRONTEND="noninteractive"
@@ -32,8 +32,6 @@ RUN apt-get -y update && \
     llvm-dev \
     lsb-release \
     netcat-openbsd \
-    openjdk-11-jdk-headless \
-    openjdk-21-jdk-headless \
     python-is-python3 \
     python2 \
     python2-dev \
@@ -58,11 +56,7 @@ RUN apt-get -y update && \
 # Allow using sudo inside the container.
 RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-# Use openjdk-11 as the default JDK for backwards compatibility
-RUN update-java-alternatives -s java-1.11.0-openjdk-${BUILDARCH}
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${BUILDARCH}
-
-FROM ubuntu2004-bazel-java11 AS ubuntu2004-java11
+FROM ubuntu2004-bazel-nojdk AS ubuntu2004-nojdk
 
 ### Install Google Cloud SDK.
 ### https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
@@ -92,6 +86,22 @@ RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/relea
     chown root:root /usr/local/bin/buildifier && \
     chmod 0755 /usr/local/bin/buildifier
 
+FROM ubuntu2004-bazel-nojdk AS ubuntu2004-bazel-java11
+
+RUN apt-get -y update && \
+    apt-get -y install openjdk-11-jdk-headless && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${BUILDARCH}
+
+FROM ubuntu2004-nojdk AS ubuntu2004-java11
+
+RUN apt-get -y update && \
+    apt-get -y install openjdk-11-jdk-headless && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${BUILDARCH}
+
 FROM ubuntu2004-java11 AS ubuntu2004-java11-kythe
 
 RUN LATEST_KYTHE=v0.0.52 && \
@@ -100,3 +110,11 @@ RUN LATEST_KYTHE=v0.0.52 && \
     tar xvz --no-same-owner --strip-components 1 --directory /usr/local/kythe && \
     chmod -R a+r /usr/local/kythe && \
     test -f /usr/local/kythe/WORKSPACE
+
+FROM ubuntu2004-nojdk AS ubuntu2004
+
+RUN apt-get -y update && \
+    apt-get -y install openjdk-21-jdk-headless && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk-${BUILDARCH}

--- a/buildkite/docker/ubuntu2204/Dockerfile
+++ b/buildkite/docker/ubuntu2204/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as ubuntu2204-bazel-java17
+FROM ubuntu:22.04 as ubuntu2204-bazel-nojdk
 ARG BUILDARCH
 
 ENV DEBIAN_FRONTEND="noninteractive"
@@ -32,8 +32,6 @@ RUN apt-get -y update && \
     llvm-dev \
     lsb-release \
     netcat-openbsd \
-    openjdk-17-jdk-headless \
-    openjdk-21-jdk-headless \
     openssh-client \
     python-is-python3 \
     python2 \
@@ -59,11 +57,7 @@ RUN apt-get -y update && \
 # Allow using sudo inside the container.
 RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-# Use openjdk-17 as the default JDK for backwards compatibility
-RUN update-java-alternatives -s java-1.17.0-openjdk-${BUILDARCH}
-ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-${BUILDARCH}
-
-FROM ubuntu2204-bazel-java17 AS ubuntu2204-java17
+FROM ubuntu2204-bazel-nojdk AS ubuntu2204-nojdk
 
 ### Install Google Cloud SDK.
 ### https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
@@ -83,3 +77,27 @@ RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/relea
     curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${BUILDARCH} && \
     chown root:root /usr/local/bin/buildifier && \
     chmod 0755 /usr/local/bin/buildifier
+
+FROM ubuntu2204-bazel-nojdk AS ubuntu2204-bazel-java17
+
+RUN apt-get -y update && \
+    apt-get -y install openjdk-17-jdk-headless && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-${BUILDARCH}
+
+FROM ubuntu2204-nojdk AS ubuntu2204-java17
+
+RUN apt-get -y update && \
+    apt-get -y install openjdk-17-jdk-headless && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-${BUILDARCH}
+
+FROM ubuntu2204-nojdk AS ubuntu2204
+
+RUN apt-get -y update && \
+    apt-get -y install openjdk-21-jdk-headless && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk-${BUILDARCH}


### PR DESCRIPTION
In addition to existing images that force a java version, this PR introduces images that always use the latest JDK.

More specifically, for ubuntu 20.04 we have following images:
- `ubuntu2004-java11` (existing): `ubuntu 20.04` + `java11` + dependencies for Bazel CI
- `ubuntu2004` (new): `ubuntu 20.04` + `java21` + dependencies for Bazel CI

For ubuntu 22.04:
- `ubuntu2204-java17` (existing): `ubuntu 22.04` + `java17` + dependencies for Bazel CI
- `ubuntu2204` (new): `ubuntu 22.04` + `java21` + dependencies for Bazel CI

For centos 7:
- `centos7-java11` (existing):  `centos 7` + `java11` + dependencies for Bazel CI
- `centos7-java11-devtoolset10` (existing): `centos 7` + `java11` + `devtoolset10` + dependencies for Bazel CI
- `centos7` (new): `centos 7` + `java21` + `devtoolset10` + dependencies for Bazel CI

A follow-up change will update the images in `bazelci.py`.