### PR TITLE
Fix `LINUX_BINARY_PLATFORM`

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -593,7 +593,7 @@ DEFAULT_PLATFORM = "ubuntu1804"
 # In order to test that "the one Linux binary" that we build for our official releases actually
 # works on all Linux distributions that we test on, we use the Linux binary built on our official
 # release platform for all Linux downstream tests.
-LINUX_BINARY_PLATFORM = "centos7_java11_devtoolset10"
+LINUX_BINARY_PLATFORM = "centos7"
 
 XCODE_VERSION_REGEX = re.compile(r"^\d+\.\d+(\.\d+)?$")
 XCODE_VERSION_OVERRIDES = {"10.2.1": "10.3", "11.2": "11.2.1", "11.3": "11.3.1"}


### PR DESCRIPTION
Addressing downstream breakage: https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/3713#018e30d8-e37e-491c-b58e-f54ef9170a01

Due to https://github.com/bazelbuild/bazel/commit/63dcbfbe6556ff52518cacd5ae943183bfe9a171