### PR TITLE
Fix publish_binary for Linux

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -419,7 +419,7 @@ PLATFORMS = {
     "centos7": {
         "name": "CentOS 7",
         "emoji-name": ":centos: CentOS 7",
-        "publish_binary": ["ubuntu2004", "centos7", "linux"],
+        "publish_binary": ["ubuntu1404", "centos7", "linux"],
         "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/centos7",
         "python": "python3.6",
     },


### PR DESCRIPTION
Change back to `ubuntu1404` to not break existing users, which was changed to `ubuntu2004` in https://github.com/bazelbuild/continuous-integration/commit/c781266b1124d09ca1718a273bac9edf563a0975