### PR TITLE
Remove custom bazel-postsubmit.yml file

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -111,7 +111,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     },
     "Bazel": {
         "git_repository": "https://github.com/bazelbuild/bazel.git",
-        "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-postsubmit.yml",
         "pipeline_slug": "bazel-bazel",
     },
     "Bazel Bench": {


### PR DESCRIPTION
Revert https://github.com/bazelbuild/continuous-integration/commit/de5ab841b71c3b36cbd61912774c6afad3845793 since have upgraded Bazel to 7.1.