### PR TITLE
Specify which files had merge conflicts while cherry-picking

### DIFF
--- a/actions/cherry_picker/cherrypick_with_commits.py
+++ b/actions/cherry_picker/cherrypick_with_commits.py
@@ -72,7 +72,7 @@ if len(successful_commits):
         failure_commits_str += "\n\nThe failed commits are NOT included in the PR. Please resolve manually.\ncc: @bazelbuild/triage"
         issue_comment_body += failure_commits_str
 elif len(failed_commits):
-    issue_comment_body = "Failed commmits (likely due to merge conflicts): "
+    issue_comment_body = "Failed commits (likely due to merge conflicts): "
     for fail_commit in failed_commits:
         issue_comment_body += f"https://github.com/{input_data['api_repo_name']}/commit/{fail_commit}, "
     issue_comment_body = issue_comment_body[::-1].replace(" ,", ".", 1)[::-1] + "\nPlease resolve manually.\ncc: @bazelbuild/triage"

--- a/actions/cherry_picker/functions.py
+++ b/actions/cherry_picker/functions.py
@@ -152,7 +152,8 @@ def cherry_pick(commit_id, release_branch_name, target_branch_name, requires_clo
                 update_lockfile(changed_files, True)
             else:
                 subprocess.run(['git', 'cherry-pick', '--skip'])
-                raise Exception("Cherry-pick was attempted, but there may be merge conflict(s). Please resolve manually.\ncc: @bazelbuild/triage")
+                unmerged_files_names = ("`" + "`\n`".join(unmerged_all_files)).rstrip("`")
+                raise Exception(f"Cherry-pick was attempted but there were merge conflicts in the following file(s). Please resolve manually.\n\n{unmerged_files_names}\n\ncc: @bazelbuild/triage")
         elif cherrypick_status.returncode == 0 and ("src/test/tools/bzlmod/MODULE.bazel.lock" in changed_files or "MODULE.bazel.lock" in changed_files):
             update_lockfile(changed_files, False)
         

--- a/actions/cherry_picker/functions.py
+++ b/actions/cherry_picker/functions.py
@@ -144,7 +144,7 @@ def cherry_pick(commit_id, release_branch_name, target_branch_name, requires_clo
             cherrypick_status = subprocess.run(['git', 'cherry-pick', '-m', '1', commit_id])
 
         lockfile_names = {"src/test/tools/bzlmod/MODULE.bazel.lock", "MODULE.bazel.lock"}
-        unmerged_all_files = str(subprocess.Popen(["git", "diff", "--name-only", "--diff-filter=U"], stdout=subprocess.PIPE).communicate()[0].decode()).split("\n")
+        unmerged_all_files = str(subprocess.Popen(["git", "diff", "--name-only", "--diff-filter=U"], stdout=subprocess.PIPE).communicate()[0].decode()).strip().split("\n")
         unmerged_rest = [j for i,j in enumerate(unmerged_all_files) if j not in lockfile_names and j != ""]
  
         if cherrypick_status.returncode != 0:
@@ -152,7 +152,7 @@ def cherry_pick(commit_id, release_branch_name, target_branch_name, requires_clo
                 update_lockfile(changed_files, True)
             else:
                 subprocess.run(['git', 'cherry-pick', '--skip'])
-                unmerged_files_names = ("`" + "`\n`".join(unmerged_all_files)).rstrip("`")
+                unmerged_files_names = "`" + "`\n`".join(unmerged_all_files) + "`"
                 raise Exception(f"Cherry-pick was attempted but there were merge conflicts in the following file(s). Please resolve manually.\n\n{unmerged_files_names}\n\ncc: @bazelbuild/triage")
         elif cherrypick_status.returncode == 0 and ("src/test/tools/bzlmod/MODULE.bazel.lock" in changed_files or "MODULE.bazel.lock" in changed_files):
             update_lockfile(changed_files, False)


### PR DESCRIPTION
When cherry-picking, the bot issues a comment "Cherry-pick was attempted but there were merge conflicts in the following file(s). Please resolve manually." But there can be an improvement for the users and specify which files had the conflicts. 