### PR TITLE
Remove restriction on approval when cherry-picking

### DIFF
--- a/actions/cherry_picker/functions.py
+++ b/actions/cherry_picker/functions.py
@@ -22,15 +22,9 @@ def get_commit_id(pr_number, actor_name, action_event, api_repo_name):
 def get_reviewers(pr_number, api_repo_name, issues_data):
     if "pull_request" not in issues_data: return []
     r = requests.get(f'https://api.github.com/repos/{api_repo_name}/pulls/{pr_number}/reviews', headers=headers)
-    if len(r.json()) == 0:
-        print(f"PR#{pr_number} has no approver at all.")
-        raise SystemExit(0)
     approvers_list = []
     for review in r.json():
         if review["state"] == "APPROVED": approvers_list.append(review["user"]["login"])
-    if len(approvers_list) == 0:
-        print(f"PR#{pr_number} has no approval from the approver(s).")
-        raise SystemExit(0)
     return approvers_list
 
 def extract_release_numbers_data(pr_number, api_repo_name):


### PR DESCRIPTION
This will allow us to create a PR while cherry-picking even when the original PR wasn't approved because sometimes PR's get merged to the master without approvals (for example, https://github.com/bazelbuild/bazel/issues/21784). But it will still check if the cherry-picking commit was made by "copybara", which is good enough.