### PR TITLE
Re-enable rules_jsonnet in Downstream CI

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -307,7 +307,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     "rules_jsonnet": {
         "git_repository": "https://github.com/bazelbuild/rules_jsonnet.git",
         "pipeline_slug": "rules-jsonnet",
-        "disabled_reason": "https://github.com/bazelbuild/rules_jsonnet/issues/173",
     },
     "rules_jvm_external": {
         "git_repository": "https://github.com/bazelbuild/rules_jvm_external.git",


### PR DESCRIPTION
This reverts commit e2b6b06c39bba496a44b4aa0de4ce8225f138f7e.

https://github.com/bazelbuild/rules_jsonnet/issues/173 was fixed by https://github.com/bazelbuild/rules_jsonnet/pull/179.