### PR TITLE
Enable rules_nodejs in Downstream CI

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -326,7 +326,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     "rules_nodejs": {
         "git_repository": "https://github.com/bazelbuild/rules_nodejs.git",
         "pipeline_slug": "rules-nodejs-nodejs",
-        "disabled_reason": "https://github.com/bazelbuild/rules_nodejs/issues/3713",
     },
     "rules_perl": {
         "git_repository": "https://github.com/bazelbuild/rules_perl.git",


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_nodejs/issues/3713

Disabled CI is Green now for rules_nodejs https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/2001