### PR TITLE
Use a custom config for bazel in downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -111,7 +111,9 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     },
     "Bazel": {
         "git_repository": "https://github.com/bazelbuild/bazel.git",
-        "file_config": ".bazelci/postsubmit.yml",
+        # https://github.com/bazelbuild/bazel/issues/21864
+        # "file_config": ".bazelci/postsubmit.yml",
+        "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-postsubmit.yml",
         "pipeline_slug": "bazel-bazel",
     },
     "Bazel Bench": {

--- a/pipelines/bazel-postsubmit.yml
+++ b/pipelines/bazel-postsubmit.yml
@@ -2,7 +2,7 @@
 # Update this file by running ./update-bazel-postsubmit.sh under the same directory
 
 tasks:
-  centos7_java11_devtoolset10:
+  centos7:
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
@@ -98,7 +98,6 @@ tasks:
       - "//tools/aquery_differ/..."
       - "//tools/python/..."
       - "//tools/bash/..."
-      # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/8162
     include_json_profile:
       - build
       - test
@@ -216,7 +215,6 @@ tasks:
       - build
       - test
   macos_arm64:
-    xcode_version: "15.1"
     shell_commands:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
@@ -305,6 +303,8 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/lib/remote:RemoteTests"
       - "-//src/test/shell/bazel/remote/..."
       - "-//tools/python:pywrapper_test"
+      # https://github.com/bazelbuild/bazel/issues/21593
+      - "-//src/test/java/com/google/devtools/build/lib/bazel/repository/downloader:DownloaderTestSuite"
     include_json_profile:
       - build
       - test
@@ -327,6 +327,10 @@ tasks:
   rbe_ubuntu2004:
     platform: ubuntu2004
     name: "RBE"
+    environment:
+      # Use last_green to pickup the fix for https://github.com/bazelbuild/bazel/issues/21604.
+      # TODO(chiwang): Remove this after Bazel 7.2.0 is released.
+      USE_BAZEL_VERSION: last_green
     shell_commands:
       - sed -i.bak
         -e 's/^# android_sdk_repository/android_sdk_repository/'
@@ -334,7 +338,7 @@ tasks:
       - rm -f WORKSPACE.bzlmod.bak
       - bazel mod deps --lockfile_mode=update
     build_flags:
-      - "--config=ubuntu2004_java11"
+      - "--config=remote"
       - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
       - "--jobs=200"
       - "--experimental_remote_cache_async"
@@ -345,7 +349,7 @@ tasks:
       - "//src:bazel_jdk_minimal"
       - "//src/main/java/..."
     test_flags:
-      - "--config=ubuntu2004_java11"
+      - "--config=remote"
       - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"
       - "--jobs=200"
       - "--experimental_remote_cache_async"
@@ -382,11 +386,14 @@ tasks:
     include_json_profile:
       - build
       - test
-  kythe_ubuntu2004:
+  kythe_ubuntu2204:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/'
       -e 's/^# android_ndk_repository/android_ndk_repository/' WORKSPACE.bzlmod
     - rm -f WORKSPACE.bzlmod.bak
+    # Remove _nowkt suffix because it's only available in newer protobuf releases. See b/329055020.
+    # TODO(chiwang): Remove this once we have upgraded to protobuf 25+.
+    - sed -i -e 's/protobuf_nowkt/protobuf/' /usr/local/kythe/BUILD
     index_flags:
     - "--define=kythe_corpus=github.com/bazelbuild/bazel"
     index_targets_query: "kind(\"cc_(binary|library|test|proto_library) rule\", ...) union kind(\"java_(binary|import|library|plugin|test|proto_library) rule\", ...) union kind(\"proto_library rule\", ...)"


### PR DESCRIPTION
Re-applying https://github.com/bazelbuild/continuous-integration/pull/1878 to address https://github.com/bazelbuild/bazel/issues/21864#issuecomment-2058993449

The postsubmit.yml was synced to the latest version in Bazel