### PR TITLE
Add docker image for fedora 40 linux distribution

### DIFF
--- a/buildkite/docker/build.sh
+++ b/buildkite/docker/build.sh
@@ -29,6 +29,7 @@ docker build -f ubuntu2004/Dockerfile --target ubuntu2004        -t "gcr.io/$PRE
 docker build -f ubuntu2204/Dockerfile --target ubuntu2204-java17 -t "gcr.io/$PREFIX/ubuntu2204-java17" ubuntu2204 &
 docker build -f ubuntu2204/Dockerfile --target ubuntu2204        -t "gcr.io/$PREFIX/ubuntu2204" ubuntu2204 &
 docker build -f fedora39/Dockerfile   --target fedora39-java17   -t "gcr.io/$PREFIX/fedora39-java17" fedora39 &
+docker build -f fedora40/Dockerfile   --target fedora40-java21   -t "gcr.io/$PREFIX/fedora40-java21" fedora40 &
 wait
 
 docker build -f centos7/Dockerfile    --target centos7-java8               -t "gcr.io/$PREFIX/centos7-java8" centos7
@@ -41,3 +42,4 @@ docker build -f ubuntu2004/Dockerfile --target ubuntu2004-bazel-java11     -t "g
 docker build -f ubuntu2204/Dockerfile --target ubuntu2204-kythe            -t "gcr.io/$PREFIX/ubuntu2204-kythe" ubuntu2204
 docker build -f ubuntu2204/Dockerfile --target ubuntu2204-bazel-java17     -t "gcr.io/$PREFIX/ubuntu2204-bazel-java17" ubuntu2204
 docker build -f fedora39/Dockerfile   --target fedora39-bazel-java17       -t "gcr.io/$PREFIX/fedora39-bazel-java17" fedora39
+docker build -f fedora40/Dockerfile   --target fedora40-bazel-java21       -t "gcr.io/$PREFIX/fedora40-bazel-java21" fedora40

--- a/buildkite/docker/fedora40/Dockerfile
+++ b/buildkite/docker/fedora40/Dockerfile
@@ -1,0 +1,66 @@
+FROM fedora:40 as fedora40-bazel-java21
+ARG BUILDARCH
+
+RUN dnf update -y
+
+### Install packages required by Bazel and its tests
+RUN dnf install -y \
+  bind-utils \
+  dnsutils \
+  dpkg-dev \
+  expect \
+  findutils \
+  gcc \
+  gcc-c++ \
+  git \
+  glibc-langpack-en \
+  glibc-locale-source \
+  iproute \
+  iputils \
+  lcov \
+  java-21-openjdk \
+  java-21-openjdk-devel \
+  patch \
+  perl \
+  python2 \
+  python3 \
+  python3-devel \
+  python3-pip \
+  python3-requests \
+  python3-setuptools \
+  python3-wheel \
+  python3-yaml \
+  unzip \
+  vim \
+  wget \
+  which \
+  zip \
+  && dnf clean all \
+  && rm -rf /var/cache/yum
+
+RUN localedef -i en_US -f ISO-8859-1 en_US.ISO-8859-1
+
+# Allow using sudo inside the container.
+RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk
+
+FROM fedora40-bazel-java21 AS fedora40-java21
+
+# Install Google Cloud SDK
+COPY google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
+
+RUN dnf install -y \
+  google-cloud-sdk
+
+# Bazelisk
+RUN LATEST_BAZELISK=$(curl -sSI https://github.com/bazelbuild/bazelisk/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
+    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${BUILDARCH} && \
+    chown root:root /usr/local/bin/bazel && \
+    chmod 0755 /usr/local/bin/bazel
+
+# Buildifier
+RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
+    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${BUILDARCH} && \
+    chown root:root /usr/local/bin/buildifier && \
+    chmod 0755 /usr/local/bin/buildifier

--- a/buildkite/docker/fedora40/google-cloud-sdk.repo
+++ b/buildkite/docker/fedora40/google-cloud-sdk.repo
@@ -1,0 +1,8 @@
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/buildkite/docker/push.sh
+++ b/buildkite/docker/push.sh
@@ -35,4 +35,6 @@ docker push "gcr.io/$PREFIX/ubuntu2204-bazel-java17" &
 docker push "gcr.io/$PREFIX/ubuntu2204" &
 docker push "gcr.io/$PREFIX/fedora39-java17" &
 docker push "gcr.io/$PREFIX/fedora39-bazel-java17" &
+docker push "gcr.io/$PREFIX/fedora40-java21" &
+docker push "gcr.io/$PREFIX/fedora40-bazel-java21" &
 wait


### PR DESCRIPTION
Fedora 40 ist one of the distribution to ship new and shiny gcc version 40.

Change-Id: I35aeb6a9a337cb361d7cea5b8608310895a103e6