### PR TITLE
Update lockfiles when PR is merged to a release branch

### DIFF
--- a/actions/update-lockfile/action.yml
+++ b/actions/update-lockfile/action.yml
@@ -1,0 +1,36 @@
+name: "Update the lockfile on all the PRs merging to 'release-' branches"
+inputs:
+  release-branch:
+    required: true
+    default: ${{ github.release-branch }}
+  is-prod:
+    required: true
+    default: ${{ github.is-prod }}
+  pr-number:
+    required: true
+    default: ${{ github.pr-number }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install bazelisk
+      run: |
+        curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64"
+        chmod +x bazelisk-linux-amd64
+      shell: bash
+    - name: Install Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install Dependencies
+      run: |
+        pip install -r ${{ github.action_path }}/requirements.txt
+      shell: bash
+    - name: Run python update_lockfile_pr.py
+      env:
+        RELEASE_BRANCH: ${{ inputs.release-branch }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+      run: |
+        chmod +x ${{ github.action_path }}/update_lockfile_pr.py
+        python -u ${{ github.action_path }}/update_lockfile_pr.py
+      shell: bash

--- a/actions/update-lockfile/functions.py
+++ b/actions/update-lockfile/functions.py
@@ -53,9 +53,7 @@ def push_to_branch():
     push_status = subprocess.run(['git', 'push', '-f'])
     if push_status.returncode != 0: raise Exception(f"Cherry-pick was attempted, but failed to push.\ncc: @bazelbuild/triage")
 
-def update_lockfiles(lockfiles, head_branch, requires_clone, release_branch, lockfile_names):
-    if requires_clone == True:
-        clone_repo()
+def update_lockfiles(lockfiles, head_branch, release_branch, lockfile_names):
     if checkout_branch(head_branch, release_branch).returncode != 0:
         print(f"{input_data['user_name']} does not have the branch: {head_branch}...")
         return

--- a/actions/update-lockfile/functions.py
+++ b/actions/update-lockfile/functions.py
@@ -1,0 +1,100 @@
+import requests, subprocess, os, re, pprint
+from vars import headers, token, gh_cli_repo_name, input_data, gh_cli_repo_url
+
+def get_release_prs(release_branch):
+    page_param = 1
+    params = {
+        "state": "open",
+        "base": release_branch,
+        "per_page": 100,
+        "page": page_param
+    }
+    pr_list = []
+    response_pr = requests.get(f"https://api.github.com/repos/{gh_cli_repo_name}/pulls", headers=headers, params=params).json()
+    pr_list.extend(response_pr)
+    while len(response_pr) == 100:
+        page_param += 1
+        response_pr = requests.get(f"https://api.github.com/repos/{gh_cli_repo_name}/pulls", headers=headers, params=params).json()
+        pr_list.extend(response_pr)
+    return list(filter(lambda n: n["user"]["login"] == input_data["user_name"], pr_list))
+
+def get_files_for_pr(pr_number):
+    page_param = 1
+    params = {
+        "per_page": 100,
+        "page": page_param,
+    }
+    files_list = []
+    response_pr_files = requests.get(f"https://api.github.com/repos/{gh_cli_repo_name}/pulls/{pr_number}/files", headers=headers, params=params).json()
+    files_list.extend(response_pr_files)
+    while len(response_pr_files) == 100:
+        page_param += 1
+        response_pr_files = requests.get(f"https://api.github.com/repos/{gh_cli_repo_name}/pulls/{pr_number}/files", headers=headers, params=params).json()
+        files_list.extend(response_pr_files)
+    return files_list
+
+def clone_repo():
+    subprocess.run(['git', 'clone', f"https://{input_data['user_name']}:{token}@github.com/{gh_cli_repo_name}.git"])
+    subprocess.run(['git', 'config', '--global', 'user.name', input_data["user_name"]])
+    subprocess.run(['git', 'config', '--global', 'user.email', input_data["email"]])
+    os.chdir("bazel")
+    subprocess.run(['git', 'remote', 'add', 'origin', gh_cli_repo_url])
+    subprocess.run(['git', 'remote', '-v'])
+
+def checkout_branch(head_branch, release_branch):
+    subprocess.run(['git', 'fetch', '--all'])
+    subprocess.run(['git', 'checkout', release_branch])
+    subprocess.run(['git', 'pull'])
+
+    status_checkout_release = subprocess.run(['git', 'checkout', head_branch])
+    return status_checkout_release
+
+def push_to_branch():
+    push_status = subprocess.run(['git', 'push', '-f'])
+    if push_status.returncode != 0: raise Exception(f"Cherry-pick was attempted, but failed to push.\ncc: @bazelbuild/triage")
+
+def update_lockfiles(lockfiles, head_branch, requires_clone, release_branch, lockfile_names):
+    if requires_clone == True:
+        clone_repo()
+    if checkout_branch(head_branch, release_branch).returncode != 0:
+        print(f"{input_data['user_name']} does not have the branch: {head_branch}...")
+        return
+    std_out_bazel_version = subprocess.Popen(["../bazelisk-linux-amd64", "--version"], stdout=subprocess.PIPE)
+    bazel_version_std_out = std_out_bazel_version.communicate()[0].decode()
+    major_version_digit = int(re.findall(r"\d.\d.\d", bazel_version_std_out)[0].split(".")[0])
+
+    if major_version_digit < 7:
+        print("Warning: The .bazelversion is less than 7. Therefore, the lockfiles will not be updated...")
+        return
+    
+    rebase_status = subprocess.run(["git", "rebase", f"origin/{release_branch}"])
+    if rebase_status.returncode != 0:
+        unmerged_all_files = str(subprocess.Popen(["git", "diff", "--name-only", "--diff-filter=U"], stdout=subprocess.PIPE).communicate()[0].decode()).split("\n")
+        unmerged_rest = [j for i, j in enumerate(unmerged_all_files) if j not in lockfile_names and j != ""]
+        if len(unmerged_rest) != 0:
+            print("Could not rebase because of conflicts with files other than the lockfiles")
+        else:
+            print("There was conflicts with lockfiles only...")
+            allowed_rebase_continue_attempts = 2
+            while allowed_rebase_continue_attempts > 0:
+                for f in lockfile_names:
+                    subprocess.run(["git", "checkout", "--ours", f])
+                subprocess.run(["git", "add", "."])
+                rebase_continue_status = subprocess.run(["git", "-c", "core.editor=true", "rebase", "--continue"])
+                if rebase_continue_status.returncode == 0:
+                    if "src/test/tools/bzlmod/MODULE.bazel.lock" in lockfiles:
+                        subprocess.run(["../bazelisk-linux-amd64", "run", "//src/test/tools/bzlmod:update_default_lock_file"])
+                    subprocess.run(["../bazelisk-linux-amd64", "mod", "deps", "--lockfile_mode=update"])
+                    subprocess.run(["git", "add", "."])
+                    subprocess.run(["git", "commit", "-m", "Update lockfile(s)"])
+                    push_to_branch()
+                    return
+                allowed_rebase_continue_attempts -= 1
+        subprocess.run(['git', 'rebase', '--abort'])
+    else:
+        if "src/test/tools/bzlmod/MODULE.bazel.lock" in lockfiles:
+            subprocess.run(["../bazelisk-linux-amd64", "run", "//src/test/tools/bzlmod:update_default_lock_file"])
+        subprocess.run(["../bazelisk-linux-amd64", "mod", "deps", "--lockfile_mode=update"])
+        subprocess.run(["git", "add", "."])
+        subprocess.run(["git", "commit", "-m", "Update lockfile(s)"])
+        push_to_branch()

--- a/actions/update-lockfile/requirements.txt
+++ b/actions/update-lockfile/requirements.txt
@@ -1,0 +1,3 @@
+requests==2.31.0
+github3.py==4.0.1
+PyGithub==1.58.2

--- a/actions/update-lockfile/update_lockfile_pr.py
+++ b/actions/update-lockfile/update_lockfile_pr.py
@@ -1,5 +1,5 @@
 import os
-from functions import get_release_prs, get_files_for_pr, update_lockfiles
+from functions import get_release_prs, get_files_for_pr, update_lockfiles, clone_repo
 
 lockfile_names = {"MODULE.bazel.lock", "src/test/tools/bzlmod/MODULE.bazel.lock"}
 original_pr_number = os.environ["PR_NUMBER"]
@@ -32,8 +32,9 @@ for pr in pr_list:
         if file["filename"] in lockfile_names:
             pr["lockfiles"].add(file["filename"])
     if len(pr["lockfiles"]) > 0:
+        if requires_clone == True: clone_repo()
         try:
-            update_lockfiles(pr["lockfiles"], pr["head"]["ref"], requires_clone, release_branch, lockfile_names)
+            update_lockfiles(pr["lockfiles"], pr["head"]["ref"], release_branch, lockfile_names)
         except Exception as e:
             print(f"Failed updating lockfiles: {pr['number']} in {pr['head']['ref']}")
         requires_clone = False

--- a/actions/update-lockfile/update_lockfile_pr.py
+++ b/actions/update-lockfile/update_lockfile_pr.py
@@ -1,0 +1,39 @@
+import os
+from functions import get_release_prs, get_files_for_pr, update_lockfiles
+
+lockfile_names = {"MODULE.bazel.lock", "src/test/tools/bzlmod/MODULE.bazel.lock"}
+original_pr_number = os.environ["PR_NUMBER"]
+original_pr_files_list = get_files_for_pr(original_pr_number)
+can_proceed = False
+for f in original_pr_files_list:
+    if f["filename"] in lockfile_names:
+        can_proceed = True
+        break
+
+if can_proceed == False:
+    print("The PR does not contain any lockfile. Therefore, it does not require lockfile updates")
+    raise SystemExit(0)
+
+release_branch = os.environ["RELEASE_BRANCH"]
+
+release_version = release_branch.split("release-")[1]
+
+milestone_name = release_version + " release blockers"
+
+# Get a list of the prs made to the release branch 
+pr_list = get_release_prs(release_branch)
+
+# Get all the files from each PR and find out if any of the files is a lockfile and update the lockfile if a pr contains any lockfile
+requires_clone = True
+for pr in pr_list:
+    pr["lockfiles"] = set()
+    files_list = get_files_for_pr(pr["number"])
+    for file in files_list:
+        if file["filename"] in lockfile_names:
+            pr["lockfiles"].add(file["filename"])
+    if len(pr["lockfiles"]) > 0:
+        try:
+            update_lockfiles(pr["lockfiles"], pr["head"]["ref"], requires_clone, release_branch, lockfile_names)
+        except Exception as e:
+            print(f"Failed updating lockfiles: {pr['number']} in {pr['head']['ref']}")
+        requires_clone = False

--- a/actions/update-lockfile/vars.py
+++ b/actions/update-lockfile/vars.py
@@ -1,0 +1,27 @@
+import os
+
+headers = {
+    'X-GitHub-Api-Version': '2022-11-28'
+}
+
+token = os.environ["GH_TOKEN"]
+
+
+if "INPUT_IS_PROD" not in os.environ or os.environ["INPUT_IS_PROD"] == "false":
+    input_data = {
+        "is_prod": False,
+        "api_repo_name": "iancha1992/bazel",
+        "user_name": "iancha1992",
+        "email": "heec@google.com",
+    }
+
+elif os.environ["INPUT_IS_PROD"] == "true":
+    input_data = {
+        "is_prod": True,
+        "api_repo_name": "bazelbuild/bazel",
+        "user_name": "bazel-io",
+        "email": "bazel-io-bot@google.com",
+    }
+
+gh_cli_repo_name = f"{input_data['user_name']}/bazel"
+gh_cli_repo_url = f"git@github.com:{gh_cli_repo_name}.git"


### PR DESCRIPTION
This will resolve the lockfile conflicts in the `release-` branch PR's if the changes were to happen in a `release` branch. 
This is first triggered by any changes pushed to a `release` branch. And then once it finds out that there is conflicts with the lockfiles, then it will update the lockfiles and force push the changes. Only applies to the PR's from the `bazel-io` account.