### PR TITLE
Add legacy platform names for old macos fleet

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -556,6 +556,13 @@ PLATFORMS = {
         "queue": "macos_arm64",
         "python": "python3",
     },
+    "macos_arm64_legacy": {
+        "name": "macOS arm64",
+        "emoji-name": ":darwin: macOS arm64",
+        "publish_binary": ["macos_arm64"],
+        "queue": "macos_arm64_legacy",
+        "python": "python3",
+    },
     "macos_arm64_v2": {
         "name": "macOS arm64",
         "emoji-name": ":darwin: macOS arm64",

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -524,7 +524,6 @@ PLATFORMS = {
     "macos_legacy": {
         "name": "macOS",
         "emoji-name": ":darwin: macOS",
-        "publish_binary": ["macos"],
         "queue": "macos_legacy",
         "python": "python3",
     },
@@ -559,7 +558,6 @@ PLATFORMS = {
     "macos_arm64_legacy": {
         "name": "macOS arm64",
         "emoji-name": ":darwin: macOS arm64",
-        "publish_binary": ["macos_arm64"],
         "queue": "macos_arm64_legacy",
         "python": "python3",
     },

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -524,6 +524,7 @@ PLATFORMS = {
     "macos_legacy": {
         "name": "macOS",
         "emoji-name": ":darwin: macOS",
+        "publish_binary": [],
         "queue": "macos_legacy",
         "python": "python3",
     },
@@ -558,6 +559,7 @@ PLATFORMS = {
     "macos_arm64_legacy": {
         "name": "macOS arm64",
         "emoji-name": ":darwin: macOS arm64",
+        "publish_binary": [],
         "queue": "macos_arm64_legacy",
         "python": "python3",
     },

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -521,6 +521,13 @@ PLATFORMS = {
         "queue": "macos",
         "python": "python3",
     },
+    "macos_legacy": {
+        "name": "macOS",
+        "emoji-name": ":darwin: macOS",
+        "publish_binary": ["macos"],
+        "queue": "macos_legacy",
+        "python": "python3",
+    },
     "macos_v2": {
         "name": "macOS",
         "emoji-name": ":darwin: macOS",


### PR DESCRIPTION
Related: https://github.com/bazelbuild/continuous-integration/issues/1708