### PR TITLE
Automatically retry on macOS for some failures

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2785,6 +2785,11 @@ def create_step(label, commands, platform, shards=1, soft_fail=None):
         ]
     }
 
+    # Automatically retry on Intel Macs to work around flaky failures.
+    if platform == "macos":
+        step["retry"]["automatic"].append({"exit_status": 128, "limit": 3})
+        step["retry"]["automatic"].append({"exit_status": 1, "limit": 3})
+
     return step
 
 


### PR DESCRIPTION
New Intel Mac VMs have been quite flaky due to some infra problems:
- https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/22410#01909c6d-48fc-4298-9e3e-1702cc14b7dd
- https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/22585#0190ea99-d981-4d95-aba8-ca3235f2543f

Add auto retry for exit codes of those failures.