### PR TITLE
Fix get_test_tags

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2351,7 +2351,7 @@ def get_test_tags(test_flags):
             continue
 
         tags = removeprefix(f, wanted_prefix).split(",")
-        include, exclude = partition_list(tags)
+        include, exclude, _ = partition_list(tags)
 
         # Skip tests tagged as "manual" by default, unless explicitly requested
         manual_tag = "manual"


### PR DESCRIPTION
Missed in https://github.com/bazelbuild/continuous-integration/pull/2017