### PR TITLE
[reapply] Automatically retry on macOS for some failures

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2790,6 +2790,11 @@ def create_step(label, commands, platform, shards=1, soft_fail=None):
         ]
     }
 
+    # Automatically retry on Intel Macs to work around flaky failures.
+    if platform == "macos":
+        step["retry"]["automatic"].append({"exit_status": 128, "limit": 1})
+        step["retry"]["automatic"].append({"exit_status": 1, "limit": 1})
+
     return step
 
 


### PR DESCRIPTION
Similar to https://github.com/bazelbuild/continuous-integration/pull/2012, but limit the retry to 1

We are still seeing file system corruption issues on Intel Macs: https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/22733#01912f7e-f80c-4e2d-8b09-1d9e7e005d38