### PR TITLE
feat: multi-arch build for OCI image

### DIFF
--- a/bazel/oci/Dockerfile
+++ b/bazel/oci/Dockerfile
@@ -8,7 +8,7 @@ RUN --mount=source=bazel/oci/install_packages.sh,target=/mnt/install_packages.sh
 
 FROM base_image AS downloader
 
-ARG TARGETOS TARGETARCH BAZEL_VERSION
+ARG TARGETARCH BAZEL_VERSION
 
 WORKDIR /var/bazel
 RUN --mount=source=bazel/oci/install_bazel.sh,target=/mnt/install_bazel.sh,type=bind \

--- a/bazel/oci/Dockerfile
+++ b/bazel/oci/Dockerfile
@@ -8,7 +8,7 @@ RUN --mount=source=bazel/oci/install_packages.sh,target=/mnt/install_packages.sh
 
 FROM base_image AS downloader
 
-ARG BAZEL_VERSION
+ARG TARGETOS TARGETARCH BAZEL_VERSION
 
 WORKDIR /var/bazel
 RUN --mount=source=bazel/oci/install_bazel.sh,target=/mnt/install_bazel.sh,type=bind \

--- a/bazel/oci/install_bazel.sh
+++ b/bazel/oci/install_bazel.sh
@@ -6,13 +6,13 @@ curl \
     --fail \
     --location \
     --remote-name \
-    "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-${TARGETOS}-${TARGETARCH}"
+    "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${TARGETARCH}"
 
 curl \
     --fail \
     --location \
-    "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-${TARGETOS}-${TARGETARCH}.sha256" \
+    "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${TARGETARCH}.sha256" \
     | sha256sum --check
 
-mv "bazel-${BAZEL_VERSION}-${TARGETOS}-${TARGETARCH}" bazel
+mv "bazel-${BAZEL_VERSION}-linux-${TARGETARCH}" bazel
 chmod +x bazel

--- a/bazel/oci/install_bazel.sh
+++ b/bazel/oci/install_bazel.sh
@@ -6,13 +6,13 @@ curl \
     --fail \
     --location \
     --remote-name \
-    "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64"
+    "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-${TARGETOS}-${TARGETARCH}"
 
 curl \
     --fail \
     --location \
-    "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64.sha256" \
+    "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-${TARGETOS}-${TARGETARCH}.sha256" \
     | sha256sum --check
 
-mv "bazel-${BAZEL_VERSION}-linux-x86_64" bazel
+mv "bazel-${BAZEL_VERSION}-${TARGETOS}-${TARGETARCH}" bazel
 chmod +x bazel


### PR DESCRIPTION
I was trying to build the image on arm64 but this image was specifically made for x86_64.

I propose to make the image available for other architectures. As we are using docker buildx we can use the `TARGETARCH` argument ([Automatic platform ARGs in the global scope](https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope)).