### PR TITLE
Upload shard distribution per platform

### DIFF
--- a/buildkite/sim.py
+++ b/buildkite/sim.py
@@ -1,0 +1,8 @@
+import os
+
+os.environ["BUILDKITE_ORGANIZATION_SLUG"] = "bazel"
+os.environ["BUILDKITE_PIPELINE_SLUG"] = "bazel-bazel"
+os.environ["BUILDKITE_BUILD_NUMBER"] = "29509"
+
+import bazelci
+bazelci.print_shard_summary()


### PR DESCRIPTION
This change allows us to better understand and benchmark the sharding strategy.

Tested:
- https://buildkite.com/bazel/bazel-fwe-ms-test/builds/24#01924d33-2fa7-4a90-b518-6d95431fdfd2
- https://storage.googleapis.com/bazel-untrusted-buildkite-artifacts/01924d33-2fa7-4a90-b518-6d95431fdfd2/tmp/tmp4nl2p4v3/shard_distribution.json