### PR TITLE
A few improvements to bazel ci scripts

### DIFF
--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -48,6 +48,9 @@ BAZEL_TEAM_OWNED_MODULES = [
 
 PROJECT = "module" if PIPELINE == "bcr-bazel-compatibility-test" else "project"
 
+MAX_LOG_FETCHER_THREADS = 30
+LOG_FETCHER_SEMAPHORE = threading.Semaphore(MAX_LOG_FETCHER_THREADS)
+
 class LogFetcher(threading.Thread):
     def __init__(self, job, client):
         threading.Thread.__init__(self)
@@ -56,7 +59,8 @@ class LogFetcher(threading.Thread):
         self.log = None
 
     def run(self):
-        self.log = self.client.get_build_log(self.job)
+        with LOG_FETCHER_SEMAPHORE:
+            self.log = self.client.get_build_log(self.job)
 
 
 def process_build_log(failed_jobs_per_flag, already_failing_jobs, log, job):

--- a/buildkite/aggregate_incompatible_flags_test_result.py
+++ b/buildkite/aggregate_incompatible_flags_test_result.py
@@ -33,7 +33,7 @@ FLAG_LINE_PATTERN = re.compile(r"\s*(?P<flag>--\S+)\s*")
 
 MODULE_VERSION_PATTERN = re.compile(r'(?P<module_version>[a-z](?:[a-z0-9._-]*[a-z0-9])?@[^\s]+)')
 
-BAZEL_TEAM_OWNED_MODULES = [
+BAZEL_TEAM_OWNED_MODULES = frozenset([
     "bazel-skylib",
     "rules_android",
     "rules_android_ndk",
@@ -44,7 +44,7 @@ BAZEL_TEAM_OWNED_MODULES = [
     "rules_platform",
     "rules_shell",
     "rules_testing",
-]
+])
 
 PROJECT = "module" if PIPELINE == "bcr-bazel-compatibility-test" else "project"
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -710,11 +710,11 @@ gwD6RBL0qz1PFfg7Zw==
             except urllib.error.HTTPError as ex:
                 # Handle specific error codes
                 if ex.code == 429:  # Too Many Requests
-                    retry_after = ex.headers.get("Retry-After")
+                    retry_after = ex.headers.get("RateLimit-Reset")
                     if retry_after:
                         wait_time = int(retry_after)
                     else:
-                        wait_time = (2 ** attempt)  # Exponential backoff if no Retry-After header
+                        wait_time = (2 ** attempt)  # Exponential backoff if no RateLimit-Reset header
 
                     time.sleep(wait_time)
                 else:


### PR DESCRIPTION
`aggregate_incompatible_flags_test_result.py`:

- Stripped out timestamps added by BuildKite in job log.
- Added support for collecting incompatible flag test result for https://buildkite.com/bazel/bcr-bazel-compatibility-test

`bazelci.py`:
- Added support for overriding Bazel version in task config before task expansion.
- Support `concurrency` and `concurrency_group` to limit CI resource usage.
- Avoid hitting 429 Too Many Requests error while fetching a large number of buildkite job logs.