### PR TITLE
Upgrade Linux & Windows CI fleet

### DIFF
--- a/buildkite/create_images.py
+++ b/buildkite/create_images.py
@@ -101,7 +101,7 @@ def create_instance(instance_name, params):
             instance_name,
             project=params["project"],
             zone=params["zone"],
-            machine_type="c2-standard-8",
+            machine_type="c3d-standard-8",
             network=params.get("network", "default"),
             metadata_from_file=startup_script,
             boot_disk_type="pd-ssd",

--- a/buildkite/instances.yml
+++ b/buildkite/instances.yml
@@ -14,7 +14,7 @@
 default_vm:
   boot_disk_size: 500GB
   boot_disk_type: pd-ssd
-  machine_type: c2-standard-30
+  machine_type: c3d-standard-30
   network: default
   region: us-central1
   restart-on-failure: False
@@ -26,7 +26,7 @@ default_vm:
   initial_delay: 60
 instance_groups:
   - name: bk-docker
-    count: 100
+    count: 200
     project: bazel-untrusted
     service_account: buildkite@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-docker
@@ -44,7 +44,7 @@ instance_groups:
     image_family: bk-docker
     metadata_from_file: startup-script=startup-docker-pdssd.sh
   - name: bk-windows
-    count: 30
+    count: 60
     project: bazel-untrusted
     service_account: buildkite@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-windows


### PR DESCRIPTION
- Migrate all machines from c2-standard-30 to c3d-standard-30
- Grow Linux pool from 100 to 200
- Grow Windows pool from 30 to 60
- Upgrade image creation machine from c2-standard-8 to c3d-standard-8

Progress towards https://github.com/bazelbuild/continuous-integration/issues/2089