### PR TITLE
BCR bazel compatibility test: Add generate_report.py

### DIFF
--- a/buildkite/bazel-central-registry/generate_report.py
+++ b/buildkite/bazel-central-registry/generate_report.py
@@ -55,10 +55,9 @@ def get_github_maintainer(module_name):
 
 def print_report_in_markdown(failed_jobs_per_module, pipeline_url):
     bazel_version = os.environ.get("USE_BAZEL_VERSION")
+    print("\n")
     print("## The following modules are broken%s:" % (f" with Bazel@{bazel_version}" if bazel_version else ""))
-
     print("BCR Bazel Compatibility Test: ", pipeline_url)
-
     for module, jobs in failed_jobs_per_module.items():
         module_name = module.strip().split("@")[0]
         github_maintainers = get_github_maintainer(module_name)
@@ -66,6 +65,7 @@ def print_report_in_markdown(failed_jobs_per_module, pipeline_url):
         print("Maintainers: ", ", ".join(f"@{maintainer}" for maintainer in github_maintainers))
         for job in jobs:
             print(f"- [{job['name']}]({job['web_url']})")
+    print("\n")
 
 
 def main(argv=None):

--- a/buildkite/bazel-central-registry/generate_report.py
+++ b/buildkite/bazel-central-registry/generate_report.py
@@ -83,10 +83,11 @@ def main(argv=None):
         for job in build_info["jobs"]:
             if "state" in job and "name" in job and job["state"] == "failed":
                 module = extract_module_version(job["name"])
-                if module:
-                    if module not in failed_jobs_per_module:
-                        failed_jobs_per_module[module] = []
-                    failed_jobs_per_module[module].append(job)
+                if not module:
+                    continue
+                if module not in failed_jobs_per_module:
+                    failed_jobs_per_module[module] = []
+                failed_jobs_per_module[module].append(job)
 
         print_report_in_markdown(failed_jobs_per_module, build_info["web_url"])
     else:

--- a/buildkite/bazel-central-registry/generate_report.py
+++ b/buildkite/bazel-central-registry/generate_report.py
@@ -81,13 +81,12 @@ def main(argv=None):
         build_info = client.get_build_info(args.build_number)
         failed_jobs_per_module = {}
         for job in build_info["jobs"]:
-            if "state" in job and "name" in job:
+            if "state" in job and "name" in job and job["state"] == "failed":
                 module = extract_module_version(job["name"])
                 if module:
-                    if job["state"] == "failed":
-                        if module not in failed_jobs_per_module:
-                            failed_jobs_per_module[module] = []
-                        failed_jobs_per_module[module].append(job)
+                    if module not in failed_jobs_per_module:
+                        failed_jobs_per_module[module] = []
+                    failed_jobs_per_module[module].append(job)
 
         print_report_in_markdown(failed_jobs_per_module, build_info["web_url"])
     else:

--- a/buildkite/bazel-central-registry/generate_report.py
+++ b/buildkite/bazel-central-registry/generate_report.py
@@ -54,7 +54,7 @@ def get_github_maintainer(module_name):
 
 
 def print_report_in_markdown(failed_jobs_per_module, pipeline_url):
-    bazel_version = os.environ.get("USE_BAZEL_VERSION", "")
+    bazel_version = os.environ.get("USE_BAZEL_VERSION")
     print("## The following modules are broken%s:" % (f" with Bazel@{bazel_version}" if bazel_version else ""))
 
     print("BCR Bazel Compatibility Test: ", pipeline_url)

--- a/buildkite/bazel-central-registry/generate_report.py
+++ b/buildkite/bazel-central-registry/generate_report.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+#
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint: disable=line-too-long
+# pylint: disable=missing-function-docstring
+# pylint: disable=unspecified-encoding
+# pylint: disable=invalid-name
+"""The CI script for BCR Bazel Compatibility Test pipeline."""
+
+
+import argparse
+import os
+import json
+import re
+import sys
+
+import bazelci
+import bcr_presubmit
+
+BUILDKITE_ORG = os.environ["BUILDKITE_ORGANIZATION_SLUG"]
+
+PIPELINE = os.environ["BUILDKITE_PIPELINE_SLUG"]
+
+MODULE_VERSION_PATTERN = re.compile(r'(?P<module_version>[a-z](?:[a-z0-9._-]*[a-z0-9])?@[^\s]+)')
+
+def extract_module_version(line):
+    match = MODULE_VERSION_PATTERN.search(line)
+    if match:
+        return match.group("module_version")
+
+
+def get_github_maintainer(module_name):
+    metadata = json.load(open(bcr_presubmit.get_metadata_json(module_name), "r"))
+    github_maintainers = []
+    for maintainer in metadata["maintainers"]:
+        if "github" in maintainer:
+            github_maintainers.append(maintainer["github"])
+
+    if not github_maintainers:
+        github_maintainers.append("bazelbuild/bcr-maintainers")
+    return github_maintainers
+
+
+def print_report_in_markdown(failed_jobs_per_module, pipeline_url):
+    bazel_version = os.environ.get("USE_BAZEL_VERSION", "")
+    print("## The following modules are broken%s:" % (f" with Bazel@{bazel_version}" if bazel_version else ""))
+
+    print("BCR Bazel Compatibility Test: ", pipeline_url)
+
+    for module, jobs in failed_jobs_per_module.items():
+        module_name = module.strip().split("@")[0]
+        github_maintainers = get_github_maintainer(module_name)
+        print(f"### {module}")
+        print("Maintainers: ", ", ".join(f"@{maintainer}" for maintainer in github_maintainers))
+        for job in jobs:
+            print(f"- [{job['name']}]({job['web_url']})")
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(description="Script to report BCR Bazel Compatibility Test result.")
+    parser.add_argument("--build_number", type=str)
+
+    args = parser.parse_args(argv)
+    if args.build_number:
+        client = bazelci.BuildkiteClient(org=BUILDKITE_ORG, pipeline=PIPELINE)
+        build_info = client.get_build_info(args.build_number)
+        failed_jobs_per_module = {}
+        for job in build_info["jobs"]:
+            if "state" in job and "name" in job:
+                module = extract_module_version(job["name"])
+                if module:
+                    if job["state"] == "failed":
+                        if module not in failed_jobs_per_module:
+                            failed_jobs_per_module[module] = []
+                        failed_jobs_per_module[module].append(job)
+
+        print_report_in_markdown(failed_jobs_per_module, build_info["web_url"])
+    else:
+        parser.print_help()
+        return 2
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/buildkite/bazel-central-registry/generate_report.py
+++ b/buildkite/bazel-central-registry/generate_report.py
@@ -17,7 +17,7 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=unspecified-encoding
 # pylint: disable=invalid-name
-"""The CI script for BCR Bazel Compatibility Test pipeline."""
+"""The CI script for generate report for BCR Bazel Compatibility Test pipeline."""
 
 
 import argparse

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -56,7 +56,7 @@ THIS_IS_SPARTA = True
 
 CLOUD_PROJECT = "bazel-public" if THIS_IS_TRUSTED else "bazel-untrusted"
 
-GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "testing"}[
+GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "pcloudy-bcr-test"}[
     BUILDKITE_ORG
 ]
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -56,7 +56,7 @@ THIS_IS_SPARTA = True
 
 CLOUD_PROJECT = "bazel-public" if THIS_IS_TRUSTED else "bazel-untrusted"
 
-GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "pcloudy-bcr-test"}[
+GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "testing"}[
     BUILDKITE_ORG
 ]
 


### PR DESCRIPTION
This will be run in the last step for a https://buildkite.com/bazel/bcr-bazel-compatibility-test build without `USE_BAZELISK_MIGRATE` and generate a report in markdown that can be used for filing a GitHub issue report for broken modules.

e.g.:
<img width="685" alt="image" src="https://github.com/user-attachments/assets/3e888dd0-601c-4b38-bce0-047eb80be9bb">
