### PR TITLE
Avoid generate duplicated tasks

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1044,7 +1044,7 @@ def maybe_overwrite_bazel_version(bazel_version, config):
         config["tasks"][task]["bazel"] = bazel_version
     matrix = config.get("matrix", {})
     if "bazel" in matrix:
-        # This will only apply to "old_bazel" and avoid generate multiple tasks with the same config
+        # This will only apply to "old_bazel" and avoid generating multiple tasks with the same config
         matrix["bazel"] = [", ".join(matrix["bazel"])]
 
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1042,6 +1042,10 @@ def maybe_overwrite_bazel_version(bazel_version, config):
     for task in config.get("tasks", {}):
         config["tasks"][task]["old_bazel"] = config["tasks"][task].get("bazel")
         config["tasks"][task]["bazel"] = bazel_version
+    matrix = config.get("tasks", {})
+    if "bazel" in matrix:
+        # This will only apply to "old_bazel" and avoid generate multiple tasks with the same config
+        matrix["bazel"] = [", ".join(matrix["bazel"])]
 
 
 def load_config(http_url, file_config, allow_imports=True, bazel_version=None):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1042,7 +1042,7 @@ def maybe_overwrite_bazel_version(bazel_version, config):
     for task in config.get("tasks", {}):
         config["tasks"][task]["old_bazel"] = config["tasks"][task].get("bazel")
         config["tasks"][task]["bazel"] = bazel_version
-    matrix = config.get("tasks", {})
+    matrix = config.get("matrix", {})
     if "bazel" in matrix:
         # This will only apply to "old_bazel" and avoid generate multiple tasks with the same config
         matrix["bazel"] = [", ".join(matrix["bazel"])]


### PR DESCRIPTION
Previously, bazel version defined in the matrix was still expanded via the "old_bazel" attributes, leading to duplicated tasks:

- https://buildkite.com/bazel/bcr-bazel-compatibility-test/builds/22#0192d96c-70d2-4057-a659-c9944b421a0b
- https://buildkite.com/bazel/bcr-bazel-compatibility-test/builds/22#0192d96c-70dc-458b-bd72-637d99898ac5

This PR flattens bazel versions in the matrix to a single string to avoid that while still keeping a nice warning message like
```
Bazel version overridden from 6.x, 7.x to 8.0.0rc2
```