### PR TITLE
chore: link buildkite/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-See https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/README.md
+buildkite/README.md


### PR DESCRIPTION
Replace the root `README.md` with a symlink to `buildkite/README.md` since all it contained was a link to it anyway.