### PR TITLE
Generate rules_java release notes with local genrule execution

### DIFF
--- a/pipelines/rules_java-release.yml
+++ b/pipelines/rules_java-release.yml
@@ -40,7 +40,7 @@ steps:
       bazel build //distro:rules_java-\${version}
 
       echo "+++ Preparing release notes"
-      bazel build //distro:relnotes
+      bazel build --genrule_strategy=local //distro:relnotes
 
       echo "+++ Downloading github-release"
       curl -L https://mirror.bazel.build/github.com/c4milo/github-release/releases/download/v1.1.0/github-release_v1.1.0_linux_amd64.tar.gz | sudo tar xz -C /usr/local/bin


### PR DESCRIPTION
With an upcoming release, the rules_pkg utility is no longer suitable, and we will be using a genrule that needs to execute a git command that won't work inside a sandbox.