### PR TITLE
Don't modify the environment when executing a CI command

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2645,7 +2645,6 @@ def execute_command(
         args,
         shell=shell,
         check=fail_if_nonzero,
-        env=os.environ,
         cwd=cwd,
         errors="replace",
         stdout=(


### PR DESCRIPTION
`os.environ` does not contain certain special environment variables on Windows (e.g. `=C:`) that are present when executing from `cmd.exe`.