### PR TITLE
Revert "Upgrade agent to 0.2.3 (#2124)"

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1609,7 +1609,7 @@ def download_bazelci_agent(dest_dir):
     repo = "bazelbuild/continuous-integration"
     if THIS_IS_TESTING and "BAZELCI_AGENT_REPO" in os.environ:
         repo = os.environ["BAZELCI_AGENT_REPO"]
-    version = "0.2.3"
+    version = "0.2.2"
     if THIS_IS_TESTING and "BAZELCI_AGENT_VERSION" in os.environ:
         version = os.environ["BAZELCI_AGENT_VERSION"]
     postfix = ""


### PR DESCRIPTION
This reverts commit a086a7a3240d11cc288b310e953cca91b1a3a99e.

Bad release: https://github.com/bazelbuild/continuous-integration/pull/2117#issuecomment-2504300375