### PR TITLE
Fix rules_java release pipeline config

### DIFF
--- a/pipelines/rules_java-release.yml
+++ b/pipelines/rules_java-release.yml
@@ -28,7 +28,7 @@ steps:
     command: | 
       echo "+++ Checking out Git branch"
       git fetch origin ${BUILDKITE_BRANCH}
-      git checkout ${BUILDKITE_BRANCH}
+      git checkout ${BUILDKITE_COMMIT}
 
       echo "+++ Getting the latest rules_java version"
       contents=$(cat MODULE.bazel)
@@ -53,4 +53,4 @@ steps:
       echo "+++ Creating a release on GitHub"
       cd bazel-bin/distro
       relnotes=$(cat relnotes.txt)
-      GITHUB_TOKEN=\${github_token} github-release "bazelbuild/rules_java" \${version} "\${BUILDKITE_BRANCH}" "\${relnotes}" rules_java-\${version}.tar.gz      
+      GITHUB_TOKEN=\${github_token} github-release "bazelbuild/rules_java" \${version} "\${BUILDKITE_COMMIT}" "\${relnotes}" rules_java-\${version}.tar.gz      


### PR DESCRIPTION
This enables making releases at specific points even if the branch has moved ahead.

Before this change, the release would always be made at the HEAD of chosen branch, we should instead to do so at the specific commit that the workflow is executed on.