### PR TITLE
Specify value to --toolchain_resolution_debug

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1923,7 +1923,7 @@ def rbe_flags(original_flags, accept_cached):
         "--remote_timeout=3600",
         "--incompatible_strict_action_env",
         "--google_default_credentials",
-        "--toolchain_resolution_debug",
+        "--toolchain_resolution_debug=.*",
         "--remote_download_toplevel",
     ]
 


### PR DESCRIPTION
[2d25d7fa86666b6e33e65f8a3e27241c88ab36cc](https://github.com/bazelbuild/bazel/commit/2d25d7fa86666b6e33e65f8a3e27241c88ab36cc) made this an error, so since the Bazel 8 release all RBE builds have been failing.