### PR TITLE
Re-enable buildtools on the CI

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -141,7 +141,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     "Buildtools": {
         "git_repository": "https://github.com/bazelbuild/buildtools.git",
         "pipeline_slug": "buildtools",
-        "disabled_reason": "https://github.com/bazelbuild/buildtools/issues/1297, https://github.com/bazelbuild/buildtools/issues/1300, https://github.com/bazelbuild/buildtools/issues/1314",
     },
     "CLion Plugin": {
         "git_repository": "https://github.com/bazelbuild/intellij.git",


### PR DESCRIPTION
Rollback of #2143

The tests now pass on the CI, also with `.bazelversion` = `last_green`.