### PR TITLE
Refactor CI scripts to better support reproducing bcr_presubmit locally

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -46,7 +46,7 @@ import yaml
 # Initialize the random number generator.
 random.seed()
 
-BUILDKITE_ORG = os.environ["BUILDKITE_ORGANIZATION_SLUG"]
+BUILDKITE_ORG = os.environ.get("BUILDKITE_ORGANIZATION_SLUG", "bazel")
 THIS_IS_PRODUCTION = BUILDKITE_ORG == "bazel"
 THIS_IS_TESTING = BUILDKITE_ORG == "bazel-testing"
 THIS_IS_TRUSTED = BUILDKITE_ORG == "bazel-trusted"


### PR DESCRIPTION
- Default BUILDKITE_ORG to bazel
- Allow overriding repo root for `create_anonymous_repo` and `prepare_test_module_repo`
- Allow suppressing log for `prepare_test_module_repo`
- Use `--enable_bzlmod` instead of `--experimental_enable_bzlmod` since Bazel 5 is now dropped.