### PR TITLE
Enabling rules_android CI

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -207,8 +207,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/rules_android.git",
         "pipeline_slug": "rules-android",
         "owned_by_bazel": True,
-        "disabled_reason": "https://github.com/bazelbuild/rules_android/issues/261, https://github.com/bazelbuild/rules_android/issues/266, https://github.com/bazelbuild/rules_android/issues/328"
-    },
+        },
     "rules_android_ndk": {
         "git_repository": "https://github.com/bazelbuild/rules_android_ndk.git",
         "pipeline_slug": "rules-android-ndk",


### PR DESCRIPTION
Enabling rules_android CI in Downstream as it is Green in Disabled pipeline https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/2299