### PR TITLE
Remove "wait" before the "build and publish" step

### DIFF
--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -509,6 +509,9 @@ steps:
       cd scripts/release
       python3 relnotes.py
 
+  - wait: ~
+    continue_on_failure: true
+  
   - block: "Build and publish"
     if: build.branch !~ /pre/i  
 

--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -509,8 +509,6 @@ steps:
       cd scripts/release
       python3 relnotes.py
 
-  - wait
-
   - block: "Build and publish"
     if: build.branch !~ /pre/i  
 


### PR DESCRIPTION
We've been seeing some issues with the release notes script lately that need to be fixed. These failures block the pipeline and stop us from moving forward to the (unrelated / unaffected) "build and publish" steps.