### PR TITLE
BCR PR reviewer: trim for skip_check

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -457,7 +457,7 @@ async function runSkipCheck(octokit) {
   const check = payload.comment.body.slice(SKIP_CHECK_TRIGGER.length);
   const owner = payload.repository.owner.login;
   const repo = payload.repository.name;
-  if (check == "unstable_url") {
+  if (check.trim() == "unstable_url") {
     await octokit.rest.issues.addLabels({
       owner,
       repo,


### PR DESCRIPTION
Sometimes people post a comment like `@bazel-io skip_check unstable_url\n` (with an actual newline at the end). This PR makes that work too.