### PR TITLE
bcr_pr_reviewer: set merge_method to squash

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -303,6 +303,7 @@ async function reviewPR(octokit, owner, repo, prNumber) {
         owner,
         repo,
         pull_number: prNumber,
+        merge_method: 'squash',
       });
 
       // Add auto-merged label


### PR DESCRIPTION
To avoid 
```
Failed to merge PR: Merge commits are not allowed on this repository. - https://docs.github.com/rest/pulls/pulls#merge-a-pull-request
```