### PR TITLE
Changed the flags in anonymous repos' `.bazelrc` to common so they apply to all bazel commands.

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -168,9 +168,8 @@ def create_anonymous_repo(module_name, module_version, root=None):
     scratch_file(root, "BUILD")
     scratch_file(root, "MODULE.bazel", ["bazel_dep(name = '%s', version = '%s')" % (module_name, module_version)])
     scratch_file(root, ".bazelrc", [
-        "build --enable_bzlmod",
-        "build --registry=%s" % BCR_REPO_DIR.as_uri(),
-        "query --registry=%s" % BCR_REPO_DIR.as_uri(),
+        "common --enable_bzlmod",
+        "common --registry=%s" % BCR_REPO_DIR.as_uri(),
     ])
     return root
 

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -170,6 +170,7 @@ def create_anonymous_repo(module_name, module_version, root=None):
     scratch_file(root, ".bazelrc", [
         "build --enable_bzlmod",
         "build --registry=%s" % BCR_REPO_DIR.as_uri(),
+        "query --registry=%s" % BCR_REPO_DIR.as_uri(),
     ])
     return root
 


### PR DESCRIPTION
When creating [anonymous test repos](https://github.com/bazelbuild/bazel-central-registry/blob/00b9bfe8053208dc8983378ac3749f8d0fa1c3be/docs/README.md#reproduce-presubmit-builds-locally) for testing BCR changes, it's useful to sometimes do `bazel query` to verify available targets.