### PR TITLE
fix regular expression in python source `bazelci.py`

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -831,7 +831,7 @@ def gcloud_command():
 
 
 def match_matrix_attr_pattern(s):
-    return re.match("^\${{\s*(\w+)\s*}}$", s)
+    return re.match(r"^\${{\s*(\w+)\s*}}$", s)
 
 
 def get_matrix_attributes(task):


### PR DESCRIPTION
The code;

```
return re.match("^\${{\s*(\w+)\s*}}$", s)
```

Appears to cause a [warning](https://buildkite.com/bazel/clion-plugin/builds/24866#01953779-eb82-4f1d-b7bb-ee19e6c4fab3) in the building of the C-Lion Intelli-J / Bazel plugin;

```
/Users/buildkite/builds/bk-macos-arm64-3wgt/bazel/clion-plugin/bazelci.py:834: SyntaxWarning: invalid escape sequence '\$'
  return re.match("^\${{\s*(\w+)\s*}}$", s)
```

It looks like the string should be a raw string. Note that this change has not been tested.