### PR TITLE
Add a flag to specify the JDK version to package with Bazel when building the container image

### DIFF
--- a/bazel/oci/Dockerfile
+++ b/bazel/oci/Dockerfile
@@ -3,6 +3,8 @@
 
 FROM ubuntu:20.04 AS base_image
 
+ARG JAVA_VERSION
+
 RUN --mount=source=bazel/oci/install_packages.sh,target=/mnt/install_packages.sh,type=bind \
     /mnt/install_packages.sh
 

--- a/bazel/oci/README.md
+++ b/bazel/oci/README.md
@@ -9,6 +9,15 @@ To build and publish docker container for new Bazel LTS release to `gcr.io/bazel
 $ ./build.sh gcr.io/bazel-public/bazel <bazel version>
 ```
 
+Note: this installs the Java 8 JDK on the docker container image. To build an image with a more recent JDK version, 
+specify the package name of the JDK to install as the third argument, for instance:
+
+```bash
+  $ ./build.sh gcr.io/bazel-public/bazel <bazel version> openjdk-21-jdk
+```
+
+This will append the JDK version to the tag of the Bazel container image.
+
 ### 2. Push the docker container to `gcr.io/bazel-public/bazel`
 ```bash
 $ docker push gcr.io/bazel-public/bazel:<bazel version>

--- a/bazel/oci/build.sh
+++ b/bazel/oci/build.sh
@@ -2,6 +2,8 @@
 
 readonly OCI_REPOSITORY=$1
 readonly BAZEL_VERSION=$2
+JAVA_VERSION=$3
+TAG=$BAZEL_VERSION-$JAVA_VERSION
 
 set -o errexit -o nounset -o pipefail
 
@@ -21,6 +23,10 @@ if [ -z "${BAZEL_VERSION}" ]; then
     exit 1
 fi
 
+if [ -z "$JAVA_VERSION" ]; then
+  JAVA_VERSION="openjdk-8-jdk"
+fi
+
 GIT_ROOT=$(git rev-parse --show-toplevel)
 readonly GIT_ROOT
 
@@ -30,6 +36,6 @@ fi
 
 docker ${buildx:+"${buildx}"} build \
     --file "${GIT_ROOT}/bazel/oci/Dockerfile" \
-    --tag "${OCI_REPOSITORY}:${BAZEL_VERSION}" \
-    --build-arg BAZEL_VERSION="${BAZEL_VERSION}" \
+    --tag "${OCI_REPOSITORY}:${TAG}" \
+    --build-arg BAZEL_VERSION="${BAZEL_VERSION}" --build-arg JAVA_VERSION="${JAVA_VERSION}"\
     "${GIT_ROOT}"

--- a/bazel/oci/install_packages.sh
+++ b/bazel/oci/install_packages.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "Using Java version: $JAVA_VERSION"
+
 set -o errexit -o nounset -o pipefail
 
 apt-get update
@@ -11,7 +13,7 @@ apt-get install --yes \
     build-essential \
     curl \
     git \
-    openjdk-8-jdk \
+    "$JAVA_VERSION" \
     python3 \
     python3-pip \
     unzip \


### PR DESCRIPTION
The current build script includes the Java 8 JDK but rules_jvm_external extension requires Java 11 (https://github.com/bazel-contrib/rules_jvm_external/releases/tag/6.7). 