### PR TITLE
Update slack.bazel.build

### DIFF
--- a/slack-bazel-build/docker/nginx.conf
+++ b/slack-bazel-build/docker/nginx.conf
@@ -18,7 +18,7 @@ http {
         listen      ${PORT};
         server_name slack.bazel.build;
 
-        return 301 https://join.slack.com/t/bazelbuild/shared_invite/zt-2zmd6zz00-Ed4ec3lXHTT9ggLB25GGYA;
+        return 301 https://join.slack.com/t/bazelbuild/shared_invite/zt-321q3yhg1-sveGam~7JEr1AoBAOwPynA;
 
         error_page   500 502 503 504  /50x.html;
         location = /50x.html {


### PR DESCRIPTION
Each link will expire after 400 people used it.