### PR TITLE
Enabling CLion Plugin & IntelliJ Plugin Aspect in Downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -148,7 +148,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/intellij.git",
         "file_config": ".bazelci/clion.yml",
         "pipeline_slug": "clion-plugin",
-        "disabled_reason": "https://github.com/bazelbuild/intellij/issues/7232#issuecomment-2617127267",
     },
     "CLion Plugin Google": {
         "git_repository": "https://github.com/bazelbuild/intellij.git",
@@ -192,7 +191,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/intellij.git",
         "file_config": ".bazelci/aspect.yml",
         "pipeline_slug": "intellij-plugin-aspect",
-        "disabled_reason": "https://github.com/bazelbuild/intellij/issues/7232#issuecomment-2617127267",
     },
     "IntelliJ Plugin Aspect Google": {
         "git_repository": "https://github.com/bazelbuild/intellij.git",


### PR DESCRIPTION
Enabling below projects as they are green in Disabled [CI](https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/2351)

1.  [CLion Plugin](https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/2351#0195b25f-7866-4ff4-94af-d2079a27b95f)
2.  [IntelliJ Plugin Aspect](https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/2351#0195b25f-8bbf-452d-a606-617bad3a3b17)

CC Greenteam @Wyverald @mai93