### PR TITLE
Fix single quote escape

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2914,7 +2914,7 @@ def print_project_pipeline(
         pipeline_steps.append(step)
 
     if skipped_downstream_tasks:
-        lines = ["\n- {}".format(s) for s in skipped_downstream_tasks]
+        lines = ["\n- {}".format(s.replace("'", "'\\''")) for s in skipped_downstream_tasks]
         commands = [
             "buildkite-agent meta-data exists 'has-skipped-annotation' || buildkite-agent annotate --style=info 'The following tasks were skipped:\n' --context 'ctx-skipped_downstream_tasks'",
             "buildkite-agent meta-data set 'has-skipped-annotation' 'true'",


### PR DESCRIPTION
Fixes https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/4575#0195f9de-1798-489e-85c3-04ede11483ef

where the single quote in `doesn't` was causing problem.