### PR TITLE
Incompatible flag test: Make the job fail if not all incompatible flags pass

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1756,10 +1756,7 @@ def execute_shell_commands(
 
 def handle_bazel_failure(exception, action):
     msg = "bazel {0} failed with exit code {1}".format(action, exception.returncode)
-    if use_bazelisk_migrate():
-        print_collapsed_group(msg)
-    else:
-        raise BuildkiteException(msg)
+    raise BuildkiteException(msg)
 
 
 def execute_bazel_run(bazel_binary, platform, targets):


### PR DESCRIPTION
https://buildkite.com/bazel/bcr-bazel-compatibility-test/builds/347#_

The all green state for incompatible flag test build might be confusing. Only leave the job state green when all incompatible flags pass.