### PR TITLE
BCR Presubmit: support testing incompatible flags

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -542,6 +542,19 @@ async function runSkipCheck(octokit) {
       comment_id: payload.comment.id,
       content: '+1',
     });
+  } else if (check.trim() == "incompatible_flags") {
+    await octokit.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number: payload.issue.number,
+      labels: ["skip-incompatible-flags-test"],
+    });
+    await octokit.rest.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: payload.comment.id,
+      content: '+1',
+    });
   } else {
     await octokit.rest.reactions.createForIssueComment({
       owner,

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -319,7 +319,7 @@ def run_test(repo_location, task_config_file, task, overwrite_bazel_version=None
             "\n\x1b[31mERROR\x1b[0m: BCR presubmit failed with incompatible flags.\n"
             "Please consider migrate your project for the incompatible flags.\n"
             "You can bypass this test by commenting '@bazel-io skip_check incompatible_flags' in the PR or override the list of flags in your presubmit.yml file.\n"
-            "See more details at <doc link>"
+            "See more details at https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/README.md#testing-incompatible-flags"
             )
         return return_code
     except subprocess.CalledProcessError as e:

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -490,7 +490,7 @@ def fetch_incompatible_flags(module_name, module_version):
 
 
 def maybe_enable_bazelisk_migrate(module_name, module_version):
-    bazelci.print_collapsed_group(":information_source: Set up env vars for incompatible flags test if enabled.")
+    bazelci.print_collapsed_group(":triangular_flag_on_post: Set up env vars for incompatible flags test if enabled.")
     pr_labels = get_labels_from_pr()
     if "skip-incompatible-flags-test" in pr_labels:
         bazelci.eprint("Skipping incompatible flags test as 'skip-incompatible-flags-test' label is attached to this PR.")

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -485,7 +485,8 @@ def get_bazel_version_for_task(config_file, task, overwrite_bazel_version=None):
         return overwrite_bazel_version
     configs = bazelci.fetch_configs(None, config_file)
     task_config = configs.get("tasks", {}).get(task, {})
-    bazelci.eprint(task_config)
+    bazelci.eprint(f"Task config for '{task}':")
+    bazelci.eprint(yaml.dump(task_config, default_flow_style=False))
     bazel_version = task_config.get("bazel", "latest")
     return bazel_version
 

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -501,7 +501,7 @@ def maybe_enable_bazelisk_migrate(module_name, module_version):
         bazelci.eprint("No incompatible flags found.")
         return
 
-    os.environ["USE_BAZELISK_MIGRATE"] = 1
+    os.environ["USE_BAZELISK_MIGRATE"] = "1"
     os.environ["INCOMPATIBLE_FLAGS"] = ",".join(incompatible_flags)
     bazelci.eprint(f"USE_BAZELISK_MIGRATE is set to {os.environ['USE_BAZELISK_MIGRATE']}")
     bazelci.eprint(f"INCOMPATIBLE_FLAGS are set to {os.environ['INCOMPATIBLE_FLAGS']}")

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -314,7 +314,7 @@ def run_test(repo_location, task_config_file, task, overwrite_bazel_version=None
                 "--repo_location=%s" % repo_location,
             ] + (["--overwrite_bazel_version=%s" % overwrite_bazel_version] if overwrite_bazel_version else [])
         )
-        if return_code == 73 and os.environ.get("USE_BAZELISK_MIGRATE"):
+        if return_code == 73 and os.environ.get("ENABLE_BAZELISK_MIGRATE"):
             bazelci.eprint(
             "\n\x1b[31mERROR\x1b[0m: BCR presubmit failed with incompatible flags.\n"
             "Please consider migrate your project for the incompatible flags.\n"

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -490,7 +490,7 @@ def fetch_incompatible_flags(module_name, module_version):
 
 
 def maybe_enable_bazelisk_migrate(module_name, module_version):
-    bazelci.print_collapsed_group(":triangular_flag_on_post: Set up env vars for incompatible flags test if enabled.")
+    bazelci.print_collapsed_group(":triangular_flag_on_post: Set up env vars for incompatible flags test if enabled")
     pr_labels = get_labels_from_pr()
     if "skip-incompatible-flags-test" in pr_labels:
         bazelci.eprint("Skipping incompatible flags test as 'skip-incompatible-flags-test' label is attached to this PR.")

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -511,7 +511,7 @@ def fetch_incompatible_flags(module_name, module_version, bazel_version):
 
 def maybe_enable_bazelisk_migrate(module_name, module_version, overwrite_bazel_version, task, config_file):
     # Only try to set up bazelisk --migrate when ENABLE_BAZELISK_MIGRATE is specified.
-    if os.environ.get("ENABLE_BAZELISK_MIGRATE"):
+    if not os.environ.get("ENABLE_BAZELISK_MIGRATE"):
         return
 
     bazelci.print_collapsed_group(":triangular_flag_on_post: Set up env vars for incompatible flags test if enabled")

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -314,7 +314,7 @@ def run_test(repo_location, task_config_file, task, overwrite_bazel_version=None
                 "--repo_location=%s" % repo_location,
             ] + (["--overwrite_bazel_version=%s" % overwrite_bazel_version] if overwrite_bazel_version else [])
         )
-        if return_code != 0 and os.environ.get("USE_BAZELISK_MIGRATE"):
+        if return_code == 73 and os.environ.get("USE_BAZELISK_MIGRATE"):
             bazelci.eprint(
             "\n\x1b[31mERROR\x1b[0m: BCR presubmit failed with incompatible flags.\n"
             "Please consider migrate your project for the incompatible flags.\n"
@@ -520,6 +520,7 @@ def fetch_incompatible_flags(module_name, module_version, bazel_version):
 
 def maybe_enable_bazelisk_migrate(module_name, module_version, overwrite_bazel_version, task, config_file):
     # Only try to set up bazelisk --migrate when ENABLE_BAZELISK_MIGRATE is specified.
+    # ENABLE_BAZELISK_MIGRATE should be set for the BCR presubmit pipeline but not for the BCR compatibility test pipeline, which also depends on bcr_presubmit.py
     if not os.environ.get("ENABLE_BAZELISK_MIGRATE"):
         return
 

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -317,7 +317,7 @@ def run_test(repo_location, task_config_file, task, overwrite_bazel_version=None
         if return_code == 73 and os.environ.get("ENABLE_BAZELISK_MIGRATE"):
             bazelci.eprint(
             "\n\x1b[31mERROR\x1b[0m: BCR presubmit failed with incompatible flags.\n"
-            "Please consider migrate your project for the incompatible flags.\n"
+            "Please consider migrating your project for the incompatible flags.\n"
             "You can bypass this test by commenting '@bazel-io skip_check incompatible_flags' in the PR or override the list of flags in your presubmit.yml file.\n"
             "See more details at https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/README.md#testing-incompatible-flags"
             )

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -316,8 +316,10 @@ def run_test(repo_location, task_config_file, task, overwrite_bazel_version=None
         )
         if return_code != 0 and os.environ.get("USE_BAZELISK_MIGRATE"):
             bazelci.eprint(
-            "\x1b[31mERROR\x1b[0m: BCR presubmit failed with incompatible flags. "
-            "If this is expected, please leave a comment '@bazel-io skip_check incompatible_flags' in the PR to bypass the test."
+            "\n\x1b[31mERROR\x1b[0m: BCR presubmit failed with incompatible flags.\n"
+            "Please consider migrate your project for the incompatible flags.\n"
+            "You can bypass this test by commenting '@bazel-io skip_check incompatible_flags' in the PR or override the list of flags in your presubmit.yml file.\n"
+            "See more details at <doc link>"
             )
         return return_code
     except subprocess.CalledProcessError as e:

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -580,11 +580,11 @@ def main(argv=None):
     elif args.subparsers_name == "anonymous_module_runner":
         repo_location = create_anonymous_repo(args.module_name, args.module_version)
         config_file = get_presubmit_yml(args.module_name, args.module_version)
-        maybe_enable_bazelisk_migrate(module_name, module_version)
+        maybe_enable_bazelisk_migrate(args.module_name, args.module_version)
         return run_test(repo_location, config_file, args.task, args.overwrite_bazel_version)
     elif args.subparsers_name == "test_module_runner":
         repo_location, config_file = prepare_test_module_repo(args.module_name, args.module_version, args.overwrite_bazel_version)
-        maybe_enable_bazelisk_migrate(module_name, module_version)
+        maybe_enable_bazelisk_migrate(args.module_name, args.module_version)
         return run_test(repo_location, config_file, args.task, args.overwrite_bazel_version)
     else:
         parser.print_help()

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -521,7 +521,7 @@ def maybe_enable_bazelisk_migrate(module_name, module_version, bazel_version):
 
     incompatible_flags = fetch_incompatible_flags(module_name, module_version, bazel_version)
     if not incompatible_flags:
-        bazelci.eprint("No incompatible flags found.")
+        bazelci.eprint(f"No incompatible flags found for Bazel version {bazel_version}.")
         return
 
     os.environ["USE_BAZELISK_MIGRATE"] = "1"

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -306,7 +306,7 @@ def prepare_test_module_repo(module_name, module_version, overwrite_bazel_versio
 
 def run_test(repo_location, task_config_file, task, overwrite_bazel_version=None):
     try:
-        return bazelci.main(
+        return_code = bazelci.main(
             [
                 "runner",
                 "--task=" + task,
@@ -314,6 +314,12 @@ def run_test(repo_location, task_config_file, task, overwrite_bazel_version=None
                 "--repo_location=%s" % repo_location,
             ] + (["--overwrite_bazel_version=%s" % overwrite_bazel_version] if overwrite_bazel_version else [])
         )
+        if return_code != 0 and os.environ.get("USE_BAZELISK_MIGRATE"):
+            bazelci.eprint(
+            "\x1b[31mERROR\x1b[0m: BCR presubmit failed with incompatible flags. "
+            "If this is expected, please leave a comment '@bazel-io skip_check incompatible_flags' in the PR to bypass the test."
+            )
+        return return_code
     except subprocess.CalledProcessError as e:
         bazelci.eprint(str(e))
         return 1

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3437,7 +3437,7 @@ def fetch_incompatible_flags():
     """
     Return a list of incompatible flags to be tested. The key is the flag name and the value is its Github URL.
     """
-    # If INCOMPATIBLE_FLAGS is set manually, we test those flags, try to keep the URL info if possible.
+    # If INCOMPATIBLE_FLAGS is set manually, we test those flags, leave the issue URL as "Unknown".
     if "INCOMPATIBLE_FLAGS" in os.environ:
         given_incompatible_flags = {}
         for flag in os.environ["INCOMPATIBLE_FLAGS"].split(","):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1102,11 +1102,6 @@ def execute_commands(
     bazel_version=None,
 ):
     if use_bazelisk_migrate():
-        # If we are testing incompatible flags with Bazelisk,
-        # use Bazel@last_green if USE_BAZEL_VERSION env var is not set explicitly.
-        if "USE_BAZEL_VERSION" not in os.environ:
-            bazel_version = "last_green"
-
         # Override use_but in case we are in the downstream pipeline so that it doesn't try to
         # download Bazel built from previous jobs.
         use_but = False

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -54,7 +54,7 @@ THIS_IS_SPARTA = True
 
 CLOUD_PROJECT = "bazel-public" if THIS_IS_TRUSTED else "bazel-untrusted"
 
-GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "pcloudy-bcr-test"}[
+GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "testing"}[
     BUILDKITE_ORG
 ]
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -54,7 +54,7 @@ THIS_IS_SPARTA = True
 
 CLOUD_PROJECT = "bazel-public" if THIS_IS_TRUSTED else "bazel-untrusted"
 
-GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "testing"}[
+GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "pcloudy-bcr-test"}[
     BUILDKITE_ORG
 ]
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -504,7 +504,9 @@ class BuildkiteException(Exception):
     Raised whenever something goes wrong and we should exit with an error.
     """
 
-    pass
+    def __init__(self, message, exit_code=1):
+        super().__init__(message)
+        self.exit_code = exit_code
 
 
 class BuildkiteInfraException(Exception):
@@ -1751,7 +1753,7 @@ def execute_shell_commands(
 
 def handle_bazel_failure(exception, action):
     msg = "bazel {0} failed with exit code {1}".format(action, exception.returncode)
-    raise BuildkiteException(msg)
+    raise BuildkiteException(msg, exit_code=exception.returncode)
 
 
 def execute_bazel_run(bazel_binary, platform, targets):
@@ -4513,7 +4515,7 @@ def main(argv=None):
             return 2
     except BuildkiteException as e:
         eprint(str(e))
-        return 1
+        return e.exit_code
     return 0
 
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3442,6 +3442,13 @@ def fetch_incompatible_flags():
     """
     Return a list of incompatible flags to be tested. The key is the flag name and the value is its Github URL.
     """
+    # If INCOMPATIBLE_FLAGS is set manually, we test those flags, try to keep the URL info if possible.
+    if "INCOMPATIBLE_FLAGS" in os.environ:
+        given_incompatible_flags = {}
+        for flag in os.environ["INCOMPATIBLE_FLAGS"].split(","):
+            given_incompatible_flags[flag] = "Unknown"
+        return given_incompatible_flags
+
     output = subprocess.check_output(
         [
             # Query for open issues with "incompatible-change" and "migration-ready" label.
@@ -3464,13 +3471,6 @@ def fetch_incompatible_flags():
                 f"{name} is not recognized as an incompatible flag, please modify the issue title "
                 f'of {url} to "<incompatible flag name (without --)>:..."'
             )
-
-    # If INCOMPATIBLE_FLAGS is set manually, we test those flags, try to keep the URL info if possible.
-    if "INCOMPATIBLE_FLAGS" in os.environ:
-        given_incompatible_flags = {}
-        for flag in os.environ["INCOMPATIBLE_FLAGS"].split(","):
-            given_incompatible_flags[flag] = incompatible_flags.get(flag, "")
-        return given_incompatible_flags
 
     return incompatible_flags
 


### PR DESCRIPTION
- Set `ENABLE_BAZELISK_MIGRATE` to `1` to enable this feature for BCR presubmit
- Once enabled, the BCR presubmit will try to fetch incompatible flags from the `incompatible_flags.yml` file in the BCR root or `presubmit.yml` of the module.
- Then the script set up env vars to enable bazelisk's [--migrate](https://github.com/bazelbuild/bazelisk?tab=readme-ov-file#--migrate) feature to test those incompatible flags. A Bazelisk improvement is needed at https://github.com/bazelbuild/bazelisk/pull/678.
- The incompatible flag tests can be skipped by applying `skip-incompatible-flags-test` flag to the BCR PR, which can be triggered by anyone with comment `@bazel-io skip_check incompatible_flags`.

In the `incompatible_flags.yml` or `presubmit.yml` file, incompatible flags can be specified in the following format:
```
incompatible_flags:
  "--incompatible_config_setting_private_default_visibility":
    - 6.x
    - 7.x
    - 8.x
  "--incompatible_disable_native_repo_rules":
    - 7.x
    - 8.x
  "--incompatible_autoload_externally=":
    - 7.x
    - 8.x
  "--incompatible_disable_autoloads_in_main_repo":
    - last_green
    - rolling
```