### PR TITLE
Enable containerd image store for Docker

### DIFF
--- a/buildkite/setup-docker.sh
+++ b/buildkite/setup-docker.sh
@@ -119,6 +119,14 @@ EOF
 SocketMode=0666
 EOF
 
+  cat > /etc/docker/daemon.json <<'EOF'
+{
+  "features": {
+    "containerd-snapshotter": true
+  }
+}
+EOF
+
   # Disable the Docker service, as the startup script has to mount /var/lib/docker first.
   systemctl disable docker
   systemctl stop docker
@@ -211,6 +219,7 @@ EOF
 
 ### Configure and start Docker.
 systemctl start docker
+docker info -f '{{ .DriverStatus }}'
 
 ### Ensure that Docker images can be downloaded from GCR.
 gcloud auth configure-docker --quiet


### PR DESCRIPTION
We need this feature to build multi-platform Docker images.

Tested in QA: https://buildkite.com/bazel-testing/bazel-bazel/builds/8650