### PR TITLE
Add support for Linux ARM64 workers

### DIFF
--- a/buildkite/create_images.py
+++ b/buildkite/create_images.py
@@ -23,6 +23,8 @@ import gcloud
 import gcloud_utils
 
 DEBUG = False
+DEFAULT_MACHINE_TYPE = "c2-standard-8"
+DEFAULT_BOOT_DISK_TYPE = "pd-ssd"
 
 IMAGE_CREATION_VMS = {
     "bk-testing-docker": {
@@ -35,6 +37,19 @@ IMAGE_CREATION_VMS = {
         "licenses": [
             "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
         ],
+    },
+    "bk-testing-docker-arm64": {
+        "project": "bazel-public",
+        "zone": "us-central1-c",
+        "source_image_project": "ubuntu-os-cloud",
+        "source_image_family": "ubuntu-2004-lts-arm64",
+        "setup_script": "setup-docker.sh",
+        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE"],
+        "licenses": [
+            "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
+        ],
+        "machine_type": "c4a-standard-8-lssd",
+        "boot_disk_type": "hyperdisk-balanced",
     },
     "bk-testing-windows": {
         "project": "bazel-public",
@@ -92,10 +107,10 @@ def create_instance(instance_name, params):
             instance_name,
             project=params["project"],
             zone=params["zone"],
-            machine_type="c2-standard-8",
+            machine_type=params.get("machine_type", DEFAULT_MACHINE_TYPE),
             network=params.get("network", "default"),
             metadata_from_file=startup_script,
-            boot_disk_type="pd-ssd",
+            boot_disk_type=params.get("boot_disk_type", DEFAULT_BOOT_DISK_TYPE),
             boot_disk_size=params.get("boot_disk_size", "500GB"),
             **image,
         )
@@ -144,7 +159,10 @@ def main(argv=None):
         print("Usage: create_images.py {}".format(" ".join(IMAGE_CREATION_VMS.keys())))
         return 1
 
-    unknown_args = set(argv).difference(IMAGE_CREATION_VMS.keys())
+    # Handle multiple args as well as a single-arg comma-delimited list.
+    names = argv if len(argv) > 1 else argv[0].split(",")
+
+    unknown_args = set(names).difference(IMAGE_CREATION_VMS.keys())
     if unknown_args:
         print(
             "Unknown platforms: {}\nAvailable platforms: {}".format(
@@ -153,11 +171,8 @@ def main(argv=None):
         )
         return 1
 
-    if len(argv) > 1:
-        print("Only one platform can be created at a time.")
-        return 1
-
-    workflow(argv[0], IMAGE_CREATION_VMS[argv[0]])
+    for n in names:
+        workflow(n, IMAGE_CREATION_VMS[n])
 
     return 0
 

--- a/buildkite/create_instances.py
+++ b/buildkite/create_instances.py
@@ -113,16 +113,19 @@ def main(argv=None):
     )
 
     args = parser.parse_args(argv)
+    # Handle multiple args as well as a single-arg comma-delimited list.
+    names = args.names if len(args.names) > 1 else args.names[0].split(",")
+
     config = read_config_file()
 
     # Verify names passed on the command-line.
     valid_names = [item["name"] for item in config["instance_groups"]]
-    for name in args.names:
+    for name in names:
         if name not in valid_names:
             print("Unknown instance name: {}!".format(name))
             print("\nValid instance names are: {}".format(" ".join(valid_names)))
             return 1
-    if not args.names:
+    if not names:
         parser.print_help()
         print("\nValid instance names are: {}".format(" ".join(valid_names)))
         return 1

--- a/buildkite/docker/push.sh
+++ b/buildkite/docker/push.sh
@@ -15,10 +15,6 @@ case $(git symbolic-ref --short HEAD) in
 esac
 
 # Containers used by Bazel CI
-# docker push "gcr.io/$PREFIX/centos7" &
-# docker push "gcr.io/$PREFIX/centos7-java11" &
-# docker push "gcr.io/$PREFIX/centos7-java11-devtoolset10" &
-# docker push "gcr.io/$PREFIX/centos7-releaser" &
 docker push "gcr.io/$PREFIX/debian10-java11" &
 docker push "gcr.io/$PREFIX/debian11-java17" &
 docker push "gcr.io/$PREFIX/ubuntu1804-bazel-java11" &

--- a/buildkite/docker/ubuntu2004/Dockerfile
+++ b/buildkite/docker/ubuntu2004/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04 AS ubuntu2004-bazel-nojdk
-ARG BUILDARCH
+ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV LANG "C.UTF-8"
@@ -58,10 +58,11 @@ RUN apt-get -y update && \
 # Workaround https://bugs.launchpad.net/ubuntu/+source/gcc-9/+bug/2029910
 # TODO: remove when the latest ubuntu:20.04 image has the fix.
 WORKDIR /tempdir
-RUN apt-get -y update && apt-get download libgcc-10-dev
-RUN dpkg -x libgcc-10-dev_10.5.0-1ubuntu1~20.04_amd64.deb .
-RUN cp usr/lib/gcc/x86_64-linux-gnu/10/libtsan_preinit.o /usr/lib/gcc/x86_64-linux-gnu/9/
-RUN rm -rf /tempdir
+RUN ARCH="$(uname -m)" && \
+    apt-get -y update && apt-get download libgcc-10-dev && \
+    dpkg -x "libgcc-10-dev_10.5.0-1ubuntu1~20.04_${TARGETARCH}.deb" . && \
+    cp "usr/lib/gcc/${ARCH}-linux-gnu/10/libtsan_preinit.o" "/usr/lib/gcc/${ARCH}-linux-gnu/9/" && \
+    rm -rf /tempdir
 WORKDIR /
 
 # Allow using sudo inside the container.
@@ -83,20 +84,20 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 RUN apt-get -y update && \
     apt-get -y install apt-transport-https ca-certificates && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=$BUILDARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    add-apt-repository "deb [arch=$TARGETARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-get -y update && \
     apt-get -y install docker-ce && \
     rm -rf /var/lib/apt/lists/*
 
 # Bazelisk
 RUN LATEST_BAZELISK=$(curl -sSI https://github.com/bazelbuild/bazelisk/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/bazel && \
     chmod 0755 /usr/local/bin/bazel
 
 # Buildifier
 RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
-    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${TARGETARCH} && \
     chown root:root /usr/local/bin/buildifier && \
     chmod 0755 /usr/local/bin/buildifier
 
@@ -106,7 +107,7 @@ RUN apt-get -y update && \
     apt-get -y install openjdk-11-jdk-headless && \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${BUILDARCH}
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${TARGETARCH}
 
 FROM ubuntu2004-nojdk AS ubuntu2004-java11
 
@@ -114,7 +115,7 @@ RUN apt-get -y update && \
     apt-get -y install openjdk-11-jdk-headless && \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${BUILDARCH}
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${TARGETARCH}
 
 FROM ubuntu2004-nojdk AS ubuntu2004
 
@@ -122,7 +123,7 @@ RUN apt-get -y update && \
     apt-get -y install openjdk-21-jdk-headless && \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk-${BUILDARCH}
+ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk-${TARGETARCH}
 
 FROM ubuntu2004 AS ubuntu2004-kythe
 

--- a/buildkite/instances.yml
+++ b/buildkite/instances.yml
@@ -43,6 +43,33 @@ instance_groups:
     service_account: buildkite-trusted@bazel-public.iam.gserviceaccount.com
     image_family: bk-docker
     metadata_from_file: startup-script=startup-docker-pdssd.sh
+  - name: bk-docker-arm64
+    count: 2
+    project: bazel-untrusted
+    service_account: buildkite@bazel-untrusted.iam.gserviceaccount.com
+    image_family: bk-docker-arm64
+    metadata_from_file: startup-script=startup-docker-pdssd.sh
+    machine_type: c4a-standard-8-lssd
+    zone: us-central1-c
+    boot_disk_type: hyperdisk-balanced
+  - name: bk-testing-docker-arm64
+    count: 2
+    project: bazel-untrusted
+    service_account: buildkite-testing@bazel-untrusted.iam.gserviceaccount.com
+    image_family: bk-testing-docker-arm64
+    metadata_from_file: startup-script=startup-docker-pdssd.sh
+    machine_type: c4a-standard-8-lssd
+    zone: us-central1-c
+    boot_disk_type: hyperdisk-balanced
+  - name: bk-trusted-docker-arm64
+    count: 2
+    project: bazel-public
+    service_account: buildkite-trusted@bazel-public.iam.gserviceaccount.com
+    image_family: bk-docker-arm64
+    metadata_from_file: startup-script=startup-docker-pdssd.sh
+    machine_type: c4a-standard-8-lssd
+    zone: us-central1-c
+    boot_disk_type: hyperdisk-balanced
   - name: bk-windows
     count: 30
     project: bazel-untrusted

--- a/buildkite/promote_images.py
+++ b/buildkite/promote_images.py
@@ -32,6 +32,15 @@ IMAGE_PROMOTIONS = {
             "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
         ],
     },
+    "bk-docker-arm64": {
+        "project": "bazel-public",
+        "source_image_project": "bazel-public",
+        "source_image_family": "bk-testing-docker-arm64",
+        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE"],
+        "licenses": [
+            "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
+        ],
+    },
     "bk-windows": {
         "project": "bazel-public",
         "source_image_project": "bazel-public",
@@ -80,7 +89,10 @@ def main(argv=None):
         print("Usage: promote_images.py {}".format(" ".join(IMAGE_PROMOTIONS.keys())))
         return 1
 
-    unknown_args = set(argv).difference(IMAGE_PROMOTIONS.keys())
+    # Handle multiple args as well as a single-arg comma-delimited list.
+    names = argv if len(argv) > 1 else argv[0].split(",")
+
+    unknown_args = set(names).difference(IMAGE_PROMOTIONS.keys())
     if unknown_args:
         print(
             "Unknown platforms: {}\nAvailable platforms: {}".format(
@@ -90,7 +102,7 @@ def main(argv=None):
         return 1
 
     # Put VM creation instructions into the work queue.
-    for name in argv:
+    for name in names:
         WORK_QUEUE.put({"name": name, "params": IMAGE_PROMOTIONS[name]})
 
     # Spawn worker threads that will create the VMs.

--- a/buildkite/startup-docker-pdssd.sh
+++ b/buildkite/startup-docker-pdssd.sh
@@ -58,11 +58,16 @@ systemctl start docker
 gcloud auth configure-docker --quiet
 sudo -H -u buildkite-agent gcloud auth configure-docker --quiet
 
+QUEUE="default"
+if [[ "$(uname -m)" == "aarch64" ]]; then
+  QUEUE="arm64"
+fi
+
 ### Write the Buildkite agent configuration.
 cat > /etc/buildkite-agent/buildkite-agent.cfg <<EOF
 token="${BUILDKITE_TOKEN}"
 name="%hostname"
-tags="queue=default,kind=docker,os=linux"
+tags="queue=${QUEUE},kind=docker,os=linux"
 build-path="/var/lib/buildkite-agent/builds"
 git-mirrors-path="/var/lib/gitmirrors"
 git-clone-mirror-flags="-v --bare"

--- a/pipelines/publish-vm-image.yml
+++ b/pipelines/publish-vm-image.yml
@@ -2,7 +2,7 @@
 steps:
   - command: |-
       cd buildkite
-      ./create_images.py ${BAZEL_TEST_VM_NAME}
+      ./create_images.py "${BAZEL_TEST_VM_NAMES}"
     label: ":pipeline:"
     agents:
       - "queue=default"
@@ -34,7 +34,7 @@ steps:
 
   - command: |-
       cd buildkite
-      ./create_instances.py ${BAZEL_TEST_VM_NAME}
+      ./create_instances.py "${BAZEL_TEST_VM_NAMES}"
     label: ":pipeline:"
     agents:
       - "queue=default"
@@ -70,7 +70,7 @@ steps:
 
   - command: |-
       cd buildkite
-      ./promote_images.py ${BAZEL_VM_NAME}
+      ./promote_images.py "${BAZEL_VM_NAMES}"
     label: ":pipeline:"
     agents:
       - "queue=default"


### PR DESCRIPTION
With this change we can create ARM64 GCE images, as well as multi-platform Ubuntu 20.04 Docker images.

This change does not impact any existing pipelines, but it allows as to build new images and test them more thoroughly.

Proof of new images in testing org (tests are still failing): https://buildkite.com/bazel-testing/bazel-bazel-arm64/builds/6#01968447-ec09-493f-9fe9-ac95cb4f2185

Progress towards https://github.com/bazelbuild/continuous-integration/issues/2272