### PR TITLE
Add multi-platform Docker images for Rocky Linux 8

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -287,6 +287,27 @@ PLATFORMS = {
         "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/centos7-java11-devtoolset10",
         "python": "python3.6",
     },
+    "rockylinux8": {
+        "name": "Rocky Linux 8",
+        "emoji-name": ":rocky: Rocky Linux 8",
+        "publish_binary": [],
+        "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/rockylinux8",
+        "python": "python3.8",
+    },
+    "rockylinux8_java11": {
+        "name": "Rocky Linux 8 (OpenJDK 11, gcc 8.5.0)",
+        "emoji-name": ":rocky: Rocky Linux 8 (OpenJDK 11, gcc 8.5.0)",
+        "publish_binary": [],
+        "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/rockylinux8-java11",
+        "python": "python3.8",
+    },
+    "rockylinux8_java11_devtoolset10": {
+        "name": "Rocky Linux 8 (OpenJDK 11, gcc 10.2.1)",
+        "emoji-name": ":rocky: Rocky Linux 8 (OpenJDK 11, gcc 10.2.1)",
+        "publish_binary": [],
+        "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/rockylinux8-java11-devtoolset10",
+        "python": "python3.8",
+    },
     "debian10": {
         "name": "Debian 10 Buster (OpenJDK 11, gcc 8.3.0)",
         "emoji-name": ":debian: Debian 10 Buster (OpenJDK 11, gcc 8.3.0)",
@@ -336,7 +357,7 @@ PLATFORMS = {
         "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/ubuntu2004",
         "python": "python3.8",
         "queue": "arm64",
-        # TODO: Re-enable always-pull if we also publish docker containers for Linux ARM64
+        # TODO(#2272): Re-enable always-pull if we also publish docker containers for Linux ARM64
         "always-pull": False,
     },
     "kythe_ubuntu2004": {
@@ -1152,9 +1173,6 @@ def execute_commands(
     bazel_binary = "bazel"
     if use_bazel_at_commit:
         print_collapsed_group(":gcloud: Downloading Bazel built at " + use_bazel_at_commit)
-        # Linux binaries are published under platform name "centos7"
-        if binary_platform == LINUX_BINARY_PLATFORM:
-            binary_platform = "centos7"
         os.environ["USE_BAZEL_VERSION"] = download_bazel_binary_at_commit(
             tmpdir, binary_platform, use_bazel_at_commit
         )
@@ -1779,6 +1797,7 @@ def remote_caching_flags(platform, accept_cached=True):
     if THIS_IS_TRUSTED and not is_mac():
         return []
     # We don't enable remote caching on the Linux ARM64 machine since it doesn't have access to GCS.
+    # TODO(#2272): Delete once GCE workers are running.
     if platform == "ubuntu2004_arm64":
         return []
 

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -294,6 +294,14 @@ PLATFORMS = {
         "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/rockylinux8",
         "python": "python3.8",
     },
+    "rockylinux8_arm64": {
+        "name": "Rocky Linux 8 ARM64",
+        "emoji-name": ":rocky: Rocky Linux 8 ARM64",
+        "publish_binary": [],
+        "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/rockylinux8",
+        "python": "python3.8",
+        "queue": "arm64_v2",  # TODO(#2272): change to arm64
+    },
     "rockylinux8_java11": {
         "name": "Rocky Linux 8 (OpenJDK 11, gcc 8.5.0)",
         "emoji-name": ":rocky: Rocky Linux 8 (OpenJDK 11, gcc 8.5.0)",

--- a/buildkite/docker/build.sh
+++ b/buildkite/docker/build.sh
@@ -32,7 +32,8 @@ if [[ -z "$(docker buildx ls | grep mp-builder)" ]]; then
 fi
 
 # Containers used by Bazel
-# For Ubuntu 20.04 we build multi-platform images.
+# For Rocky Linux & Ubuntu 20.04 we build multi-platform images.
+docker build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target rockylinux8 -t "gcr.io/$PREFIX/rockylinux8"  rockylinux8 &
 docker build -f debian10/Dockerfile   --target debian10-java11   -t "gcr.io/$PREFIX/debian10-java11" debian10 &
 docker build -f debian11/Dockerfile   --target debian11-java17   -t "gcr.io/$PREFIX/debian11-java17" debian11 &
 docker build -f ubuntu1804/Dockerfile --target ubuntu1804-java11 -t "gcr.io/$PREFIX/ubuntu1804-java11" ubuntu1804 &
@@ -45,6 +46,9 @@ docker build -f fedora39/Dockerfile   --target fedora39-java17   -t "gcr.io/$PRE
 docker build -f fedora40/Dockerfile   --target fedora40-java21   -t "gcr.io/$PREFIX/fedora40-java21" fedora40 &
 wait
 
+docker build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target rockylinux8-java11              -t "gcr.io/$PREFIX/rockylinux8-java11"                rockylinux8
+docker build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target rockylinux8-java11-devtoolset10 -t "gcr.io/$PREFIX/rockylinux8-java11-devtoolset10"   rockylinux8
+docker build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target rockylinux8-releaser            -t "gcr.io/$PREFIX/rockylinux8-releaser"              rockylinux8
 docker build -f ubuntu1804/Dockerfile --target ubuntu1804-bazel-java11     -t "gcr.io/$PREFIX/ubuntu1804-bazel-java11" ubuntu1804
 docker build -f ubuntu2004/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2004-bazel-java11     -t "gcr.io/$PREFIX/ubuntu2004-bazel-java11" ubuntu2004
 docker build -f ubuntu2204/Dockerfile --target ubuntu2204-kythe            -t "gcr.io/$PREFIX/ubuntu2204-kythe" ubuntu2204

--- a/buildkite/docker/push.sh
+++ b/buildkite/docker/push.sh
@@ -15,6 +15,10 @@ case $(git symbolic-ref --short HEAD) in
 esac
 
 # Containers used by Bazel CI
+docker push "gcr.io/$PREFIX/rockylinux8" &
+docker push "gcr.io/$PREFIX/rockylinux8-java11" &
+docker push "gcr.io/$PREFIX/rockylinux8-java11-devtoolset10" &
+docker push "gcr.io/$PREFIX/rockylinux8-releaser" &
 docker push "gcr.io/$PREFIX/debian10-java11" &
 docker push "gcr.io/$PREFIX/debian11-java17" &
 docker push "gcr.io/$PREFIX/ubuntu1804-bazel-java11" &

--- a/buildkite/docker/rockylinux8/Dockerfile
+++ b/buildkite/docker/rockylinux8/Dockerfile
@@ -1,0 +1,100 @@
+FROM rockylinux:8 AS rockylinux8-nojdk
+ARG TARGETARCH
+
+# Install required packages.
+COPY google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
+
+RUN dnf -y install 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled powertools && \
+    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    dnf -y install \
+    bind-utils \
+    dpkg-dev \
+    ed \
+    file \
+    gcc \
+    gcc-c++ \
+    git \
+    glibc-langpack-en \
+    glibc-locale-source \
+    gnupg2 \
+    google-cloud-sdk \
+    iproute \
+    lcov \
+    openssl-perl \
+    patch \
+    python38 \
+    python38-PyYAML \
+    python38-requests \
+    python38-six \
+    rpm-build \
+    sudo \
+    unzip \
+    which \
+    zip \
+    && \
+    dnf clean all
+
+# Allow using sudo inside the container.
+RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN dnf -y install dnf-utils && \
+    dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo && \
+    dnf -y install docker-ce docker-ce-cli containerd.io && \
+    dnf clean all
+
+# Ensure that Bazel can use its beloved ISO-8859-1 locale.
+RUN localedef -i en_US -f ISO-8859-1 en_US.ISO-8859-1
+
+# Bazelisk
+RUN LATEST_BAZELISK=$(curl -sSI https://github.com/bazelbuild/bazelisk/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
+    curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${LATEST_BAZELISK}/bazelisk-linux-${TARGETARCH} && \
+    chown root:root /usr/local/bin/bazel && \
+    chmod 0755 /usr/local/bin/bazel
+
+# Buildifier
+RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/releases/latest | grep -i '^location: ' | sed 's|.*/||' | sed $'s/\r//') && \
+    curl -Lo /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${LATEST_BUILDIFIER}/buildifier-linux-${TARGETARCH} && \
+    chown root:root /usr/local/bin/buildifier && \
+    chmod 0755 /usr/local/bin/buildifier
+
+FROM rockylinux8-nojdk AS rockylinux8-nojdk-devtoolset10
+
+RUN dnf -y install gcc-toolset-10 scl-utils && dnf clean all
+
+FROM rockylinux8-nojdk AS rockylinux8-java8
+
+RUN dnf -y install java-1.8.0-openjdk-devel && dnf clean all
+
+FROM rockylinux8-nojdk AS rockylinux8-java11
+
+RUN dnf -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \
+    dnf -y install zulu11-jdk && \
+    dnf clean all
+
+FROM rockylinux8-nojdk-devtoolset10 AS rockylinux8-java11-devtoolset10
+
+RUN dnf -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \
+    dnf -y install zulu11-jdk && \
+    dnf clean all
+
+FROM rockylinux8-nojdk-devtoolset10 AS rockylinux8
+
+RUN dnf -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \
+    dnf -y install zulu11-jdk && \
+    dnf clean all
+
+FROM rockylinux8-java11-devtoolset10 AS rockylinux8-releaser
+# dpkg-source needs a GNU tar version >= 1.28.0 because of --sort=name.
+# Technically this is no longer necessary as we moved from CentOS 7 to
+# Rocky Linux 8, since the latter comes with tar 1.3.0.
+# However, I'm keeping it for now for consistency reasons.
+RUN pushd /usr/local/src && \
+    curl -fsSL http://ftp.gnu.org/gnu/tar/tar-1.34.tar.bz2 | tar xvj && \
+    cd tar-1.34 && \
+    FORCE_UNSAFE_CONFIGURE=1 ./configure && \
+    make -j && \
+    make install && \
+    popd && \
+    rm -rf /usr/local/src/tar-1.34 && \
+    ln -s tar /usr/local/bin/gtar

--- a/buildkite/docker/rockylinux8/google-cloud-sdk.repo
+++ b/buildkite/docker/rockylinux8/google-cloud-sdk.repo
@@ -1,0 +1,8 @@
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-$basearch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/buildkite/setup-docker.sh
+++ b/buildkite/setup-docker.sh
@@ -230,6 +230,8 @@ docker info -f '{{ .DriverStatus }}'
 gcloud auth configure-docker --quiet
 
 ### Pull the Docker images that we need in production.
+docker pull "gcr.io/bazel-public/rockylinux8-java11-devtoolset10" &
+docker pull "gcr.io/bazel-public/rockylinux8-releaser" &
 docker pull "gcr.io/bazel-public/debian10-java11" &
 docker pull "gcr.io/bazel-public/debian11-java17" &
 docker pull "gcr.io/bazel-public/ubuntu1804-java11" &


### PR DESCRIPTION
Even after this change all existing pipelines will continue to use CentOS 7. We need to test the Rocky Linux images more thoroughly, then we can have a migration period with CentOS and Rocky running in parallel for some time.

Progress towards https://github.com/bazelbuild/continuous-integration/issues/2272