### PR TITLE
Move ubuntu2004_arm64 to arm64_v2 queue

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -367,9 +367,7 @@ PLATFORMS = {
         "publish_binary": [],
         "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/ubuntu2004",
         "python": "python3.8",
-        "queue": "arm64",
-        # TODO(#2272): Re-enable always-pull if we also publish docker containers for Linux ARM64
-        "always-pull": False,
+        "queue": "arm64_v2",
     },
     "kythe_ubuntu2004": {
         "name": "Kythe (Ubuntu 20.04 LTS)",
@@ -1807,10 +1805,6 @@ def remote_caching_flags(platform, accept_cached=True):
     # Only enable caching for untrusted and testing builds, except for trusted MacOS VMs.
     if THIS_IS_TRUSTED and not is_mac():
         return []
-    # We don't enable remote caching on the Linux ARM64 machine since it doesn't have access to GCS.
-    # TODO(#2272): Delete once GCE workers are running.
-    if platform == "ubuntu2004_arm64":
-        return []
 
     platform_cache_key = [
         BUILDKITE_ORG.encode("utf-8"),
@@ -2724,7 +2718,6 @@ def create_step(
             image=PLATFORMS[platform]["docker-image"],
             commands=commands,
             queue=PLATFORMS[platform].get("queue", "default"),
-            always_pull=PLATFORMS[platform].get("always-pull", True),
         )
     else:
         step = {
@@ -2774,7 +2767,7 @@ def create_step(
 
 
 def create_docker_step(
-    label, image, commands=None, additional_env_vars=None, queue="default", always_pull=True
+    label, image, commands=None, additional_env_vars=None, queue="default"
 ):
     env = ["ANDROID_HOME", "ANDROID_NDK_HOME", "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"]
     if THIS_IS_TRUSTED:
@@ -2789,7 +2782,7 @@ def create_docker_step(
         "agents": {"queue": queue},
         "plugins": {
             "docker#v3.8.0": {
-                "always-pull": always_pull,
+                "always-pull": True,
                 "environment": env,
                 "image": image,
                 "network": "host",


### PR DESCRIPTION
This is a temporary change - it moves any Ubuntu ARM64 jobs from the physical ARM64 machines to the new GCE ARM64 VMs, thus allowing us to deprecate the old machines without any interruptions to the CI.

Progress towards https://github.com/bazelbuild/continuous-integration/issues/2272