### PR TITLE
Fix git_repository for rules_python

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -232,7 +232,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "owned_by_bazel": True,
     },
     "rules_python": {
-        "git_repository": "https://github.com/bazelbuild/rules_python.git",
+        "git_repository": "https://github.com/bazel-contrib/rules_python.git",
         "pipeline_slug": "rules-python-python",
     },
     "rules_testing": {


### PR DESCRIPTION
This is required to fetch the correct last green commit for rules_python in the downstream pipeline.