### PR TITLE
Shrink untrusted ARM64 Docker pools

### DIFF
--- a/buildkite/instances.yml
+++ b/buildkite/instances.yml
@@ -44,7 +44,7 @@ instance_groups:
     image_family: bk-docker
     metadata_from_file: startup-script=startup-docker-pdssd.sh
   - name: bk-docker-arm64
-    count: 20
+    count: 8
     project: bazel-untrusted
     service_account: buildkite@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-docker-arm64
@@ -53,7 +53,7 @@ instance_groups:
     zone: us-central1-c
     boot_disk_type: hyperdisk-balanced
   - name: bk-testing-docker-arm64
-    count: 10
+    count: 2
     project: bazel-untrusted
     service_account: buildkite-testing@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-testing-docker-arm64


### PR DESCRIPTION
Our current quota only allows 80 cores.

Progress towards https://github.com/bazelbuild/continuous-integration/issues/2272