### PR TITLE
Stop publishing CentOS 7 binaries

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -269,7 +269,7 @@ PLATFORMS = {
     "centos7": {
         "name": "CentOS 7",
         "emoji-name": ":centos: CentOS 7",
-        "publish_binary": ["centos7"],
+        "publish_binary": [],
         "docker-image": f"gcr.io/{DOCKER_REGISTRY_PREFIX}/centos7",
         "python": "python3.6",
     },


### PR DESCRIPTION
It has been EOL for almost a year now, and we have replaced it with Rocky Linux 8.

Progress towards https://github.com/bazelbuild/continuous-integration/issues/2272