### PR TITLE
Build & push rockylinux8-java8 Docker image

### DIFF
--- a/buildkite/docker/build.sh
+++ b/buildkite/docker/build.sh
@@ -46,6 +46,7 @@ docker build -f fedora39/Dockerfile   --target fedora39-java17   -t "gcr.io/$PRE
 docker build -f fedora40/Dockerfile   --target fedora40-java21   -t "gcr.io/$PREFIX/fedora40-java21" fedora40 &
 wait
 
+docker build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target rockylinux8-java8               -t "gcr.io/$PREFIX/rockylinux8-java8"                 rockylinux8
 docker build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target rockylinux8-java11              -t "gcr.io/$PREFIX/rockylinux8-java11"                rockylinux8
 docker build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target rockylinux8-java11-devtoolset10 -t "gcr.io/$PREFIX/rockylinux8-java11-devtoolset10"   rockylinux8
 docker build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target rockylinux8-releaser            -t "gcr.io/$PREFIX/rockylinux8-releaser"              rockylinux8

--- a/buildkite/docker/push.sh
+++ b/buildkite/docker/push.sh
@@ -16,6 +16,7 @@ esac
 
 # Containers used by Bazel CI
 docker push "gcr.io/$PREFIX/rockylinux8" &
+docker push "gcr.io/$PREFIX/rockylinux8-java8" &
 docker push "gcr.io/$PREFIX/rockylinux8-java11" &
 docker push "gcr.io/$PREFIX/rockylinux8-java11-devtoolset10" &
 docker push "gcr.io/$PREFIX/rockylinux8-releaser" &


### PR DESCRIPTION
We currently need it for the release pipeline (but should upgrade to rockylinux8-java11 eventually).

Progress towards https://github.com/bazelbuild/continuous-integration/issues/2272