### PR TITLE
Restore `bazel mod deps` in post-submit config.

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -492,7 +492,7 @@ Example usage:
 ---
 matrix:
   bazel_version: ["4.2.2", "5.0.0"]
-  unix_platform: ["centos7", "debian10", "macos", "ubuntu2004"]
+  unix_platform: ["rockylinux8", "debian10", "macos", "ubuntu2004"]
   python: ["python2", "python3"]
   unix_compiler: ["gcc", "clang"]
   win_compiler: ["msvc", "clang"]

--- a/pipelines/bazel-postsubmit.patch
+++ b/pipelines/bazel-postsubmit.patch
@@ -5,7 +5,7 @@
 +# Update this file by running ./update-bazel-postsubmit.sh under the same directory
  
  tasks:
-   centos7:
+   rockylinux8:
      shell_commands:
        - rm -rf $HOME/bazeltest
        - mkdir $HOME/bazeltest

--- a/pipelines/bazel-postsubmit.yml
+++ b/pipelines/bazel-postsubmit.yml
@@ -6,6 +6,7 @@ tasks:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
+      - bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-linux"
     build_targets:
@@ -46,6 +47,7 @@ tasks:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
+      - bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-linux"
     build_targets:
@@ -59,6 +61,7 @@ tasks:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
+      - bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-linux"
     build_targets:
@@ -93,6 +96,7 @@ tasks:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
+      - bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-linux"
     build_targets:
@@ -111,6 +115,7 @@ tasks:
     shell_commands:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
+      - bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-linux"
     build_targets:
@@ -142,6 +147,7 @@ tasks:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
       - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
+      - bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-macos"
     build_targets:
@@ -185,6 +191,7 @@ tasks:
       - rm -rf $HOME/bazeltest
       - mkdir $HOME/bazeltest
       - ln -sf $OUTPUT_BASE/external $HOME/bazeltest/external
+      - bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-macos"
     build_targets:
@@ -218,6 +225,7 @@ tasks:
     setup:
       - mkdir C:\b
       - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
+      - bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-windows"
     build_targets:
@@ -267,6 +275,7 @@ tasks:
     setup:
       - mkdir C:\b
       - mklink /J C:\b\bazeltest_external %OUTPUT_BASE:/=\%\external
+      - bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=ci-windows"
       - "--config=windows_arm64"
@@ -278,6 +287,8 @@ tasks:
   rbe_ubuntu2004:
     platform: ubuntu2004
     name: "RBE"
+    shell_commands:
+      - bazel mod deps --lockfile_mode=update
     build_flags:
       - "--config=remote"
       - "--remote_executor=grpcs://remotebuildexecution.googleapis.com"


### PR DESCRIPTION
This change is a partial revert of 2c23d7c47604a4984a20dcd19a66fb71f2ddba00 to fix breakages such as https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/4676.

Progress towards https://github.com/bazelbuild/continuous-integration/issues/2272.