### PR TITLE
runner_step: Use Rocky Linux instead of CentOS

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3177,6 +3177,9 @@ def runner_step(
     shards=1,
     soft_fail=None,
 ):
+    # TODO(#2272): remove after a migration period
+    platform = platform.replace("centos7", "rockylinux8")
+
     py = PLATFORMS[platform]["python"]
     command = f"{py} {RUNNER_CMD} --task={task}"
     if http_config:


### PR DESCRIPTION
This should have been part of https://github.com/bazelbuild/continuous-integration/pull/2305

Progress towards #2272