### PR TITLE
Update slack.bazel.build link

### DIFF
--- a/slack-bazel-build/docker/nginx.conf
+++ b/slack-bazel-build/docker/nginx.conf
@@ -18,7 +18,7 @@ http {
         listen      ${PORT};
         server_name slack.bazel.build;
 
-        return 301 https://join.slack.com/t/bazelbuild/shared_invite/zt-346hfqcao-gACYGP6kaGi1Vu0Bqtlrkw;
+        return 301 https://join.slack.com/t/bazelbuild/shared_invite/zt-364or18jk-7whaXBiCdZVhC7v2FCq3xw;
 
         error_page   500 502 503 504  /50x.html;
         location = /50x.html {


### PR DESCRIPTION
We might have to start doing this every month, since there is apparently no way to extend the expiration time of invite links anymore.