### PR TITLE
Add llvm and clang to rockylinux8 image

### DIFF
--- a/buildkite/docker/rockylinux8/Dockerfile
+++ b/buildkite/docker/rockylinux8/Dockerfile
@@ -9,6 +9,7 @@ RUN dnf -y install 'dnf-command(config-manager)' && \
     dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf -y install \
     bind-utils \
+    clang \
     dpkg-dev \
     ed \
     file \
@@ -21,6 +22,7 @@ RUN dnf -y install 'dnf-command(config-manager)' && \
     google-cloud-sdk \
     iproute \
     lcov \
+    llvm \
     openssl-perl \
     patch \
     python38 \


### PR DESCRIPTION
Extends the coverage of Bazel tests that use clang to rockylinux8.