### PR TITLE
Don't use colons in retry log filenames

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -4399,7 +4399,7 @@ def log_retry():
         basename = "_".join((
             os.getenv("BUILDKITE_PIPELINE_SLUG"),
             os.getenv("BUILDKITE_BUILD_NUMBER"),
-            os.getenv("BUILDKITE_LABEL").replace(" ", "-"),
+            os.getenv("BUILDKITE_LABEL").replace(" ", "-").replace(":", "-"),
             os.getenv("BUILDKITE_RETRY_COUNT"),
         ))
         path = os.path.join(tmpdir, basename)


### PR DESCRIPTION
Windows!

attempt to fix https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/27887#0197ae77-d1e0-4540-8837-26eb8efdcdd1