### PR TITLE
Add rbe configs for bazel 7 and 8

### DIFF
--- a/rbe-configs/data.py
+++ b/rbe-configs/data.py
@@ -1,5 +1,18 @@
 configs = [
   {
+    "bazel_version": "8.0.1",
+    "containers": [
+      {
+          'toolchain_name': 'ubuntu2004',
+          'cpp_env_json': 'cpp_env/ubuntu2004.json'
+      },
+      {
+          'toolchain_name': 'ubuntu2204',
+          'cpp_env_json': 'cpp_env/ubuntu2004.json'
+      }
+    ]
+  },
+  {
     "bazel_version": "7.0.2",
     "containers": [
       {

--- a/rbe-configs/data.py
+++ b/rbe-configs/data.py
@@ -1,5 +1,26 @@
 configs = [
   {
+    "bazel_version": "7.0.2",
+    "containers": [
+      {
+          'toolchain_name': 'ubuntu1804-bazel-java11',
+          'cpp_env_json': 'cpp_env/ubuntu1804.json'
+      },
+      {
+          'toolchain_name': 'ubuntu2004',
+          'cpp_env_json': 'cpp_env/ubuntu2004.json'
+      },
+      {
+        'toolchain_name': 'ubuntu2004-bazel-java11',
+        'cpp_env_json': 'cpp_env/ubuntu2004.json'
+      },
+      {
+          'toolchain_name': 'ubuntu2204',
+          'cpp_env_json': 'cpp_env/ubuntu2004.json'
+      }
+    ]
+  },
+  {
     "bazel_version": "6.3.2",
     "containers": [
       {

--- a/rbe-configs/generate.py
+++ b/rbe-configs/generate.py
@@ -47,12 +47,18 @@ def generate_configs(output_root: str, bazel_version: str, toolchain_name: str,
       '@platforms//os:linux', '@platforms//cpu:x86_64',
       '@bazel_tools//tools/cpp:gcc'
   ]
+
+  local_config_cc_from_rules_cc = bazel_version[0] > '7'
+  cpp_config_targets = '@@rules_cc++cc_configure_extension+local_config_cc//...' if local_config_cc_from_rules_cc else ''
+  cpp_config_repo ='rules_cc++cc_configure_extension+local_config_cc' if local_config_cc_from_rules_cc else ''
   subprocess.run(
       [
           'rbe_configs_gen',
           '--bazel_version={}'.format(bazel_version),
           '--toolchain_container={}'.format(toolchain_container),
           '--cpp_env_json={}'.format(cpp_env_json),
+          '--cpp_config_targets={}'.format(cpp_config_targets),
+          '--cpp_config_repo={}'.format(cpp_config_repo),
           '--exec_constraints={}'.format(','.join(exec_constraints)),
           '--output_tarball={}'.format(output_tarball),
           '--output_manifest={}'.format(output_manifest),


### PR DESCRIPTION
Use target `@@rules_cc++cc_configure_extension+local_config_cc` instead of `@local_config_cc` for c++ configs since the latter one no longer exists since Bazel 8+.