### PR TITLE
Upgrade bazel docker image to 22.04

### DIFF
--- a/bazel/oci/Dockerfile
+++ b/bazel/oci/Dockerfile
@@ -1,7 +1,7 @@
 # ATTENTION: use the build.sh script to build this image.
 # ./build.sh <OCI_REPOSITORY> <BAZEL_VERSION>
 
-FROM ubuntu:20.04 AS base_image
+FROM ubuntu:22.04 AS base_image
 
 RUN --mount=source=bazel/oci/install_packages.sh,target=/mnt/install_packages.sh,type=bind \
     /mnt/install_packages.sh


### PR DESCRIPTION
Ubuntu 20.04 is end of standard support and so security patches are only available to paid subscribers. Upgrading to 22.04 which has support until 2027.