### PR TITLE
Fix Ubuntu ARM64 link error in the regular org.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1120,7 +1120,7 @@ def calculate_flags(task_config, task_config_key, action_key, tmpdir, test_env_v
     # Eventually we should set the flags in build_bazel_binaries.yml in the Bazel repo.
     # However, for now we need to hack bazelci.py so that we can rebuild binaries
     # at older commits.
-    if THIS_IS_TRUSTED and is_linux() and is_64_bit():
+    if is_linux() and is_64_bit():
         flags += ["--linkopt=-Wl,--no-fix-cortex-a53-843419", "--host_linkopt=-Wl,--no-fix-cortex-a53-843419"]
     
     return flags, json_profile_out, capture_corrupted_outputs_dir


### PR DESCRIPTION
This is a temporary fix that unblocks the downstream pipeline for commits older than https://github.com/bazelbuild/bazel/commit/97b7a5a5725eaa63c9babc43a649e02e08f2f006

Example failure: https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/4849#0198744c-7548-41b5-bb20-deb8ce6ead51

Progress towards https://github.com/bazelbuild/continuous-integration/issues/2353