### PR TITLE
Remove CI for Bazel for Intellij Plugin

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -172,23 +172,11 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "http_config": "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/flogger.yml",
         "pipeline_slug": "flogger",
     },
-    "IntelliJ Plugin": {
-        "git_repository": "https://github.com/bazelbuild/intellij.git",
-        "file_config": ".bazelci/intellij.yml",
-        "pipeline_slug": "intellij-plugin",
-        "disabled_reason": "https://github.com/bazelbuild/intellij/issues/7670",
-    },
     "IntelliJ Plugin Google": {
         "git_repository": "https://github.com/bazelbuild/intellij.git",
         "file_config": ".bazelci/intellij.yml",
         "pipeline_slug": "intellij-plugin-google",
         "disabled_reason": "https://github.com/bazelbuild/intellij/issues/7232#issuecomment-2617127267",
-    },
-    "IntelliJ UE Plugin": {
-        "git_repository": "https://github.com/bazelbuild/intellij.git",
-        "file_config": ".bazelci/intellij-ue.yml",
-        "pipeline_slug": "intellij-ue-plugin",
-        "disabled_reason": "https://github.com/bazelbuild/intellij/issues/7670",
     },
     "IntelliJ UE Plugin Google": {
         "git_repository": "https://github.com/bazelbuild/intellij.git",

--- a/buildkite/terraform/bazel/main.tf
+++ b/buildkite/terraform/bazel/main.tf
@@ -54,27 +54,6 @@ resource "buildkite_pipeline" "limdor-bazel-examples" {
   }
 }
 
-resource "buildkite_pipeline" "intellij-ue-plugin" {
-  name = "IntelliJ UE plugin"
-  repository = "https://github.com/bazelbuild/intellij.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij-ue.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
-  description = "Tests the Bazel IntelliJ plugin with IntelliJ IDEA Ultimate"
-  default_branch = "master"
-  branch_configuration = "!google"
-  team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
-  provider_settings {
-    trigger_mode = "code"
-    build_pull_requests = true
-    skip_pull_request_builds_for_existing_commits = true
-    build_pull_request_forks = true
-    prefix_pull_request_fork_branch_names = true
-    build_branches = true
-    publish_commit_status = true
-    filter_enabled = true
-    filter_condition = "build.pull_request.base_branch != \"google\""
-  }
-}
-
 resource "buildkite_pipeline" "intellij-ue-plugin-google" {
   name = "IntelliJ UE plugin Google"
   repository = "https://github.com/bazelbuild/intellij.git"
@@ -1564,27 +1543,6 @@ resource "buildkite_pipeline" "clion-plugin-google" {
     publish_commit_status = true
     filter_enabled = true
     filter_condition = "build.pull_request.base_branch == \"google\""
-  }
-}
-
-resource "buildkite_pipeline" "intellij-plugin" {
-  name = "IntelliJ plugin"
-  repository = "https://github.com/bazelbuild/intellij.git"
-  steps = templatefile("pipeline.yml.tpl", { envs = {}, steps = { commands = ["curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py", "python3.6 bazelci.py project_pipeline --file_config=.bazelci/intellij.yml | tee /dev/tty | buildkite-agent pipeline upload"] } })
-  description = "Tests the Bazel IntelliJ plugin with IntelliJ IDEA Community Edition"
-  default_branch = "master"
-  branch_configuration = "!google"
-  team = [{ access_level = "BUILD_AND_READ", slug = "bazel" }]
-  provider_settings {
-    trigger_mode = "code"
-    build_pull_requests = true
-    skip_pull_request_builds_for_existing_commits = true
-    build_pull_request_forks = true
-    prefix_pull_request_fork_branch_names = true
-    build_branches = true
-    publish_commit_status = true
-    filter_enabled = true
-    filter_condition = "build.pull_request.base_branch != \"google\""
   }
 }
 


### PR DESCRIPTION
The IJwB plugin is deprecated and only CLwB will be maintained on the master branch, the CI for IJwB is no longer required.

https://github.com/bazelbuild/intellij/pull/7823