### PR TITLE
Install clang-tools in Docker images

### DIFF
--- a/buildkite/docker/ubuntu2204/Dockerfile
+++ b/buildkite/docker/ubuntu2204/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get -y update && \
     bind9-host \
     build-essential \
     clang \
+    clang-tools \
     coreutils \
     curl \
     dnsutils \


### PR DESCRIPTION
This is needed for https://github.com/bazelbuild/bazel/pull/22553, which uses `clang-scan-deps`.