### PR TITLE
Install `libclang-rt-dev` on Ubuntu 24.04

### DIFF
--- a/buildkite/docker/ubuntu2404/Dockerfile
+++ b/buildkite/docker/ubuntu2404/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get -y update && \
     iputils-ping \
     lcov \
     less \
+    libclang-rt-dev \
     libc++-dev \
     libssl-dev \
     llvm \


### PR DESCRIPTION
This is needed to fix this error when building with coverage:
```
/usr/bin/ld.gold: error: cannot open /usr/lib/llvm-18/lib/clang/18/lib/linux/libclang_rt.profile-x86_64.a: No such file or directory
```

https://packages.ubuntu.com/noble/libclang-rt-dev