### PR TITLE
Disable rules_python in Downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -232,7 +232,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     "rules_python": {
         "git_repository": "https://github.com/bazel-contrib/rules_python.git",
         "pipeline_slug": "rules-python-python",
-        "disabled_reason": "https://github.com/bazel-contrib/rules_python/issues/2954, https://github.com/bazel-contrib/rules_python/issues/3122"
+        "disabled_reason": "https://github.com/bazel-contrib/rules_python/issues/2954, https://github.com/bazel-contrib/rules_python/issues/3122",
     },
     "rules_testing": {
         "git_repository": "https://github.com/bazelbuild/rules_testing.git",

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -232,6 +232,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     "rules_python": {
         "git_repository": "https://github.com/bazel-contrib/rules_python.git",
         "pipeline_slug": "rules-python-python",
+        "disabled_reason": "https://github.com/bazel-contrib/rules_python/issues/2954, https://github.com/bazel-contrib/rules_python/issues/3122"
     },
     "rules_testing": {
         "git_repository": "https://github.com/bazelbuild/rules_testing.git",


### PR DESCRIPTION
Disabled due to reason : https://github.com/bazel-contrib/rules_python/issues/3122, https://github.com/bazel-contrib/rules_python/issues/2954