### PR TITLE
Fix downloading bazel-diff

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1111,7 +1111,7 @@ def calculate_flags(task_config, task_config_key, action_key, tmpdir, test_env_v
     # at older commits.
     if is_linux() and is_64_bit():
         flags += ["--linkopt=-Wl,--no-fix-cortex-a53-843419", "--host_linkopt=-Wl,--no-fix-cortex-a53-843419"]
-    
+
     return flags, json_profile_out, capture_corrupted_outputs_dir
 
 
@@ -3225,11 +3225,11 @@ def runner_step(
 
 
 def fetch_bazelcipy_command():
-    return "curl -q --noproxy -sS {0}?{1} -o bazelci.py".format(SCRIPT_URL, int(time.time()))
+    return "curl -q --noproxy * -sS {0}?{1} -o bazelci.py".format(SCRIPT_URL, int(time.time()))
 
 
 def fetch_aggregate_incompatible_flags_test_result_command():
-    return "curl -q --noproxy -sS {0} -o aggregate_incompatible_flags_test_result.py".format(
+    return "curl -q --noproxy * -sS {0} -o aggregate_incompatible_flags_test_result.py".format(
         AGGREGATE_INCOMPATIBLE_TEST_RESULT_URL
     )
 
@@ -3506,7 +3506,7 @@ def fetch_incompatible_flags():
     output = subprocess.check_output(
         [
             # Query for open issues with "incompatible-change" and "migration-ready" label.
-            "curl", "-q", "--noproxy", "-sS",
+            "curl", "-q", "--noproxy", "*", "-sS",
             "https://api.github.com/search/issues?per_page=100&q=repo:bazelbuild/bazel+label:incompatible-change+label:migration-ready+state:open",
         ]
     ).decode("utf-8")


### PR DESCRIPTION
```
curl -q --noproxy -sSL https://github.com/Tinder/bazel-diff/releases/download/8.1.1/bazel-diff_deploy.jar -o /tmp/tmpmn45v_an/bazel-diff.jar
Running bazel-diff for bbf65aea398c490db92a77d7ec077d9a623ce3ff and ddd75b9ace6e3709c697214417e87d0aada0fcb5
java -jar /tmp/tmpmn45v_an/bazel-diff.jar generate-hashes --excludeExternalTargets -w /tmp/tmpmn45v_an/bbf65aea398c490db92a77d7ec077d9a623ce3ff -b bazel --bazelCommandOptions=--lockfile_mode=off /tmp/tmpmn45v_an/before.json
buildkite-agent annotate --style=warning --context 'diff_failed' This build runs all test targets even though `USE_BAZEL_DIFF` is set since bazel-diff failed with an error:
...
Error: Invalid or corrupt jarfile /tmp/tmpmn45v_an/bazel-diff.jar
```

https://buildkite.com/bazel/google-bazel-presubmit/builds/95512#019938cc-8f07-40f4-89e8-c930718e5234