### PR TITLE
Shard log: start at 1 instead of 0

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2412,7 +2412,7 @@ def upload_shard_distribution(sorted_test_targets, shard_count):
     tmpdir = tempfile.mkdtemp()
     try:
         data = {
-            s: get_targets_for_shard(sorted_test_targets, s, shard_count)
+            s+1: get_targets_for_shard(sorted_test_targets, s, shard_count)
             for s in range(shard_count)
         }
         base = f"{os.getenv('BUILDKITE_PIPELINE_SLUG')}_{os.getenv('BUILDKITE_BUILD_NUMBER')}_shards.json"


### PR DESCRIPTION
Buildkite UI starts shards at 1, too, so this approach makes more sense.