### PR TITLE
Add tools_android repository to downstream projects

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -239,6 +239,11 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "pipeline_slug": "rules-testing",
         "owned_by_bazel": True,
     },
+    "tools_android": {
+        "git_repository": "https://github.com/bazelbuild/tools_android.git",
+        "pipeline_slug": "tools-android",
+        "owned_by_bazel": True,
+    },
 }
 
 DOWNSTREAM_PROJECTS_TESTING = {


### PR DESCRIPTION
Closes https://github.com/bazelbuild/continuous-integration/issues/2191