### PR TITLE
Do not allow existing BCR modules to be modified

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -509,10 +509,10 @@ def should_wait_bcr_maintainer_review(modules):
     Returns True if the changes should block follow up presubmit jobs until a BCR maintainer triggers them.
     Throws an error if the changes violate BCR policies or the BCR validations fail.
     """
-    # If existing modules are changed, fail the presubmit.
     pr_labels = get_labels_from_pr()
-    if "USE-WITH-CAUTION-skip-modification-check" not in pr_labels:
-        validate_existing_modules_are_not_modified()
+
+    # If existing modules are changed, fail the presubmit.
+    validate_existing_modules_are_not_modified()
 
     # If files outside of the modules/ directory are changed, fail the presubmit.
     validate_files_outside_of_modules_dir_are_not_modified(modules)


### PR DESCRIPTION
This retires the label that permits such modifications since they generally turned out to be more breaking than we expected.