### PR TITLE
bcr_presubmit: Prepare test module source via Bazel

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2694,6 +2694,7 @@ def execute_command(
     print_output=True,
     capture_stderr=False,
     suppress_stdout=False,
+    env = os.environ,
 ):
     if print_output:
         eprint(" ".join(args))
@@ -2701,7 +2702,7 @@ def execute_command(
         args,
         shell=shell,
         check=fail_if_nonzero,
-        env=os.environ,
+        env=env,
         cwd=cwd,
         errors="replace",
         stdout=(


### PR DESCRIPTION
- Removed custom logic to download, unpack and patch module sources, which have subtle differences with how Bazel does it and behaves differently on different platforms (e.g macOS still had patch 2.0 instead of 2.8)
- Instead, we now use the latest version of Bazel to vendor the module source.

Tested locally with BCR's `bazel run //tools:setup_presubmit_repos`

Related: https://github.com/bazelbuild/bazel-central-registry/pull/6056#discussion_r2398025522