### PR TITLE
Fix syncing ./bazel_registry.json

### DIFF
--- a/buildkite/bazel-central-registry/bcr_postsubmit.py
+++ b/buildkite/bazel-central-registry/bcr_postsubmit.py
@@ -153,7 +153,7 @@ def get_canonical_basename(url):
 def sync_bcr_content():
     print_expanded_group(":gcloud: Sync BCR content")
     subprocess.check_output(
-        ["gsutil", "-h", "Cache-Control:no-cache", "rsync", "-c", "./bazel_registry.json", BCR_BUCKET]
+        ["gsutil", "-h", "Cache-Control:no-cache", "cp", "./bazel_registry.json", BCR_BUCKET]
     )
     subprocess.check_output(
         # -c Use checksum to compare files


### PR DESCRIPTION
rsync only applies to directory, otherwise we get
```
CommandException: arg (./bazel_registry.json) does not name a directory, bucket, or bucket subdir.
```