### PR TITLE
Enabling rules_python in Downstream

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -232,7 +232,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     "rules_python": {
         "git_repository": "https://github.com/bazel-contrib/rules_python.git",
         "pipeline_slug": "rules-python-python",
-        "disabled_reason": "https://github.com/bazel-contrib/rules_python/issues/2954, https://github.com/bazel-contrib/rules_python/issues/3122",
     },
     "rules_testing": {
         "git_repository": "https://github.com/bazelbuild/rules_testing.git",


### PR DESCRIPTION
Re-enabling rules_python as most of the jobs are now passing : https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/2583

