### PR TITLE
Replace --remote_default_platform_properties with --remote_default_exec_properties

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1870,7 +1870,7 @@ def remote_caching_flags(platform, accept_cached=True):
     flags += [
         f"--remote_timeout={remote_timeout}",
         "--remote_max_connections=200",
-        '--remote_default_exec_properties=cache-silo-key=%s}'
+        '--remote_default_exec_properties=cache-silo-key=%s'
         % platform_cache_digest.hexdigest(),
         "--remote_download_toplevel",
     ]


### PR DESCRIPTION
The old flag has been deleted in https://github.com/bazelbuild/bazel/commit/f6356d6cdb9a36d06e5638ea1ef3d83033631293