### PR TITLE
BCR presubmit: add `presubmit-auto-run` automatically

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -443,6 +443,17 @@ async function reviewPR(octokit, owner, repo, prNumber) {
       console.log(`Added presubmit-auto-run label to PR #${prNumber}`);
     }
   }
+  // Add low-ci-priority label if more than 10 modules are modified
+  const hasLowCiPriorityLabel = prInfo.data.labels.some(label => label.name === 'low-ci-priority');
+  if (!hasLowCiPriorityLabel && modifiedModules.size > 10) {
+    await octokit.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number: prNumber,
+      labels: ['low-ci-priority'],
+    });
+    console.log(`Added low-ci-priority label to PR #${prNumber} because it modifies ${modifiedModules.size} modules`);
+  }
 
   // Discard previous approvals if not all modules are approved
   if (!allModulesApproved && approvers.has(myLogin)) {


### PR DESCRIPTION
When reviewing a PR, attach the "presubmit-auto-run" label to the PR if all of the following are true:
1) This label hasn't been added already
2) If the PR author is one of the module maintainers or at least one of the modules has got maintainer approval
3) If the PR author has already contributed to the BCR before

If the number of changed modules is larger than 10, then `low-ci-priority` will be added to prevent the PR from blocking other CI pipeline.
