### PR TITLE
Remove unused --use_bazel_at_commit flag

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -4533,7 +4533,6 @@ def main(argv=None):
         type=str,
         help="Use an existing repository instead of cloning from github",
     )
-
     runner.add_argument("--use_but", type=bool, nargs="?", const=True)
     runner.add_argument("--save_but", type=bool, nargs="?", const=True)
     runner.add_argument("--needs_clean", type=bool, nargs="?", const=True)


### PR DESCRIPTION
This flag is no longer used and the logic has been removed to clean up the code.