### PR TITLE
Print warning when shard summary fails.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3973,7 +3973,20 @@ def print_shard_summary():
                 ]
             )
     except Exception as ex:
-        eprint(f"Failed to print shard summary: {ex}")
+        msg = f"Failed to print shard summary: {ex}"
+        try:
+            execute_command(
+                [
+                    "buildkite-agent",
+                    "annotate",
+                    "--style=warning",
+                    msg,
+                    "--context",
+                    "shard_summary_failure",
+                ]
+            )
+        except:
+            eprint(msg)
     finally:
         shutil.rmtree(tmpdir)
 


### PR DESCRIPTION
The feature hasn't been working since 2025-08-19,
but we only noticed this week. A more prominent
warning seems to be in order.