### PR TITLE
Remove remote_download_toplevel flag from flags

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1929,7 +1929,6 @@ def remote_caching_flags(platform, accept_cached=True):
         "--remote_max_connections=200",
         '--remote_default_exec_properties=cache-silo-key=%s'
         % platform_cache_digest.hexdigest(),
-        "--remote_download_toplevel",
     ]
 
     if not accept_cached:


### PR DESCRIPTION
This is already the default, since at least Bazel 7:  https://cs.opensource.google/bazel/bazel/+/release-7.6.1:src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java