### PR TITLE
Add git-mirrors-skip-update option to startup script

### DIFF
--- a/buildkite/startup-docker-pdssd.sh
+++ b/buildkite/startup-docker-pdssd.sh
@@ -70,6 +70,7 @@ name="%hostname"
 tags="queue=${QUEUE},kind=docker,os=linux"
 build-path="/var/lib/buildkite-agent/builds"
 git-mirrors-path="/var/lib/gitmirrors"
+git-mirrors-skip-update=true
 git-clone-mirror-flags="-v --bare"
 hooks-path="/etc/buildkite-agent/hooks"
 plugins-path="/etc/buildkite-agent/plugins"


### PR DESCRIPTION
Updating the mirror takes a long time, especially for https://bazel.googlesource.com/bazel.git, since the Gerrit backend has to validate permissions for each reference.
See https://buildkite.com/bazel/google-bazel-presubmit/builds/99103#019be01e-1cfb-4f2b-92b7-7f30ff66d512

It also offers no benefit since we throw away the VM after each build.