### PR TITLE
Fix Windows VM setup

### DIFF
--- a/buildkite/setup-windows.ps1
+++ b/buildkite/setup-windows.ps1
@@ -159,7 +159,7 @@ Write-Host "Installing Visual C++ 2022 Build Tools..."
 & choco install visualstudio2022-workload-vctools --params "--add Microsoft.VisualStudio.Component.VC.Tools.ARM --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"
 
 ## Install Visual C++ 2026 Build Tools.
-Write-Host "Installing Visual C++ 2022 Build Tools..."
+Write-Host "Installing Visual C++ 2026 Build Tools..."
 & choco install visualstudio2026buildtools
 & choco install visualstudio2026-workload-vctools --params "--add Microsoft.VisualStudio.Component.VC.Tools.ARM --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"
 
@@ -380,6 +380,7 @@ $port.WriteLine("[setup-windows.ps1]: Setup windows done, rebooting...")
 $port.Close()
 
 Restart-Computer
+
 
 
 


### PR DESCRIPTION
- Remove hacks for VS 2022 due to https://github.com/bazelbuild/bazel/issues/22656, the hack no longer works and hopefully this is no longer needed.
- Also install VS 2026, but keep using 2022 as default