### PR TITLE
Moving buildfarm to disabled pipeline

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -145,6 +145,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     "Buildfarm": {
         "git_repository": "https://github.com/buildfarm/buildfarm.git",
         "pipeline_slug": "buildfarm-farmer",
+        "disabled_reason": "https://github.com/buildfarm/buildfarm/issues/2396",
     },
     "Buildtools": {
         "git_repository": "https://github.com/bazelbuild/buildtools.git",


### PR DESCRIPTION
Disabled due to reason : https://github.com/buildfarm/buildfarm/issues/2396