### PR TITLE
Support new buildifier release naming for linux_amd64

### DIFF
--- a/buildifier/buildifier.py
+++ b/buildifier/buildifier.py
@@ -151,7 +151,7 @@ def get_releases():
 
 def get_release_urls(release):
     for asset in release["assets"]:
-        if asset["name"] in ["buildifier", "buildifier-linux-amd64"]:
+        if asset["name"] in ["buildifier", "buildifier-linux-amd64", "buildifier-linux_amd64"]:
             return release["html_url"], asset["browser_download_url"]
     raise Exception(
         "There is no Buildifier binary for release {}".format(release["tag_name"])


### PR DESCRIPTION
The CI script fails when attempting to download any buildifier version because the releases asset content does not match buildifier or buildifier-linux-amd64.
Make the get_release_url method support the new buildifier-linux_amd64 asset name associated with v8.5.1:

```
Downloading Buildifier version '8.2.1'
--
🛠️ Printing raw output for debugging
##### :bazel: buildifier: error while downloading Buildifier:
<pre><code>There is no Buildifier binary for release v8.5.1</code></pre>
 
See [job 019c0b2b-ffb9-45eb-9d73-e7ae090afe54](#019c0b2b-ffb9-45eb-9d73-e7ae090afe54)
```
Observed here: https://buildkite.com/bazel/buildfarm-farmer/builds/12533/steps/canvas?sid=019c0b2b-ff6c-4bab-9425-336368855db4