### PR TITLE
Revert e4266a146b5a295a6b5a7e9adaa2145a03de84e5 and 3e049f0012fc96bb1…

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -4711,9 +4711,6 @@ def main(argv=None):
     except BuildkiteException as e:
         eprint(str(e))
         return e.exit_code
-    except Exception as ex:
-        eprint(str(ex))
-        return 1
     return 0
 
 


### PR DESCRIPTION
…b59acc3dfc2787dd50f9640

The stack trace is actually more useful for debugging. We still need to fix the swallowed exit code (likely due to the fact that we pipe everything through tee).