### PR TITLE
feat: append function for appending to inherited lists

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -47,6 +47,38 @@ import yaml
 # Initialize the random number generator.
 random.seed()
 
+class AppendList(list):
+    pass
+
+class BazelCILoader(yaml.SafeLoader):
+    def construct_mapping(self, node, deep=False):
+        self.flatten_mapping(node)
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            try:
+                hash(key)
+            except TypeError as exc:
+                raise yaml.constructor.ConstructorError('while constructing a mapping', node.start_mark,
+                        'found unacceptable key (%s)' % exc, key_node.start_mark)
+            value = self.construct_object(value_node, deep=deep)
+            
+            if key in mapping and isinstance(value, AppendList):
+                if isinstance(mapping[key], list):
+                    mapping[key] = mapping[key] + value
+                elif isinstance(mapping[key], dict):
+                    mapping[key] = list(mapping[key].keys()) + value
+                else:
+                    mapping[key] = value
+            else:
+                mapping[key] = value
+        return mapping
+
+def append_constructor(loader, node):
+    return AppendList(loader.construct_sequence(node))
+
+BazelCILoader.add_constructor('!append', append_constructor)
+
 BUILDKITE_ORG = os.environ.get("BUILDKITE_ORGANIZATION_SLUG", "bazel")
 THIS_IS_PRODUCTION = BUILDKITE_ORG == "bazel"
 THIS_IS_TESTING = BUILDKITE_ORG == "bazel-testing"
@@ -1180,7 +1212,7 @@ def load_config(http_url, file_config, allow_imports=True, bazel_version=None):
     else:
         file_config = file_config or ".bazelci/presubmit.yml"
         with open(file_config, "r") as fd:
-            config = yaml.safe_load(fd)
+            config = yaml.load(fd, Loader=BazelCILoader)
 
     # Legacy mode means that there is exactly one task per platform (e.g. ubuntu1604_nojdk),
     # which means that we can get away with using the platform name as task ID.
@@ -1216,7 +1248,7 @@ def load_config(http_url, file_config, allow_imports=True, bazel_version=None):
 def load_remote_yaml_file(http_url):
     with urllib.request.urlopen(http_url) as resp:
         reader = codecs.getreader("utf-8")
-        return yaml.safe_load(reader(resp))
+        return yaml.load(reader(resp), Loader=BazelCILoader)
 
 
 def load_imported_tasks(import_name, http_url, file_config, bazel_version):

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -405,5 +405,41 @@ tasks:
         ])
 
 
+class AppendTagTest(unittest.TestCase):
+    _CONFIGS = yaml.load(
+        """
+base_config: &base_config
+  build_flags:
+    - a
+    - b
+
+dict_config: &dict_config
+  build_flags:
+    ? a
+    ? b
+
+tasks:
+  linux:
+    <<: *base_config
+    build_flags: !append
+      - c
+      - a
+  linux_dict:
+    <<: *dict_config
+    build_flags: !append
+      - c
+      - a
+        """, Loader=bazelci.BazelCILoader
+    )
+
+    def test_append_tag(self):
+        tasks = self._CONFIGS.get("tasks")
+        self.assertEqual(tasks["linux"]["build_flags"], ["a", "b", "c", "a"])
+
+    def test_append_tag_with_dict(self):
+        tasks = self._CONFIGS.get("tasks")
+        self.assertEqual(tasks["linux_dict"]["build_flags"], ["a", "b", "c", "a"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Today, re-using a job config with modified e.g. `build_flags` is tedious because
regular YAML behavior doesn't support "inheriting" of a value for modification. For
example, a base job config might set some common build flags (e.g. `--keep_going`).
When a specific job is based upon that base job config, it may want to add additional
`build_flags`. However, because the job config uses `<<:` to copy the base config,
when `build_flags: ...` is set, it completely replaces the value "inherited" from
the base config. The derived config then needs to copy/paste the values, or define
a sub-alias and manually merge the value in. This is tedious and error-prone.

To fix, introduce a `!append` YAML tag. This basically operates as a pre-processor
for how the YAML node is process. When present, the final list is the original
list with the values in the node appended to it. This allows using `<<:` to
copy the base config at the job level, then `build_flags: !append` to add extra
values to the inherited values. e.g.

```
.base_config: &base_config
  build_flags:
    - "--base-flag"

tasks:
  linux:
    <<: *base_config
  build_flags: !append
    - "--extra-flag"
```