### PR TITLE
bazelci: support expanding matrix values in strings

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -996,11 +996,18 @@ def match_matrix_attr_pattern(s):
     return re.match(r"^\${{\s*(\w+)\s*}}$", s)
 
 
+def substitute_matrix_attr_patterns(s, lookup):
+    return re.sub(
+        r"\${{\s*(\w+)\s*}}",
+        lambda match: str(lookup[match.group(1)].value),
+        s,
+    )
+
+
 def get_matrix_attributes_for_value(value):
     if isinstance(value, str):
-        res = match_matrix_attr_pattern(value)
-        if res:
-            yield res.groups()[0]
+        for attr in re.findall(r"\${{\s*(\w+)\s*}}", value):
+            yield attr
     elif isinstance(value, list):
         for subvalue in value:
             yield from get_matrix_attributes_for_value(subvalue)
@@ -1096,6 +1103,8 @@ def expand_task_for_value(value, parent, parent_item, lookup):
         if res:
             attr = res.groups()[0]
             parent[parent_item] = lookup[attr].value
+        elif re.search(r"\${{\s*(\w+)\s*}}", value):
+            parent[parent_item] = substitute_matrix_attr_patterns(value, lookup)
     elif isinstance(value, list):
         for i, subvalue in enumerate(value):
             expand_task_for_value(subvalue, parent[parent_item], i, lookup)

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -269,6 +269,48 @@ tasks:
             ],
         )
 
+    def test_embedded_matrix_expansion(self):
+        config = yaml.safe_load(
+            """
+matrix:
+  bazel_version:
+    7.x: 7.7.1
+    8.x: 8.6.0
+tasks:
+  embedded:
+    name: "Embedded {bazel_version}"
+    build_flags:
+      - --config=bazel-${{ bazel_version }}
+      - --bazel_version=${{ bazel_version }}
+      - prefix-${{ bazel_version }}-suffix
+            """
+        )
+
+        bazelci.expand_task_config(config)
+        expanded_tasks = list(config["tasks"].values())
+
+        self.assertEqual(
+            expanded_tasks,
+            [
+                dict(
+                    name="Embedded 7.x",
+                    build_flags=[
+                        "--config=bazel-7.7.1",
+                        "--bazel_version=7.7.1",
+                        "prefix-7.7.1-suffix",
+                    ],
+                ),
+                dict(
+                    name="Embedded 8.x",
+                    build_flags=[
+                        "--config=bazel-8.6.0",
+                        "--bazel_version=8.6.0",
+                        "prefix-8.6.0-suffix",
+                    ],
+                ),
+            ],
+        )
+
 
 class MatrixExclude(unittest.TestCase):
     _CONFIGS_SINGLE_EXCLUDE = yaml.safe_load(


### PR DESCRIPTION
It previously only supported expanding them if they were the entire string, which precludes things like `--config=bazel-${{ bazel_version }}`