### PR TITLE
Moving the Rules_python to disabled pipeline

### DIFF
--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -30,6 +30,7 @@ few:
 platforms.
 * The *bazel presubmit* pipeline is triggered on every pull request to Bazel.
 * The *rules_go postsubmit* pipeline is triggered on every commit to the [rules_go] repository.
+* The *rules_python* pipeline is currently disabled due to ongoing issues. See: https://github.com/bazel-contrib/rules_python/issues/3566, https://github.com/bazel-contrib/rules_python/issues/3581
 * The *TensorFlow* pipeline builds and tests TensorFlow at `HEAD` every four hours.
 
 ### Builds

--- a/buildkite/README.md
+++ b/buildkite/README.md
@@ -31,6 +31,7 @@ platforms.
 * The *bazel presubmit* pipeline is triggered on every pull request to Bazel.
 * The *rules_go postsubmit* pipeline is triggered on every commit to the [rules_go] repository.
 * The *rules_python* pipeline is currently disabled due to ongoing issues. See: https://github.com/bazel-contrib/rules_python/issues/3566, https://github.com/bazel-contrib/rules_python/issues/3581
+* The *rules_python* pipeline is currently disabled due to ongoing issues. See: https://github.com/bazel-contrib/rules_python/issues/3566, https://github.com/bazel-contrib/rules_python/issues/3581
 * The *TensorFlow* pipeline builds and tests TensorFlow at `HEAD` every four hours.
 
 ### Builds

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -233,6 +233,7 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
     "rules_python": {
         "git_repository": "https://github.com/bazel-contrib/rules_python.git",
         "pipeline_slug": "rules-python-python",
+        "disabled_reason": "https://github.com/bazel-contrib/rules_python/issues/3566, https://github.com/bazel-contrib/rules_python/issues/3581"
     },
     "rules_testing": {
         "git_repository": "https://github.com/bazelbuild/rules_testing.git",


### PR DESCRIPTION
Moving the rules python repo to disabled pipeline because of pending issues.

https://github.com/bazel-contrib/rules_python/issues/3566
https://github.com/bazel-contrib/rules_python/issues/3581
https://github.com/bazel-contrib/rules_python/issues/3613