### PR TITLE
fix: remove privileged mode, host network, and docker.sock mount from CI containers

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3022,8 +3022,6 @@ def create_docker_step(label, image, commands=None, additional_env_vars=None, qu
                 "always-pull": True,
                 "environment": env,
                 "image": image,
-                "network": "host",
-                "privileged": True,
                 "propagate-environment": True,
                 "propagate-uid-gid": True,
                 "volumes": [
@@ -3033,9 +3031,8 @@ def create_docker_step(label, image, commands=None, additional_env_vars=None, qu
                     "/opt/android-ndk-r15c:/opt/android-ndk-r15c:ro",
                     "/opt/android-ndk-r25b:/opt/android-ndk-r25b:ro",
                     "/opt/android-sdk-linux:/opt/android-sdk-linux:ro",
-                    "/var/lib/buildkite-agent:/var/lib/buildkite-agent",
+                    "/var/lib/buildkite-agent:/var/lib/buildkite-agent:ro",
                     "/var/lib/gitmirrors:/var/lib/gitmirrors:ro",
-                    "/var/run/docker.sock:/var/run/docker.sock",
                 ],
             }
         },


### PR DESCRIPTION
## Container escape via privileged Docker config on CI runners

CI containers run with `privileged: True`, `network: host`, and `/var/run/docker.sock` mounted (bazelci.py:3025-3038). Any code running inside the container can escape to the host:

```
docker run -v /:/host --privileged alpine chroot /host
```

The `/var/lib/buildkite-agent` volume is also mounted writable, giving access to agent tokens and credentials.

This means any build action that executes code (malicious dependency, build script, test) gets full host access, not just container access.

Full PoC exploit: https://issuetracker.google.com/issues/496801241

See also #2543

## Fix

- Remove `privileged: True`
- Remove `network: host`
- Remove `/var/run/docker.sock` mount
- Make `/var/lib/buildkite-agent` read-only