### PR TITLE
Add Ubuntu 24.04 Java 25 Docker image

### DIFF
--- a/buildkite/docker/build.sh
+++ b/buildkite/docker/build.sh
@@ -68,6 +68,7 @@ docker_build -f ubuntu2004/Dockerfile   --builder mp-builder --load --platform=l
 docker_build -f ubuntu2204/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2204-java17 -t "gcr.io/$PREFIX/ubuntu2204-java17" ubuntu2204 & pids+=($!)
 docker_build -f ubuntu2204/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2204        -t "gcr.io/$PREFIX/ubuntu2204" ubuntu2204 & pids+=($!)
 docker_build -f ubuntu2404/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2404        -t "gcr.io/$PREFIX/ubuntu2404" ubuntu2404 & pids+=($!)
+docker_build -f ubuntu2404/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2404-java25 -t "gcr.io/$PREFIX/ubuntu2404-java25" ubuntu2404 & pids+=($!)
 docker_build -f fedora39/Dockerfile   --target fedora39-java17   -t "gcr.io/$PREFIX/fedora39-java17" fedora39 & pids+=($!)
 docker_build -f fedora40/Dockerfile   --target fedora40-java21   -t "gcr.io/$PREFIX/fedora40-java21" fedora40 & pids+=($!)
 docker_build -f fedora43/Dockerfile   --target fedora43-java25   -t "gcr.io/$PREFIX/fedora43-java25" fedora43 & pids+=($!)

--- a/buildkite/docker/push.sh
+++ b/buildkite/docker/push.sh
@@ -34,6 +34,7 @@ docker push "gcr.io/$PREFIX/ubuntu2204-kythe" &
 docker push "gcr.io/$PREFIX/ubuntu2204-bazel-java17" &
 docker push "gcr.io/$PREFIX/ubuntu2204" &
 docker push "gcr.io/$PREFIX/ubuntu2404" &
+docker push "gcr.io/$PREFIX/ubuntu2404-java25" &
 docker push "gcr.io/$PREFIX/ubuntu2404-kythe" &
 docker push "gcr.io/$PREFIX/fedora39-java17" &
 docker push "gcr.io/$PREFIX/fedora39-bazel-java17" &

--- a/buildkite/docker/ubuntu2404/Dockerfile
+++ b/buildkite/docker/ubuntu2404/Dockerfile
@@ -85,10 +85,20 @@ RUN LATEST_BUILDIFIER=$(curl -sSI https://github.com/bazelbuild/buildtools/relea
 FROM ubuntu2404-nojdk AS ubuntu2404
 
 RUN apt-get -y update && \
-    apt-get -y install openjdk-21-jdk-headless && \
+    apt-get -y install --no-install-recommends \
+    openjdk-21-jdk-headless && \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk-${TARGETARCH}
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-${TARGETARCH}
+
+FROM ubuntu2404-nojdk AS ubuntu2404-java25
+
+RUN apt-get -y update && \
+    apt-get -y install --no-install-recommends \
+    openjdk-25-jdk-headless && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-25-openjdk-${TARGETARCH}
 
 FROM ubuntu2404 AS ubuntu2404-kythe
 


### PR DESCRIPTION
Keep ubuntu2404 on the default JDK 21 and add a separate ubuntu2404-java25 image. Also wire the new image into the Docker build and push scripts.