### PR TITLE
Delete archived android-studio-plugin pipeline from Terraform config

### DIFF
--- a/buildkite/terraform/bazel/pipelines_misc.tf
+++ b/buildkite/terraform/bazel/pipelines_misc.tf
@@ -432,56 +432,6 @@ resource "buildkite_pipeline" "grpc-ecosystem-grpc-gateway" {
   }
 }
 
-resource "buildkite_pipeline" "android-studio-plugin" {
-  name           = "Android Studio Plugin"
-  repository     = "https://github.com/bazelbuild/intellij.git"
-  default_branch = "master"
-  steps = templatefile("pipeline.yml.tpl", {
-    envs = {},
-    steps = {
-      commands = [
-        "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py",
-        "python3.6 bazelci.py project_pipeline --file_config=.bazelci/android-studio.yml --monitor_flaky_tests=true | tee /dev/tty | buildkite-agent pipeline upload"
-      ]
-    }
-  })
-  allow_rebuilds             = true
-  branch_configuration       = "!google"
-  cancel_intermediate_builds = false
-  skip_intermediate_builds   = false
-  tags                       = []
-  cluster_id                 = null
-  color                      = null
-  default_team_id            = null
-  emoji                      = null
-  pipeline_template_id       = null
-  provider_settings = {
-    trigger_mode                                  = "code"
-    build_branches                                = true
-    build_pull_requests                           = true
-    build_tags                                    = false
-    build_pull_request_forks                      = true
-    build_pull_request_ready_for_review           = false
-    build_pull_request_labels_changed             = false
-    build_pull_request_base_branch_changed        = false
-    prefix_pull_request_fork_branch_names         = true
-    filter_enabled                                = true
-    filter_condition                              = "build.pull_request.base_branch != \"google\""
-    pull_request_branch_filter_enabled            = false
-    pull_request_branch_filter_configuration      = ""
-    publish_commit_status                         = true
-    publish_commit_status_per_step                = false
-    separate_pull_request_statuses                = false
-    publish_blocked_as_pending                    = false
-    cancel_deleted_branch_builds                  = false
-    skip_builds_for_existing_commits              = false
-    skip_pull_request_builds_for_existing_commits = true
-    ignore_default_branch_pull_requests           = false
-    build_merge_group_checks_requested            = false
-    cancel_when_merge_group_destroyed             = false
-    use_merge_group_base_commit_for_git_diff_base = false
-  }
-}
 
 resource "buildkite_pipeline" "distributed-point-functions" {
   name           = "Distributed Point Functions"


### PR DESCRIPTION
The pipeline android-studio-plugin was archived in Buildkite, which caused Terraform updates to fail because Terraform cannot update archived pipelines. This PR deletes the pipeline from Terraform config.