### PR TITLE
Deploy Terraform nightly for all organizations

### DIFF
--- a/.github/workflows/terraform-nightly.yml
+++ b/.github/workflows/terraform-nightly.yml
@@ -1,0 +1,45 @@
+name: "Terraform: Nightly Deployment"
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Every night at 2 AM UTC
+
+# go/github-security: Explicitly set minimum permissions
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  terraform-nightly:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        org: ["bazel", "bazel-trusted", "bazel-testing"]
+
+    defaults:
+      run:
+        working-directory: ./buildkite/terraform/${{ matrix.org }}
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+      with:
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      with:
+        terraform_wrapper: false
+        terraform_version: "1.9.5"
+    
+    - name: Terraform Init
+      run: terraform init
+
+    - name: Terraform Apply
+      env:
+        TF_VAR_buildkite_api_token: ${{ secrets.BUILDKITE_API_TOKEN }}
+      run: terraform apply -auto-approve -input=false


### PR DESCRIPTION
This PR adds `.github/workflows/terraform-nightly.yml` which applies Terraform for `bazel`, `bazel-trusted`, and `bazel-testing` automatically every night at 2 AM UTC using a Matrix strategy. This naturally overrides modifications made directly via the Buildkite UI.