### PR TITLE
Move metadata.json check from bcr_presubmit.py to BCR reviewer

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -486,7 +486,7 @@ async function reviewPR(octokit, owner, repo, prNumber) {
 
   if (hasSensitiveMetadataChange && !isNewModule) {
     await postComment(octokit, owner, repo, prNumber,
-      `Hello BCR maintainers, modules with sensitive metadata modifications (outside versions array) have been updated in this PR. Manual reviews are strictly necessary.`);
+      `Hello BCR maintainers, modules with sensitive metadata modifications (outside versions array) have been updated in this PR. Manual reviews are necessary.`);
     await requestBcrMaintainers(octokit, owner, repo, prNumber);
   }
 

--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -371,6 +371,42 @@ async function isModuleMaintainer(octokit, owner, repo, prAuthorId) {
   }
 }
 
+async function hasSensitiveMetadataChanges(octokit, owner, repo, prNumber, allModulesWithMetadataChange) {
+  for (const moduleName of allModulesWithMetadataChange) {
+    try {
+      const { data: metadataContentMain } = await octokit.rest.repos.getContent({
+        owner,
+        repo,
+        path: `modules/${moduleName}/metadata.json`,
+        ref: 'main',
+      });
+      const metadataMain = JSON.parse(Buffer.from(metadataContentMain.content, 'base64').toString('utf-8'));
+
+      const { data: metadataContentHead } = await octokit.rest.repos.getContent({
+        owner,
+        repo,
+        path: `modules/${moduleName}/metadata.json`,
+        ref: `refs/pull/${prNumber}/head`,
+      });
+      const metadataHead = JSON.parse(Buffer.from(metadataContentHead.content, 'base64').toString('utf-8'));
+
+      metadataMain.versions = [];
+      metadataHead.versions = [];
+
+      if (JSON.stringify(metadataMain) !== JSON.stringify(metadataHead)) {
+        return { isSensitive: true, isNewModule: false };
+      }
+    } catch (error) {
+      if (error.status === 404) {
+        return { isSensitive: true, isNewModule: true };
+      } else {
+        throw error;
+      }
+    }
+  }
+  return { isSensitive: false, isNewModule: false };
+}
+
 async function reviewPR(octokit, owner, repo, prNumber) {
   console.log('\n');
   console.log(`Processing PR #${prNumber}`);
@@ -424,41 +460,14 @@ async function reviewPR(octokit, owner, repo, prNumber) {
   }
 
   let hasSensitiveMetadataChange = false;
-  for (const moduleName of allModulesWithMetadataChange) {
-    try {
-      const { data: metadataContentMain } = await octokit.rest.repos.getContent({
-        owner,
-        repo,
-        path: `modules/${moduleName}/metadata.json`,
-        ref: 'main',
-      });
-      const metadataMain = JSON.parse(Buffer.from(metadataContentMain.content, 'base64').toString('utf-8'));
-
-      const { data: metadataContentHead } = await octokit.rest.repos.getContent({
-        owner,
-        repo,
-        path: `modules/${moduleName}/metadata.json`,
-        ref: `refs/pull/${prNumber}/head`,
-      });
-      const metadataHead = JSON.parse(Buffer.from(metadataContentHead.content, 'base64').toString('utf-8'));
-
-      metadataMain.versions = [];
-      metadataHead.versions = [];
-
-      if (JSON.stringify(metadataMain) !== JSON.stringify(metadataHead)) {
-        hasSensitiveMetadataChange = true;
-        break;
-      }
-    } catch (error) {
-      if (error.status === 404) {
-        // The metadata.json file is newly created! This is a sensitive change.
-        hasSensitiveMetadataChange = true;
-        break;
-      } else {
-        console.error(`Error checking metadata.json sensitive revisions for module ${moduleName}: ${error}`);
-        return;
-      }
-    }
+  let isNewModule = false;
+  try {
+    const result = await hasSensitiveMetadataChanges(octokit, owner, repo, prNumber, allModulesWithMetadataChange);
+    hasSensitiveMetadataChange = result.isSensitive;
+    isNewModule = result.isNewModule;
+  } catch (error) {
+    console.error(`Error checking metadata.json sensitive revisions: ${error}`);
+    return;
   }
 
   // Re-fetch PR information to check if new commits were pushed since analysis started
@@ -475,7 +484,7 @@ async function reviewPR(octokit, owner, repo, prNumber) {
     return; // Exit reviewPR for this PR to prevent actions on stale data
   }
 
-  if (hasSensitiveMetadataChange) {
+  if (hasSensitiveMetadataChange && !isNewModule) {
     await postComment(octokit, owner, repo, prNumber,
       `Hello BCR maintainers, modules with sensitive metadata modifications (outside versions array) have been updated in this PR. Manual reviews are strictly necessary.`);
     await requestBcrMaintainers(octokit, owner, repo, prNumber);
@@ -609,26 +618,7 @@ async function runNotifier(octokit) {
     await requestBcrMaintainers(octokit, owner, repo, prNumber);
   }
 
-  // Notify BCR maintainers for modules with only metadata.json changes
-  const allModulesWithMetadataChange = await fetchAllModulesWithMetadataChange(octokit, owner, repo, prNumber);
-  if (allModulesWithMetadataChange === null) {
-    // This means the PR was updated while fetching files.
-    console.log(`Aborting notifier for PR #${prNumber} because it was updated during file fetching.`);
-    return;
-  }
 
-  const modulesWithOnlyMetadataChanges = new Set(
-    [...allModulesWithMetadataChange].filter(module => !modifiedModules.has(module))
-  );
-
-  if (modulesWithOnlyMetadataChanges.size > 0) {
-    const modulesList = Array.from(modulesWithOnlyMetadataChanges).join(', ');
-    console.log(`Requesting review from BCR maintainers for modules with only metadata.json changes: ${modulesList}`);
-    await postComment(octokit, owner, repo, prNumber,
-      `Hello BCR maintainers, modules with only metadata.json changes (${modulesList}) have been updated in this PR.
-      Please review the changes.`);
-    await requestBcrMaintainers(octokit, owner, repo, prNumber);
-  }
 }
 
 async function waitForDismissApprovalsWorkflow(octokit, owner, repo) {

--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -416,6 +416,51 @@ async function reviewPR(octokit, owner, repo, prNumber) {
   const prAuthor = prInfo.data.user.login.toLowerCase();
   const { allModulesApproved, anyModuleApproved } = await checkIfAllModifiedModulesApproved(modifiedModules, maintainersMap, approvers, prAuthor);
 
+  // Fetch modules with metadata changes
+  const allModulesWithMetadataChange = await fetchAllModulesWithMetadataChange(octokit, owner, repo, prNumber);
+  if (allModulesWithMetadataChange === null) {
+    console.log(`Aborting review for PR #${prNumber} because it was updated during file fetching.`);
+    return;
+  }
+
+  let hasSensitiveMetadataChange = false;
+  for (const moduleName of allModulesWithMetadataChange) {
+    try {
+      const { data: metadataContentMain } = await octokit.rest.repos.getContent({
+        owner,
+        repo,
+        path: `modules/${moduleName}/metadata.json`,
+        ref: 'main',
+      });
+      const metadataMain = JSON.parse(Buffer.from(metadataContentMain.content, 'base64').toString('utf-8'));
+
+      const { data: metadataContentHead } = await octokit.rest.repos.getContent({
+        owner,
+        repo,
+        path: `modules/${moduleName}/metadata.json`,
+        ref: `refs/pull/${prNumber}/head`,
+      });
+      const metadataHead = JSON.parse(Buffer.from(metadataContentHead.content, 'base64').toString('utf-8'));
+
+      metadataMain.versions = [];
+      metadataHead.versions = [];
+
+      if (JSON.stringify(metadataMain) !== JSON.stringify(metadataHead)) {
+        hasSensitiveMetadataChange = true;
+        break;
+      }
+    } catch (error) {
+      if (error.status === 404) {
+        // The metadata.json file is newly created! This is a sensitive change.
+        hasSensitiveMetadataChange = true;
+        break;
+      } else {
+        console.error(`Error checking metadata.json sensitive revisions for module ${moduleName}: ${error}`);
+        return;
+      }
+    }
+  }
+
   // Re-fetch PR information to check if new commits were pushed since analysis started
   const initialHeadSha = prInfo.data.head.sha;
   const latestPrInfoForShaCheck = await octokit.rest.pulls.get({
@@ -430,11 +475,17 @@ async function reviewPR(octokit, owner, repo, prNumber) {
     return; // Exit reviewPR for this PR to prevent actions on stale data
   }
 
+  if (hasSensitiveMetadataChange) {
+    await postComment(octokit, owner, repo, prNumber,
+      `Hello BCR maintainers, modules with sensitive metadata modifications (outside versions array) have been updated in this PR. Manual reviews are strictly necessary.`);
+    await requestBcrMaintainers(octokit, owner, repo, prNumber);
+  }
+
   const { data } = await octokit.rest.users.getAuthenticated();
   const myLogin = data.login.toLowerCase();
 
   // Approve the PR if not previously approved and all modules are approved
-  if (allModulesApproved) {
+  if (allModulesApproved && !hasSensitiveMetadataChange) {
     if (!approvers.has(myLogin)) {
       console.log('Approving the PR');
       await octokit.rest.pulls.createReview({

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -417,46 +417,6 @@ def file_exists_in_main_branch(file_path):
     return result.stdout.strip() != ""
 
 
-def should_metadata_change_block_presubmit(modules_with_metadata_change, pr_labels):
-    # Skip the metadata.json check if the PR is labeled with "presubmit-auto-run".
-    if "presubmit-auto-run" in pr_labels:
-        return False
-
-    bazelci.print_expanded_group("Checking metadata.json file changes:")
-
-    # If information like, maintainers, homepage, repository is changed, the presubmit should wait for a BCR maintainer review.
-    # For each changed module, check if anything other than the "versions" field is changed in the metadata.json file.
-    needs_bcr_maintainer_review = False
-    for name in modules_with_metadata_change:
-        metadata_json = get_metadata_json(name)
-
-        if not file_exists_in_main_branch(metadata_json):
-            bazelci.eprint("\x1b[33mWARNING\x1b[0m: The metadata.json file for '%s' is newly created!\n" % name)
-            needs_bcr_maintainer_review = True
-            continue
-
-        # Read the new metadata.json file.
-        metadata_new = json.load(open(metadata_json, "r"))
-
-        # Check out and read the original metadata.json file from the main branch.
-        subprocess.run(["git", "checkout", "main", "--", metadata_json], check=True)
-        metadata_old = json.load(open(metadata_json, "r"))
-
-        # Revert the metadata.json file to the HEAD of current branch.
-        subprocess.run(["git", "checkout", "HEAD", "--", metadata_json], check=True)
-
-        # Clear the "versions" field and compare the rest of the metadata.json file.
-        metadata_old["versions"] = []
-        metadata_new["versions"] = []
-        if metadata_old != metadata_new:
-            bazelci.eprint("\x1b[33mWARNING\x1b[0m: The change in metadata.json file for '%s' needs BCR maintainer review!\n" % name)
-            needs_bcr_maintainer_review = True
-        else:
-            bazelci.eprint("The change in metadata.json file for '%s' looks good!\n" % name)
-
-    return needs_bcr_maintainer_review
-
-
 def should_wait_bcr_maintainer_review(modules, pr_labels):
     """Validate the changes and decide whether the presubmit should wait for a BCR maintainer review.
     Returns False if all changes look good and the presubmit can proceed.
@@ -472,8 +432,7 @@ def should_wait_bcr_maintainer_review(modules, pr_labels):
     # Get modules with metadata.json changes.
     modules_with_metadata_change = get_modules_with_metadata_change()
 
-    # Check if any changes in the metadata.json file need a manual review.
-    needs_bcr_maintainer_review = should_metadata_change_block_presubmit(modules_with_metadata_change, pr_labels)
+    needs_bcr_maintainer_review = False
 
     # Run BCR validations on target modules and decide if the presubmit jobs should be blocked.
     if should_bcr_validation_block_presubmit(modules, modules_with_metadata_change, pr_labels):

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -432,13 +432,8 @@ def should_wait_bcr_maintainer_review(modules, pr_labels):
     # Get modules with metadata.json changes.
     modules_with_metadata_change = get_modules_with_metadata_change()
 
-    needs_bcr_maintainer_review = False
-
     # Run BCR validations on target modules and decide if the presubmit jobs should be blocked.
-    if should_bcr_validation_block_presubmit(modules, modules_with_metadata_change, pr_labels):
-        needs_bcr_maintainer_review = True
-
-    return needs_bcr_maintainer_review
+    return should_bcr_validation_block_presubmit(modules, modules_with_metadata_change, pr_labels)
 
 
 def get_bazel_version_for_task(config_file, task, overwrite_bazel_version=None):


### PR DESCRIPTION
This will require BCR maintainer review for any metadata.json changes
beyond the version field.

Context https://github.com/bazelbuild/bazel-central-registry/pull/8202