### PR TITLE
fix(bcr-pr-reviewer): require write permission before skip_check

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -750,6 +750,34 @@ async function runSkipCheck(octokit) {
   const check = commentBody.slice(SKIP_CHECK_TRIGGER.length);
   const owner = payload.repository.owner.login;
   const repo = payload.repository.name;
+  const commenter = payload.comment.user.login;
+
+  // Only collaborators with write or admin access may skip checks.
+  // Without this guard any GitHub user can comment "@bazel-io skip_check <name>"
+  // and bypass BCR validation checks on any PR.
+  let isAuthorized = false;
+  try {
+    const { data: { permission } } = await octokit.rest.repos.getCollaboratorPermissionLevel({
+      owner,
+      repo,
+      username: commenter,
+    });
+    isAuthorized = ['admin', 'write'].includes(permission);
+  } catch (error) {
+    console.warn(`Could not verify permission level for ${commenter}: ${error.message}`);
+  }
+
+  if (!isAuthorized) {
+    console.log(`@${commenter} does not have write access and cannot skip checks.`);
+    await octokit.rest.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: payload.comment.id,
+      content: 'confused',
+    });
+    return;
+  }
+
   if (check == "unstable_url") {
     await octokit.rest.issues.addLabels({
       owner,


### PR DESCRIPTION
## Summary

The `runSkipCheck` function in `actions/bcr-pr-reviewer/index.js` adds BCR validation bypass labels to PRs in response to `@bazel-io skip_check <name>` comments. It currently does this **without verifying that the commenter is authorized**.

**The vulnerability:** Any GitHub user can comment on any BCR PR with `@bazel-io skip_check unstable_url` (or `compatibility_level` or `incompatible_flags`) and the bot will silently add the bypass label, circumventing BCR validation checks that protect the registry's integrity.

**Impact:** An attacker can:
1. Find any open BCR PR that would normally fail a URL stability, compatibility level, or incompatible flags check
2. Post `@bazel-io skip_check <check_name>` as a comment
3. The bot adds `skip-url-stability-check` / `skip-compatibility-level-check` / `skip-incompatible-flags-test` label
4. The PR passes checks it should have failed, allowing potentially unsafe module versions into the Bazel Central Registry

**Contrast with `runHandleComment`:** The `abandon` command handler (`runHandleComment`) already checks that the commenter is a module maintainer before closing a PR. The `skip_check` command has no equivalent check.

**Fix:** Add an authorization check using `getCollaboratorPermissionLevel` before processing the command. Only users with `write` or `admin` access can trigger the label addition; others receive a 'confused' reaction.

## Changes

- `actions/bcr-pr-reviewer/index.js`: Add `getCollaboratorPermissionLevel` check in `runSkipCheck` before adding any bypass labels

## Test Plan

- [ ] User with `write` or `admin` access comments `@bazel-io skip_check unstable_url` → label added, +1 reaction
- [ ] User without repo write access comments `@bazel-io skip_check unstable_url` → no label added, confused reaction
- [ ] Other `skip_check` variants (`compatibility_level`, `incompatible_flags`) behave the same way

---

*Reported to Google via OSS VRP. Fix PR submitted as part of responsible disclosure.*