### PR TITLE
fix: add authorization check to @bazel-io skip_check command

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -750,6 +750,31 @@ async function runSkipCheck(octokit) {
   const check = commentBody.slice(SKIP_CHECK_TRIGGER.length);
   const owner = payload.repository.owner.login;
   const repo = payload.repository.name;
+  const prNumber = context.issue.number;
+
+  // Authorization check: only maintainers of the modified modules may use
+  // @bazel-io skip_check.  This mirrors the same guard in runHandleComment.
+  const commenter = payload.comment.user.login.toLowerCase();
+  const modifiedModuleVersions = await fetchAllModifiedModuleVersions(octokit, owner, repo, prNumber);
+  const modifiedModules = new Set(Array.from(modifiedModuleVersions || []).map(module => module.split('@')[0]));
+  const [ maintainersMap ] = await generateMaintainersMap(octokit, owner, repo, modifiedModules, /* toNotifyOnly= */ false);
+  if (!maintainersMap.has(commenter)) {
+    console.log(`@${commenter} is not a maintainer of any modified modules, ignoring skip_check command.`);
+    await octokit.rest.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: payload.comment.id,
+      content: '-1',
+    });
+    await octokit.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body: `@${commenter}, you don't have permissions to use \`@bazel-io skip_check\` since you are not a maintainer of any of the modified modules.`,
+    });
+    return;
+  }
+
   if (check == "unstable_url") {
     await octokit.rest.issues.addLabels({
       owner,


### PR DESCRIPTION
## Summary

Any GitHub user can currently manipulate BCR PR labels by commenting
`@bazel-io skip_check <type>` on any open pull request. The three
affected labels are:

- `skip-url-stability-check` (via `skip_check unstable_url`)
- `skip-compatibility-level-check` (via `skip_check compatibility_level`)
- `skip-incompatible-flags-test` (via `skip_check incompatible_flags`)

Because `runSkipCheck` (around line 744) does not verify the commenter's
identity before adding labels, a non-maintainer — or a completely
unrelated GitHub user — can silently bypass BCR's URL-stability,
compatibility-level, and incompatible-flags checks simply by posting a
comment.

## Root cause

`runHandleComment` (line 804) already guards the `@bazel-io abandon`
command behind a maintainer check:

```javascript
const [ maintainersMap, _ ] = await generateMaintainersMap(...);
const isMaintainer = maintainersMap.has(commenter);
if (!isMaintainer) { /* react -1 and return */ }
```

`runSkipCheck` was missing this same pattern.

## Fix

Added the identical authorization guard at the top of `runSkipCheck`,
before any `addLabels` call:

1. Resolve the PR's modified modules via `fetchAllModifiedModuleVersions`.
2. Build the maintainers map via `generateMaintainersMap`.
3. If the commenter is **not** in the map, react with `-1`, post an
   explanatory comment, and return early — no label is added.
4. If the commenter **is** a maintainer, fall through to the existing
   label-adding logic unchanged.

## Test plan

- [ ] Comment `@bazel-io skip_check unstable_url` as a non-maintainer on a BCR PR — bot should react with `-1` and post a permission-denied message; no label added.
- [ ] Comment `@bazel-io skip_check unstable_url` as a legitimate module maintainer — bot should react with `+1` and add `skip-url-stability-check` as before.
- [ ] Same two checks for `compatibility_level` and `incompatible_flags`.
- [ ] Unknown check type still falls through to the `confused` reaction path.