### PR TITLE
bcr_presubmit: quote task_id in Buildkite command emission

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -25,6 +25,7 @@ import json
 import os
 import pathlib
 import re
+import shlex
 import sys
 import subprocess
 import shutil
@@ -150,8 +151,19 @@ def get_test_module_task_config(module_name, module_version, bazel_version=None)
     return {}
 
 
+# task_id is the YAML key under tasks: in a module's presubmit.yml, which is
+# attacker-controllable on every PR. Restrict the chars we accept and the chars
+# we'll embed into a Buildkite command line.
+VALID_TASK_ID_RE = re.compile(r"\A[A-Za-z0-9_.\-]+\Z")
+
+
 def add_presubmit_jobs(module_name, module_version, task_configs, pipeline_steps, is_test_module=False, overwrite_bazel_version=None, low_priority=False):
     for task_id, task_config in task_configs.items():
+        if not VALID_TASK_ID_RE.match(task_id):
+            raise bazelci.BuildkiteException(
+                "Invalid task id %r in %s@%s presubmit.yml: task ids must match %s"
+                % (task_id, module_name, module_version, VALID_TASK_ID_RE.pattern)
+            )
         platform_name = get_platform(task_id, task_config)
         platform_label = bazelci.PLATFORMS[platform_name]["emoji-name"]
         task_name = task_config.get("name", "")
@@ -162,13 +174,13 @@ def add_presubmit_jobs(module_name, module_version, task_configs, pipeline_steps
         if bazel_version and not overwrite_bazel_version:
             label = f":bazel:{bazel_version} - {label}"
         command = (
-            '%s bcr_presubmit.py %s --module_name="%s" --module_version="%s" --task=%s %s'
+            '%s bcr_presubmit.py %s --module_name=%s --module_version=%s --task=%s %s'
             % (
                 bazelci.PLATFORMS[platform_name]["python"],
                 "test_module_runner" if is_test_module else "anonymous_module_runner",
-                module_name,
-                module_version,
-                task_id,
+                shlex.quote(module_name),
+                shlex.quote(module_version),
+                shlex.quote(task_id),
                 "--overwrite_bazel_version=%s" % overwrite_bazel_version if overwrite_bazel_version else ""
             )
         )


### PR DESCRIPTION
## What

In `bcr_presubmit.add_presubmit_jobs`, `task_id` (a YAML key under `tasks:` in a module's `presubmit.yml`) is currently embedded as raw text into a shell command string that is then handed to the Buildkite agent's `/bin/sh`:

```python
command = (
    '%s bcr_presubmit.py %s --module_name="%s" --module_version="%s" --task=%s %s'
    % (..., module_name, module_version, task_id, ...)
)
```

`task_id` originates from `yaml.safe_load(...presubmit.yml)`, where keys can be arbitrary quoted strings — e.g. `"foo;id>/tmp/x;echo"`. Embedding it unquoted means shell metacharacters in a task id are interpreted by the Buildkite agent, not treated as part of the `--task=` value.

`module_name` and `module_version` are also embedded into the same command string. They're more constrained by other validation paths, but quoting them too is cheap insurance and keeps the composition consistent.

## Fix

Two-layer defense:

1. **At config-load time** (`add_presubmit_jobs`): reject `task_id` values that don't match `^[A-Za-z0-9_.\-]+$`. This is what BCR module authors already use in practice (e.g. `verify_build_targets`, `centos7_clang`); the regex is permissive enough to not require any module changes upstream and strict enough to leave no shell metacharacters.
2. **At command-composition time**: pass `task_id`, `module_name`, and `module_version` through `shlex.quote()`. The `--module_name="…"` literal quotes are removed since `shlex.quote()` adds the appropriate quoting itself.

`shlex` is stdlib, no new dependency.

## Regression test

A standalone test runs `add_presubmit_jobs` against:
- `"poc_validation_task;id>/tmp/x;echo"` — must raise `BuildkiteException`
- `"poc`id`"`, `"poc$(id)"`, `"poc|nc"`, `'poc";id;echo "'` — must raise
- `"verify_build_targets"`, `"verify-build_targets.v2"` — must succeed and emit a clean command

Before this PR, the first case emits:

```
python3.8 bcr_presubmit.py anonymous_module_runner --module_name="bcr_rce_demo" --module_version="1.0.0" --task=poc_validation_task;id>/tmp/x;echo
```

— `;`, `>`, and `echo` parse as separate shell commands when the Buildkite agent runs the step.

After this PR:

```
Invalid task id 'poc_validation_task;id>/tmp/x;echo' in bcr_rce_demo@1.0.0 presubmit.yml: task ids must match \A[A-Za-z0-9_.\-]+\Z
```

— pipeline generation aborts before any step is uploaded.

I'm happy to fold the regression test into a maintained location in the repo if there's a preferred home for it (I noted there are no `*_test.py` files under `buildkite/bazel-central-registry/`).

## Why now

External contributors can submit `presubmit.yml` files via PR, and `task_id` flowing into the Buildkite agent's shell as an unquoted argument means a crafted YAML key in a PR can change what the agent runs. Tightening the input shape and quoting the composition closes that off.