### PR TITLE
Migrate bcr_postsubmit.py from gsutil to gcloud storage

### DIFF
--- a/buildkite/bazel-central-registry/bcr_postsubmit.py
+++ b/buildkite/bazel-central-registry/bcr_postsubmit.py
@@ -153,11 +153,11 @@ def get_canonical_basename(url):
 def sync_bcr_content():
     print_expanded_group(":gcloud: Sync BCR content")
     subprocess.check_output(
-        ["gsutil", "-h", "Cache-Control:no-cache", "cp", "./bazel_registry.json", BCR_BUCKET]
+        ["gcloud", "storage", "cp", "--cache-control=no-cache", "./bazel_registry.json", BCR_BUCKET]
     )
     subprocess.check_output(
         # -c Use checksum to compare files
-        ["gsutil", "-h", "Cache-Control:no-cache", "-m", "rsync", "-c", "-r", "./modules", BCR_BUCKET + "modules"]
+        ["gcloud", "storage", "rsync", "--recursive", "--checksum", "--cache-control=no-cache", "./modules", BCR_BUCKET + "modules"]
     )
 
 
@@ -167,7 +167,7 @@ def update_last_green():
         f.write(get_commit())
 
     dest = os.path.join(BCR_BUCKET, LAST_GREEN_FILE)
-    subprocess.check_output(["gsutil", "cp", path, dest])
+    subprocess.check_output(["gcloud", "storage", "cp", path, dest])
 
 
 def main():


### PR DESCRIPTION
This PR updates bcr_postsubmit.py to use gcloud storage instead of gsutil, following [the migration guide](https://docs.cloud.google.com/storage/docs/gsutil-transition-to-gcloud).