### PR TITLE
Add BCR PR Reviewer pipeline to Buildkite Terraform

### DIFF
--- a/buildkite/terraform/bazel-trusted/pipelines_misc.tf
+++ b/buildkite/terraform/bazel-trusted/pipelines_misc.tf
@@ -387,6 +387,38 @@ resource "buildkite_pipeline" "bcr-postsubmit" {
   }
 }
 
+resource "buildkite_pipeline" "bcr-pr-reviewer" {
+  name           = "BCR PR Reviewer"
+  repository     = "https://github.com/bazelbuild/bazel-central-registry.git"
+  description    = "Periodically review PRs for the Bazel Central Registry"
+  default_branch = "main"
+  steps = templatefile("pipeline.yml.tpl", {
+    envs = {},
+    steps = {
+      commands = [
+        "git clone https://github.com/bazelbuild/continuous-integration.git",
+        "cd continuous-integration/actions/bcr-pr-reviewer",
+        "npm install",
+        "node index.js"
+      ],
+      label = ":pipeline:"
+    }
+  })
+  allow_rebuilds             = true
+  branch_configuration       = "main"
+  cancel_intermediate_builds = false
+  skip_intermediate_builds   = false
+  tags                       = []
+  cluster_id                 = null
+  color                      = null
+  default_team_id            = null
+  emoji                      = null
+  pipeline_template_id       = null
+  provider_settings = {
+    trigger_mode = "none"
+  }
+}
+
 resource "buildkite_pipeline" "docker-update" {
   name           = "Docker update"
   repository     = "https://github.com/bazelbuild/continuous-integration.git"

--- a/buildkite/terraform/bazel-trusted/pipelines_misc.tf
+++ b/buildkite/terraform/bazel-trusted/pipelines_misc.tf
@@ -400,7 +400,6 @@ resource "buildkite_pipeline" "bcr-pr-reviewer" {
         "npm install",
         "export INPUT_TOKEN=$(gcloud secrets versions access latest --secret=\"bcr-pr-review-helper-token\")",
         "export \"INPUT_ACTION-TYPE\"=review_prs",
-        "export INPUT_ACTION_TYPE=review_prs",
         "export GITHUB_REPOSITORY=bazelbuild/bazel-central-registry",
         "node index.js"
       ],

--- a/buildkite/terraform/bazel-trusted/pipelines_misc.tf
+++ b/buildkite/terraform/bazel-trusted/pipelines_misc.tf
@@ -389,24 +389,26 @@ resource "buildkite_pipeline" "bcr-postsubmit" {
 
 resource "buildkite_pipeline" "bcr-pr-reviewer" {
   name           = "BCR PR Reviewer"
-  repository     = "https://github.com/bazelbuild/bazel-central-registry.git"
+  repository     = "https://github.com/bazelbuild/continuous-integration.git"
   description    = "Periodically review PRs for the Bazel Central Registry"
-  default_branch = "main"
+  default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
     steps = {
       commands = [
-        "git clone https://github.com/bazelbuild/continuous-integration.git",
-        "cd continuous-integration/actions/bcr-pr-reviewer",
+        "cd actions/bcr-pr-reviewer",
         "npm install",
         "export INPUT_TOKEN=$(gcloud secrets versions access latest --secret=\"bcr-pr-review-helper-token\")",
+        "export \"INPUT_ACTION-TYPE\"=review_prs",
+        "export INPUT_ACTION_TYPE=review_prs",
+        "export GITHUB_REPOSITORY=bazelbuild/bazel-central-registry",
         "node index.js"
       ],
       label = ":pipeline:"
     }
   })
   allow_rebuilds             = true
-  branch_configuration       = "main"
+  branch_configuration       = "master"
   cancel_intermediate_builds = false
   skip_intermediate_builds   = false
   tags                       = []

--- a/buildkite/terraform/bazel-trusted/pipelines_misc.tf
+++ b/buildkite/terraform/bazel-trusted/pipelines_misc.tf
@@ -399,6 +399,7 @@ resource "buildkite_pipeline" "bcr-pr-reviewer" {
         "git clone https://github.com/bazelbuild/continuous-integration.git",
         "cd continuous-integration/actions/bcr-pr-reviewer",
         "npm install",
+        "export INPUT_TOKEN=$(gcloud secrets versions access latest --secret=\"bcr-pr-review-helper-token\")",
         "node index.js"
       ],
       label = ":pipeline:"


### PR DESCRIPTION
This PR adds a new Buildkite pipeline for the BCR PR Reviewer in the Bazel trusted organization Terraform configuration.

This will allow running the reviewer on a reliable schedule on trusted infrastructure, solving the issue of unreliable github action schedule.