### PR TITLE
actions/bcr-pr-reviewer: Update PR activity filter to 6 hours

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -685,9 +685,36 @@ async function runPrReviewer(octokit) {
 
   const sixHoursAgo = new Date(Date.now() - 6 * 60 * 60 * 1000);
 
-  // Review each PR that has activity in the past 6 hours
+  // Review each PR
   for (const pr of prs) {
-    if (new Date(pr.updated_at) >= sixHoursAgo) {
+    let isOughtToBeReviewed = new Date(pr.updated_at) >= sixHoursAgo;
+
+    // If not active by PR timestamp, check CI activity
+    if (!isOughtToBeReviewed) {
+      try {
+        console.log(`PR #${pr.number} is inactive by timestamp. Checking CI status...`);
+        const { data: checkRunsData } = await octokit.rest.checks.listForRef({
+          owner,
+          repo,
+          ref: pr.head.sha,
+        });
+
+        // Check if any check run completed or started in the last 6 hours
+        const hasRecentCiActivity = checkRunsData.check_runs.some(run => {
+          const timeToCompare = run.completed_at ? new Date(run.completed_at) : new Date(run.started_at);
+          return timeToCompare >= sixHoursAgo;
+        });
+
+        if (hasRecentCiActivity) {
+          console.log(`PR #${pr.number} has recent CI activity. Proceeding with review.`);
+          isOughtToBeReviewed = true;
+        }
+      } catch (error) {
+        console.error(`Failed to fetch check runs for PR #${pr.number}: ${error.message}`);
+      }
+    }
+
+    if (isOughtToBeReviewed) {
       await reviewPR(octokit, owner, repo, pr.number);
     } else {
       console.log(`Skipping PR #${pr.number} as it has no activity in the past 6 hours.`);

--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -683,9 +683,15 @@ async function runPrReviewer(octokit) {
     state: 'open',
   });
 
-  // Review each PR
+  const sixHoursAgo = new Date(Date.now() - 6 * 60 * 60 * 1000);
+
+  // Review each PR that has activity in the past 6 hours
   for (const pr of prs) {
-    await reviewPR(octokit, owner, repo, pr.number);
+    if (new Date(pr.updated_at) >= sixHoursAgo) {
+      await reviewPR(octokit, owner, repo, pr.number);
+    } else {
+      console.log(`Skipping PR #${pr.number} as it has no activity in the past 6 hours.`);
+    }
   }
 }
 


### PR DESCRIPTION
This PR updates the review_prs action type to only review PRs that have had activity in the past 6 hours.