### PR TITLE
Limit github checkout time in bazel-testing org

### DIFF
--- a/buildkite/terraform/bazel-testing/pipeline.yml.tpl
+++ b/buildkite/terraform/bazel-testing/pipeline.yml.tpl
@@ -1,8 +1,9 @@
 env:
   GIT_HTTP_LOW_SPEED_LIMIT: "102400"
   GIT_HTTP_LOW_SPEED_TIME: "180"
-%{ for key, value in envs }
-  ${key}: ${key == "LC_ALL" ? value : jsonencode(value)}%{ endfor ~}
+%{ for key, value in envs ~}
+  ${key}: ${key == "LC_ALL" ? value : jsonencode(value)}
+%{ endfor ~}
 
 steps:
   - command: |-

--- a/buildkite/terraform/bazel-testing/pipeline.yml.tpl
+++ b/buildkite/terraform/bazel-testing/pipeline.yml.tpl
@@ -1,8 +1,9 @@
----%{ if length(envs) > 0 }
-env:%{ for key, value in envs }
+env:
+  GIT_HTTP_LOW_SPEED_LIMIT: "102400"
+  GIT_HTTP_LOW_SPEED_TIME: "180"
+%{ for key, value in envs }
   ${key}: ${key == "LC_ALL" ? value : jsonencode(value)}%{ endfor ~}
 
-%{ endif }
 steps:
   - command: |-
 %{ for command in steps.commands ~}


### PR DESCRIPTION
Adding variables to the environment to limit git minimum speed:
GIT_HTTP_LOW_SPEED_LIMIT: "102400" (Sets a minimum speed threshold of 100 KB/s)
GIT_HTTP_LOW_SPEED_TIME: "180" (Sets a time limit of 180 seconds / 3 minutes)

If the Git download speed drops below 100 KB/s for a continuous 3 minutes during the checkout phase, Git will automatically abort the operation and fail the build. This prevents the job from hanging indefinitely on a stalled or extremely slow network connection in the "Preparing working directory" step.