### PR TITLE
bcr-pr-reviewer: restrict @bazel-io skip_check to PR author or module maintainer

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -780,9 +780,41 @@ async function runSkipCheck(octokit) {
   if (!commentBody.startsWith(SKIP_CHECK_TRIGGER)) {
     return;
   }
+
+  // Reject commands on plain issues; skip_check only applies to pull requests
+  if (!payload.issue.pull_request) {
+    return;
+  }
+
   const check = commentBody.slice(SKIP_CHECK_TRIGGER.length);
   const owner = payload.repository.owner.login;
   const repo = payload.repository.name;
+  const prNumber = payload.issue.number;
+  const commenter = payload.comment.user.login.toLowerCase();
+  const prAuthor = payload.issue.user.login.toLowerCase();
+
+  // Only the PR author or a module maintainer may request a check skip
+  let authorized = commenter === prAuthor;
+  if (!authorized) {
+    const modifiedModuleVersions = await fetchAllModifiedModuleVersions(octokit, owner, repo, prNumber);
+    const modifiedModules = new Set(Array.from(modifiedModuleVersions).map(m => m.split('@')[0]));
+    if (modifiedModules.size > 0) {
+      const [maintainersMap] = await generateMaintainersMap(octokit, owner, repo, modifiedModules, /* toNotifyOnly= */ false);
+      authorized = maintainersMap.has(commenter);
+    }
+  }
+
+  if (!authorized) {
+    await octokit.rest.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: payload.comment.id,
+      content: 'confused',
+    });
+    console.log(`@${commenter} is not authorized to request check skips on PR #${prNumber}.`);
+    return;
+  }
+
   if (check == "unstable_url") {
     await octokit.rest.issues.addLabels({
       owner,


### PR DESCRIPTION
`@bazel-io skip_check` does not check whether the commenter is actually allowed to request a check skip. The workflow fires on any `issue_comment` that starts with the trigger, passes `BCR_PR_REVIEW_HELPER_TOKEN` to the action, and the action calls `addLabels` immediately — no author check, no maintainer check, nothing.

The `@bazel-io abandon` handler in the same file already does this right: it calls `generateMaintainersMap` and rejects anyone who is not a maintainer of a modified module. `skip_check` just does not.

This means any GitHub user can weaken the required `buildkite/bcr-presubmit` checks on someone else's PR by posting a comment. The three skippable checks map directly to presubmit flags:

- `skip-url-stability-check` → `--skip_validation=url_stability`
- `skip-compatibility-level-check` → `--skip_validation=compatibility_level`
- `skip-incompatible-flags-test` → skips the incompatible-flags test pass entirely

Fix adds the same maintainer check that `abandon` already uses, plus a guard so the command is a no-op on plain issues. PR author is also allowed since that seems to be the intended use case based on the docs.