### PR TITLE
Trigger terraform from forks via label

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches: ["master"]
     paths: ["buildkite/terraform/**"]
+  pull_request_target:
+    types: [labeled]
 
 # go/github-security: Explicitly set minimum permissions
 permissions:
@@ -17,6 +19,10 @@ jobs:
   # Job 1: Detect which organization folders changed
   detect-changes:
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork && github.event.label.name == 'run-terraform')
     outputs:
       orgs: ${{ steps.process-orgs.outputs.orgs }}
     steps:
@@ -24,6 +30,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
     - name: Get Changed Files
       id: changed-files
@@ -73,6 +80,8 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
     
     #TODO: change this back to WIP once the provider request is approved 
     - name: Authenticate to Google Cloud


### PR DESCRIPTION
PRs from forks fail in the Terraform workflow because GitHub secrets are not passed to workflows triggered from forks by default.

The Fix:
- Updated the `detect-changes` job to skip execution for fork PRs by default.
- Added a condition to trigger the workflow for forks only when a maintainer adds the `run-terraform` label. (which will use the main repo secrets then)
- Updated checkout steps to fetch the PR head commit specifically when testing PR changes, while falling back to the default branch for pushes.
- Pushes to `master` and PRs from internal branches still run automatically as before.

### How to Use
For PRs from forks, a maintainer must review the code and add the `run-terraform` label to trigger the Terraform plan.
