### PR TITLE
Generate and parse build bep file

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -581,6 +581,7 @@ ESCAPED_BACKSLASH = "%5C"
 MAX_TASK_NUMBER = 128
 
 _TEST_BEP_FILE = "test_bep.json"
+_BUILD_BEP_FILE = "build_bep.json"
 _SHARD_RE = re.compile(r"(.+) \(shard (\d+)\)")
 _SLOWEST_N_TARGETS = 20
 
@@ -1395,6 +1396,8 @@ def execute_commands(
         eprint(json.dumps(task_config, indent=2))
 
     tmpdir = tempfile.mkdtemp()
+    build_bep_file = None
+    test_bep_file = None
     if is_mac():
         activate_xcode(task_config)
 
@@ -1518,6 +1521,9 @@ def execute_commands(
             json_profile_out_build,
             capture_corrupted_outputs_dir_build,
         ) = calculate_flags(task_config, "build_flags", "build", tmpdir, test_env_vars)
+        build_bep_file = os.path.join(tmpdir, _BUILD_BEP_FILE)
+        open(build_bep_file, "w").close()
+        build_succeeded = False
         try:
             release_name = get_release_name_from_branch_name()
             execute_bazel_build(
@@ -1531,15 +1537,36 @@ def execute_commands(
                     else []
                 ),
                 build_targets,
-                None,
+                build_bep_file,
             )
             if save_but:
                 upload_bazel_binary(platform)
+            build_succeeded = True
         finally:
             if json_profile_out_build:
                 upload_log_file(json_profile_out_build, tmpdir)
             if capture_corrupted_outputs_dir_build:
                 upload_corrupted_outputs(capture_corrupted_outputs_dir_build, tmpdir)
+            
+            if is_trueish(os.environ.get("ENABLE_METRICS_COLLECTION", "false")):
+                if not test_targets or not build_succeeded:
+                    try:
+                        from collect_metrics import collect_metrics_and_push_to_bigquery
+                        collect_metrics_and_push_to_bigquery(build_bep_path=build_bep_file)
+                    except Exception as e:
+                        bazelci.eprint(f"Failed to upload build metrics: {e}")
+                        job_url = f"{os.getenv('BUILDKITE_BUILD_URL')}#{os.getenv('BUILDKITE_JOB_ID')}"
+                        execute_command(
+                            [
+                                "buildkite-agent",
+                                "annotate",
+                                "--style=warning",
+                                f"Failed to upload metrics from [this job]({job_url})",
+                                "--context",
+                                "ctx-metrics_upload_failed",
+                            ],
+                            fail_if_nonzero=False,
+                        )
 
     if test_targets:
         if not is_windows():
@@ -1619,9 +1646,9 @@ def execute_commands(
                 if is_trueish(os.environ.get("ENABLE_METRICS_COLLECTION", "false")):
                     try:
                         from collect_metrics import collect_metrics_and_push_to_bigquery
-                        collect_metrics_and_push_to_bigquery(test_bep_file)
+                        collect_metrics_and_push_to_bigquery(build_bep_path=build_bep_file, test_bep_path=test_bep_file)
                     except Exception as e:
-                        eprint(f"Failed to upload metrics: {e}")
+                        eprint(f"Failed to upload test metrics: {e}")
                         job_url = f"{os.getenv('BUILDKITE_BUILD_URL')}#{os.getenv('BUILDKITE_JOB_ID')}"
                         execute_command(
                         [

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1543,6 +1543,8 @@ def execute_commands(
             capture_corrupted_outputs_dir_build,
         ) = calculate_flags(task_config, "build_flags", "build", tmpdir, test_env_vars)
         build_bep_file = os.path.join(tmpdir, _BUILD_BEP_FILE)
+        # Create an empty build_bep_file so that the bazelci-agent can start to follow the file right away. Otherwise,
+        # there is a race between when bazelci-agent starts to read the file and when Bazel creates the file.
         open(build_bep_file, "w").close()
         build_succeeded = False
         try:

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1287,6 +1287,27 @@ def is_trueish(s):
     return str(s).lower() in ["true", "1", "t", "y", "yes"]
 
 
+def collect_metrics_if_enabled(build_bep_path=None, test_bep_path=None):
+    if is_trueish(os.environ.get("ENABLE_METRICS_COLLECTION", "false")):
+        try:
+            from collect_metrics import collect_metrics_and_push_to_bigquery
+            collect_metrics_and_push_to_bigquery(build_bep_path=build_bep_path, test_bep_path=test_bep_path)
+        except Exception as e:
+            eprint(f"Failed to upload metrics: {e}")
+            job_url = f"{os.getenv('BUILDKITE_BUILD_URL')}#{os.getenv('BUILDKITE_JOB_ID')}"
+            execute_command(
+                [
+                    "buildkite-agent",
+                    "annotate",
+                    "--style=warning",
+                    f"Failed to upload metrics from [this job]({job_url})",
+                    "--context",
+                    "ctx-metrics_upload_failed",
+                ],
+                fail_if_nonzero=False,
+            )
+
+
 def use_bazelisk_migrate():
     """
     If USE_BAZELISK_MIGRATE is set, we use `bazelisk --migrate` to test incompatible flags.
@@ -1547,26 +1568,8 @@ def execute_commands(
                 upload_log_file(json_profile_out_build, tmpdir)
             if capture_corrupted_outputs_dir_build:
                 upload_corrupted_outputs(capture_corrupted_outputs_dir_build, tmpdir)
-            
-            if is_trueish(os.environ.get("ENABLE_METRICS_COLLECTION", "false")):
-                if not test_targets or not build_succeeded:
-                    try:
-                        from collect_metrics import collect_metrics_and_push_to_bigquery
-                        collect_metrics_and_push_to_bigquery(build_bep_path=build_bep_file)
-                    except Exception as e:
-                        bazelci.eprint(f"Failed to upload build metrics: {e}")
-                        job_url = f"{os.getenv('BUILDKITE_BUILD_URL')}#{os.getenv('BUILDKITE_JOB_ID')}"
-                        execute_command(
-                            [
-                                "buildkite-agent",
-                                "annotate",
-                                "--style=warning",
-                                f"Failed to upload metrics from [this job]({job_url})",
-                                "--context",
-                                "ctx-metrics_upload_failed",
-                            ],
-                            fail_if_nonzero=False,
-                        )
+            if not test_targets or not build_succeeded:
+                collect_metrics_if_enabled(build_bep_file, None)
 
     if test_targets:
         if not is_windows():
@@ -1643,24 +1646,7 @@ def execute_commands(
                         ],
                         fail_if_nonzero=False,
                     )
-                if is_trueish(os.environ.get("ENABLE_METRICS_COLLECTION", "false")):
-                    try:
-                        from collect_metrics import collect_metrics_and_push_to_bigquery
-                        collect_metrics_and_push_to_bigquery(build_bep_path=build_bep_file, test_bep_path=test_bep_file)
-                    except Exception as e:
-                        eprint(f"Failed to upload test metrics: {e}")
-                        job_url = f"{os.getenv('BUILDKITE_BUILD_URL')}#{os.getenv('BUILDKITE_JOB_ID')}"
-                        execute_command(
-                        [
-                            "buildkite-agent",
-                            "annotate",
-                            "--style=warning",
-                            f"Failed to upload metrics from [this job]({job_url})",
-                            "--context",
-                            "ctx-metrics_upload_failed",
-                        ],
-                        fail_if_nonzero=False,
-                    )
+                collect_metrics_if_enabled(build_bep_file, test_bep_file)
 
             _ = future.result()
             # TODO: print results

--- a/buildkite/collect_metrics.py
+++ b/buildkite/collect_metrics.py
@@ -45,6 +45,21 @@ class BazelMetrics:
     exit_code: int = 0
     targets: List[TestTarget] = dataclasses.field(default_factory=list)
 
+    def to_dict(self, is_test=False):
+        res = {
+            "wall_time_s": self.wall_time_ms / 1000.0,
+            "critical_path_s": self.critical_path_s,
+            "remote_and_disk_cache_hits": self.remote_and_disk_cache_hits,
+            "total_actions": self.total_actions,
+            "output_size_bytes": self.output_size_bytes,
+            "bytes_downloaded": self.bytes_downloaded,
+            "exit_code": self.exit_code,
+        }
+        if is_test:
+            res["failed_test_count"] = self.failed_test_count
+            res["targets"] = [dataclasses.asdict(t) for t in self.targets]
+        return res
+
 def print_and_annotate_warning(message):
     """
     Prints a warning to the logs and annotates the Buildkite UI so it's visible on the build page.
@@ -356,27 +371,9 @@ def collect_metrics_and_push_to_bigquery(build_bep_path=None, test_bep_path=None
     }
 
     if build_metrics:
-        row["build"] = {
-            "wall_time_s": build_metrics.wall_time_ms / 1000.0,
-            "critical_path_s": build_metrics.critical_path_s,
-            "remote_and_disk_cache_hits": build_metrics.remote_and_disk_cache_hits,
-            "total_actions": build_metrics.total_actions,
-            "output_size_bytes": build_metrics.output_size_bytes,
-            "bytes_downloaded": build_metrics.bytes_downloaded,
-            "exit_code": build_metrics.exit_code,
-        }
+        row["build"] = build_metrics.to_dict(is_test=False)
 
     if test_metrics:
-        row["test"] = {
-            "wall_time_s": test_metrics.wall_time_ms / 1000.0,
-            "critical_path_s": test_metrics.critical_path_s,
-            "remote_and_disk_cache_hits": test_metrics.remote_and_disk_cache_hits,
-            "total_actions": test_metrics.total_actions,
-            "output_size_bytes": test_metrics.output_size_bytes,
-            "bytes_downloaded": test_metrics.bytes_downloaded,
-            "exit_code": test_metrics.exit_code,
-            "failed_test_count": test_metrics.failed_test_count,
-            "targets": [dataclasses.asdict(t) for t in test_metrics.targets],
-        }
+        row["test"] = test_metrics.to_dict(is_test=True)
 
     publish_to_bigquery(row)

--- a/buildkite/collect_metrics.py
+++ b/buildkite/collect_metrics.py
@@ -139,7 +139,7 @@ def extract_critical_path(build_tool_logs):
 
 def parse_bep(filepath):
     """
-    Parses the Build Event Protocol (BEP) JSON file to extract build metrics and targets.
+    Parses the Build Event Protocol (BEP) JSON file to extract build/test metrics.
 
     Returns:
         BazelMetrics: An object containing aggregated build metrics and test targets.
@@ -271,9 +271,9 @@ def publish_to_bigquery(row):
         if 'temp_path' in locals() and os.path.exists(temp_path):
             os.remove(temp_path)
 
-def collect_metrics_and_push_to_bigquery(bep_file_path):
+def collect_metrics_and_push_to_bigquery(build_bep_path=None, test_bep_path=None):
     """
-    Reads the BEP file, collects environment variables, and pushes metrics to BigQuery.
+    Reads the BEP files, collects environment variables, and pushes metrics to BigQuery.
     Called from bazelci.py after the build finishes.
     """
 
@@ -307,9 +307,16 @@ def collect_metrics_and_push_to_bigquery(bep_file_path):
     CHANGED_FILES_COUNT = get_git_stats()
 
     # Parse BEP Data
-    build_metrics = parse_bep(bep_file_path)
-    if build_metrics is None:
-        print_and_annotate_warning("Skipping BigQuery push due to BEP parsing failure.")
+    build_metrics = None
+    if build_bep_path:
+        build_metrics = parse_bep(build_bep_path)
+    
+    test_metrics = None
+    if test_bep_path:
+        test_metrics = parse_bep(test_bep_path)
+
+    if not build_metrics and not test_metrics:
+        print_and_annotate_warning("Skipping BigQuery push due to missing or failed BEP parsing.")
         return
 
     # Get Timestamps & calculate Queue time
@@ -341,20 +348,35 @@ def collect_metrics_and_push_to_bigquery(bep_file_path):
         "branch": BRANCH,
         "repo": REPO,
         "commit_sha": COMMIT_SHA,
-        "exit_code": build_metrics.exit_code,
-        "failed_test_count": build_metrics.failed_test_count,
         "retry_count": RETRY_COUNT,
-        "wall_time_s": build_metrics.wall_time_ms / 1000.0,
-        "critical_path_s": build_metrics.critical_path_s,
         "queue_duration_s": queue_duration,
         "checkout_duration_s": CHECKOUT_DURATION_S,
         "prep_duration_s": PREP_DURATION_S,
-        "remote_and_disk_cache_hits": build_metrics.remote_and_disk_cache_hits,
-        "total_actions": build_metrics.total_actions,
-        "output_size_bytes": build_metrics.output_size_bytes,
-        "bytes_downloaded": build_metrics.bytes_downloaded,
         "changed_files_count": CHANGED_FILES_COUNT,
-        "targets": [dataclasses.asdict(t) for t in build_metrics.targets],
     }
+
+    if build_metrics:
+        row["build"] = {
+            "wall_time_s": build_metrics.wall_time_ms / 1000.0,
+            "critical_path_s": build_metrics.critical_path_s,
+            "remote_and_disk_cache_hits": build_metrics.remote_and_disk_cache_hits,
+            "total_actions": build_metrics.total_actions,
+            "output_size_bytes": build_metrics.output_size_bytes,
+            "bytes_downloaded": build_metrics.bytes_downloaded,
+            "exit_code": build_metrics.exit_code,
+        }
+
+    if test_metrics:
+        row["test"] = {
+            "wall_time_s": test_metrics.wall_time_ms / 1000.0,
+            "critical_path_s": test_metrics.critical_path_s,
+            "remote_and_disk_cache_hits": test_metrics.remote_and_disk_cache_hits,
+            "total_actions": test_metrics.total_actions,
+            "output_size_bytes": test_metrics.output_size_bytes,
+            "bytes_downloaded": test_metrics.bytes_downloaded,
+            "exit_code": test_metrics.exit_code,
+            "failed_test_count": test_metrics.failed_test_count,
+            "targets": [dataclasses.asdict(t) for t in test_metrics.targets],
+        }
 
     publish_to_bigquery(row)

--- a/buildkite/collect_metrics_test.py
+++ b/buildkite/collect_metrics_test.py
@@ -134,6 +134,60 @@ class TestPublishMetrics(unittest.TestCase):
                 bep_metrics_2 = collect_metrics.parse_bep("dummy2.json")
                 self.assertEqual(bep_metrics_2.output_size_bytes, 4096)
 
+    def test_parse_bep_build_only(self):
+        # Create a mock BEP file content with only build metrics
+        mock_bep_content = [
+            # Build Metrics
+            json.dumps(
+                {
+                    "id": {"buildMetrics": {}},
+                    "buildMetrics": {
+                        "timingMetrics": {"wallTimeInMs": "5000"},
+                        "actionSummary": {
+                            "actionsExecuted": "20",
+                            "runnerCount": [{"name": "remote cache hit", "count": "10"}],
+                        },
+                        "artifactMetrics": {"topLevelArtifacts": {"sizeInBytes": "1024"}},
+                        "networkMetrics": {"systemNetworkStats": {"bytesRecv": "512"}},
+                    },
+                }
+            ),
+            # Build Tool Logs
+            json.dumps(
+                {
+                    "id": {"buildToolLogs": {}},
+                    "buildToolLogs": {
+                        "log": [
+                            {
+                                "name": "critical path",
+                                "contents": base64.b64encode(b"Critical Path: 5.0s\n").decode("utf-8"),
+                            }
+                        ]
+                    },
+                }
+            ),
+            # Build Finished
+            json.dumps(
+                {"id": {"buildFinished": {}}, "finished": {"exitCode": {"code": 0}}}
+            ),
+        ]
+
+        # Mock file reading
+        with patch("builtins.open", mock_open(read_data="\n".join(mock_bep_content))), \
+             patch("os.path.exists", return_value=True):
+            bep_metrics = collect_metrics.parse_bep("dummy.json")
+
+            # Verify Metrics
+            self.assertEqual(bep_metrics.wall_time_ms, 5000)
+            self.assertEqual(bep_metrics.total_actions, 20)
+            self.assertEqual(bep_metrics.remote_and_disk_cache_hits, 10)
+            self.assertEqual(bep_metrics.failed_test_count, 0)
+            self.assertEqual(bep_metrics.critical_path_s, 5.0)
+            self.assertEqual(bep_metrics.exit_code, 0)
+
+            # Verify Targets are empty
+            self.assertEqual(len(bep_metrics.targets), 0)
+
     def test_extract_critical_path(self):
         # Mock a Base64 encoded critical path log
         raw_log = "Critical Path: 12.5s\n  Action A..."
@@ -192,7 +246,7 @@ class TestPublishMetrics(unittest.TestCase):
                 created_at="2023-10-25T10:00:00Z",
                 started_at="2023-10-25T10:05:00Z"
             )
-            collect_metrics.collect_metrics_and_push_to_bigquery("dummy_path.json")
+            collect_metrics.collect_metrics_and_push_to_bigquery(test_bep_path="dummy_path.json")
 
         # Verify publish_to_bigquery was called
         mock_publish.assert_called_once()
@@ -204,8 +258,69 @@ class TestPublishMetrics(unittest.TestCase):
         self.assertEqual(row["pipeline"], "test-pipeline")
         self.assertEqual(row["org"], "test-org")
         self.assertEqual(row["changed_files_count"], 5)
-        self.assertEqual(row["failed_test_count"], 0)
+        self.assertEqual(row["test"]["failed_test_count"], 0)
         self.assertEqual(row.get("queue_duration_s"), 300.0)
+
+    @patch("collect_metrics.publish_to_bigquery")
+    @patch("collect_metrics.parse_bep")
+    @patch("collect_metrics.get_git_stats")
+    def test_collect_metrics_combined(self, mock_git, mock_parse, mock_publish):
+        # Setup Environment
+        os.environ["BUILDKITE_BUILD_NUMBER"] = "500"
+        os.environ["BUILDKITE_PIPELINE_SLUG"] = "test-pipeline"
+        os.environ["BUILDKITE_ORGANIZATION_SLUG"] = "test-org"
+
+        # Setup Mocks
+        mock_git.return_value = 5
+
+        # Mock BEP Return based on filename
+        def parse_bep_side_effect(filepath):
+            if "build" in filepath:
+                return collect_metrics.BazelMetrics(
+                    wall_time_ms=5000,
+                    critical_path_s=4.0,
+                    total_actions=20,
+                    exit_code=0,
+                )
+            elif "test" in filepath:
+                return collect_metrics.BazelMetrics(
+                    wall_time_ms=10000,
+                    critical_path_s=8.0,
+                    total_actions=50,
+                    exit_code=0,
+                    failed_test_count=1,
+                    targets=[collect_metrics.TestTarget(label="//pkg:test1", status="FAILED", duration_s=5.0)],
+                )
+            return None
+
+        mock_parse.side_effect = parse_bep_side_effect
+
+        # Run Function
+        with patch("collect_metrics.fetch_job_timestamps") as mock_fetch:
+            mock_fetch.return_value = collect_metrics.JobTimestamps(
+                created_at="2023-10-25T10:00:00Z",
+                started_at="2023-10-25T10:05:00Z",
+                finished_at="2023-10-25T10:15:00Z"
+            )
+            collect_metrics.collect_metrics_and_push_to_bigquery(
+                build_bep_path="build_bep.json", test_bep_path="test_bep.json"
+            )
+
+        # Verify publish_to_bigquery was called
+        mock_publish.assert_called_once()
+
+        # Inspect the row payload
+        row = mock_publish.call_args[0][0]
+
+        self.assertEqual(row["build_number"], 500)
+        self.assertIn("build", row)
+        self.assertIn("test", row)
+        
+        self.assertEqual(row["build"]["wall_time_s"], 5.0)
+        self.assertEqual(row["test"]["wall_time_s"], 10.0)
+        self.assertEqual(row["test"]["failed_test_count"], 1)
+        self.assertEqual(len(row["test"]["targets"]), 1)
+        self.assertEqual(row["test"]["targets"][0]["label"], "//pkg:test1")
 
     @patch("collect_metrics.subprocess.run")
     def test_publish_to_bigquery_failure(self, mock_run):
@@ -232,7 +347,7 @@ class TestPublishMetrics(unittest.TestCase):
         with patch.dict(os.environ, {"BUILDKITE_BUILD_NUMBER": "500"}):
             with patch("collect_metrics.print_and_annotate_warning") as mock_annotate:
                 collect_metrics.collect_metrics_and_push_to_bigquery("dummy")
-                mock_annotate.assert_called_once_with("Skipping BigQuery push due to BEP parsing failure.")
+                mock_annotate.assert_called_once_with("Skipping BigQuery push due to missing or failed BEP parsing.")
 
 
     def test_parse_bep_file_not_found(self):

--- a/buildkite/collect_metrics_test.py
+++ b/buildkite/collect_metrics_test.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, MagicMock, mock_open
 import os
 import json
+import tempfile
 import base64
 
 import collect_metrics
@@ -97,10 +98,13 @@ class TestPublishMetrics(unittest.TestCase):
         ]
         mock_bep_content = create_mock_bep_content(test_results=test_results)
 
-        # Mock file reading
-        with patch("builtins.open", mock_open(read_data="\n".join(mock_bep_content))), \
-             patch("os.path.exists", return_value=True):
-            bep_metrics = collect_metrics.parse_bep("dummy.json")
+        # Create a temp file to hold the data
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as tf:
+            tf.write("\n".join(mock_bep_content))
+            temp_path = tf.name
+
+        try:
+            bep_metrics = collect_metrics.parse_bep(temp_path)
 
             # Verify Metrics
             self.assertEqual(bep_metrics.wall_time_ms, 10000)
@@ -115,34 +119,48 @@ class TestPublishMetrics(unittest.TestCase):
             target1 = next(t for t in bep_metrics.targets if t.label == "//pkg:test1")
             self.assertEqual(target1.status, "PASSED")
             self.assertEqual(target1.duration_s, 1.5)
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
 
-            # --- Second Run to fall back to outputArtifactsSeen ---
-            mock_bep_content_2 = [
-                json.dumps(
-                    {
-                        "id": {"buildMetrics": {}},
-                        "buildMetrics": {
-                            "artifactMetrics": {
-                                "topLevelArtifacts": {"sizeInBytes": "0"},
-                                "outputArtifactsSeen": {"sizeInBytes": "4096"}
-                            },
+        # --- Second Run to fall back to outputArtifactsSeen ---
+        mock_bep_content_2 = [
+            json.dumps(
+                {
+                    "id": {"buildMetrics": {}},
+                    "buildMetrics": {
+                        "artifactMetrics": {
+                            "topLevelArtifacts": {"sizeInBytes": "0"},
+                            "outputArtifactsSeen": {"sizeInBytes": "4096"}
                         },
-                    }
-                ),
-            ]
+                    },
+                }
+            ),
+        ]
+        
+        # Create a temp file to hold the data
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as tf2:
+            tf2.write("\n".join(mock_bep_content_2))
+            temp_path_2 = tf2.name
             
-            with patch("builtins.open", mock_open(read_data="\n".join(mock_bep_content_2))):
-                bep_metrics_2 = collect_metrics.parse_bep("dummy2.json")
-                self.assertEqual(bep_metrics_2.output_size_bytes, 4096)
+        try:
+            bep_metrics_2 = collect_metrics.parse_bep(temp_path_2)
+            self.assertEqual(bep_metrics_2.output_size_bytes, 4096)
+        finally:
+            if os.path.exists(temp_path_2):
+                os.remove(temp_path_2)
 
     def test_parse_bep_build_only(self):
         # Create a mock BEP file content with only build metrics
         mock_bep_content = create_mock_bep_content()
 
-        # Mock file reading
-        with patch("builtins.open", mock_open(read_data="\n".join(mock_bep_content))), \
-             patch("os.path.exists", return_value=True):
-            bep_metrics = collect_metrics.parse_bep("dummy.json")
+        # Create a temp file to hold the data
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as tf:
+            tf.write("\n".join(mock_bep_content))
+            temp_path = tf.name
+
+        try:
+            bep_metrics = collect_metrics.parse_bep(temp_path)
 
             # Verify Metrics
             self.assertEqual(bep_metrics.wall_time_ms, 10000)
@@ -154,6 +172,9 @@ class TestPublishMetrics(unittest.TestCase):
 
             # Verify Targets are empty
             self.assertEqual(len(bep_metrics.targets), 0)
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
 
     def test_extract_critical_path(self):
         # Mock a Base64 encoded critical path log

--- a/buildkite/collect_metrics_test.py
+++ b/buildkite/collect_metrics_test.py
@@ -7,6 +7,51 @@ import base64
 import collect_metrics
 
 
+def create_mock_bep_content(test_results=None, exit_code=0):
+    content = []
+    
+    # 1. Optional Test Results
+    if test_results:
+        for tr in test_results:
+            content.append(json.dumps({
+                "id": {"testResult": {"label": tr["label"]}},
+                "testResult": {"status": tr["status"], "testAttemptDurationMillis": str(tr["duration_ms"])},
+            }))
+            
+    # 2. Common Build Metrics
+    content.append(json.dumps({
+        "id": {"buildMetrics": {}},
+        "buildMetrics": {
+            "timingMetrics": {"wallTimeInMs": "10000"},
+            "actionSummary": {
+                "actionsExecuted": "100",
+                "runnerCount": [{"name": "remote cache hit", "count": "50"}],
+            },
+            "artifactMetrics": {"topLevelArtifacts": {"sizeInBytes": "1024"}},
+            "networkMetrics": {"systemNetworkStats": {"bytesRecv": "512"}},
+        },
+    }))
+    
+    # 3. Common Build Tool Logs (Critical Path)
+    content.append(json.dumps({
+        "id": {"buildToolLogs": {}},
+        "buildToolLogs": {
+            "log": [{
+                "name": "critical path",
+                "contents": base64.b64encode(b"Critical Path: 15.0s\n").decode("utf-8"),
+            }]
+        },
+    }))
+    
+    # 4. Common Build Finished
+    content.append(json.dumps({
+        "id": {"buildFinished": {}},
+        "finished": {"exitCode": {"code": exit_code}}
+    }))
+    
+    return content
+
+
 class TestPublishMetrics(unittest.TestCase):
 
     def setUp(self):
@@ -46,55 +91,11 @@ class TestPublishMetrics(unittest.TestCase):
     # --- Test 2: BEP Parsing ---
     def test_parse_bep_valid(self):
         # Create a mock BEP file content
-        mock_bep_content = [
-            # Test Result Event
-            json.dumps(
-                {
-                    "id": {"testResult": {"label": "//pkg:test1"}},
-                    "testResult": {"status": "PASSED", "testAttemptDurationMillis": "1500"},
-                }
-            ),
-            # Another Test Result (Failed)
-            json.dumps(
-                {
-                    "id": {"testResult": {"label": "//pkg:test2"}},
-                    "testResult": {"status": "FAILED", "testAttemptDurationMillis": "5000"},
-                }
-            ),
-            # Build Metrics
-            json.dumps(
-                {
-                    "id": {"buildMetrics": {}},
-                    "buildMetrics": {
-                        "timingMetrics": {"wallTimeInMs": "10000"},
-                        "actionSummary": {
-                            "actionsExecuted": "100",
-                            "runnerCount": [{"name": "remote cache hit", "count": "50"}],
-                        },
-                        "artifactMetrics": {"topLevelArtifacts": {"sizeInBytes": "2048"}},
-                        "networkMetrics": {"systemNetworkStats": {"bytesRecv": "1024"}},
-                    },
-                }
-            ),
-            # Build Tool Logs
-            json.dumps(
-                {
-                    "id": {"buildToolLogs": {}},
-                    "buildToolLogs": {
-                        "log": [
-                            {
-                                "name": "critical path",
-                                "contents": base64.b64encode(b"Critical Path: 15.0s\n").decode("utf-8"),
-                            }
-                        ]
-                    },
-                }
-            ),
-            # Build Finished
-            json.dumps(
-                {"id": {"buildFinished": {}}, "finished": {"exitCode": {"code": 0}}}
-            ),
+        test_results = [
+            {"label": "//pkg:test1", "status": "PASSED", "duration_ms": 1500},
+            {"label": "//pkg:test2", "status": "FAILED", "duration_ms": 5000},
         ]
+        mock_bep_content = create_mock_bep_content(test_results=test_results)
 
         # Mock file reading
         with patch("builtins.open", mock_open(read_data="\n".join(mock_bep_content))), \
@@ -136,41 +137,7 @@ class TestPublishMetrics(unittest.TestCase):
 
     def test_parse_bep_build_only(self):
         # Create a mock BEP file content with only build metrics
-        mock_bep_content = [
-            # Build Metrics
-            json.dumps(
-                {
-                    "id": {"buildMetrics": {}},
-                    "buildMetrics": {
-                        "timingMetrics": {"wallTimeInMs": "5000"},
-                        "actionSummary": {
-                            "actionsExecuted": "20",
-                            "runnerCount": [{"name": "remote cache hit", "count": "10"}],
-                        },
-                        "artifactMetrics": {"topLevelArtifacts": {"sizeInBytes": "1024"}},
-                        "networkMetrics": {"systemNetworkStats": {"bytesRecv": "512"}},
-                    },
-                }
-            ),
-            # Build Tool Logs
-            json.dumps(
-                {
-                    "id": {"buildToolLogs": {}},
-                    "buildToolLogs": {
-                        "log": [
-                            {
-                                "name": "critical path",
-                                "contents": base64.b64encode(b"Critical Path: 5.0s\n").decode("utf-8"),
-                            }
-                        ]
-                    },
-                }
-            ),
-            # Build Finished
-            json.dumps(
-                {"id": {"buildFinished": {}}, "finished": {"exitCode": {"code": 0}}}
-            ),
-        ]
+        mock_bep_content = create_mock_bep_content()
 
         # Mock file reading
         with patch("builtins.open", mock_open(read_data="\n".join(mock_bep_content))), \
@@ -178,11 +145,11 @@ class TestPublishMetrics(unittest.TestCase):
             bep_metrics = collect_metrics.parse_bep("dummy.json")
 
             # Verify Metrics
-            self.assertEqual(bep_metrics.wall_time_ms, 5000)
-            self.assertEqual(bep_metrics.total_actions, 20)
-            self.assertEqual(bep_metrics.remote_and_disk_cache_hits, 10)
+            self.assertEqual(bep_metrics.wall_time_ms, 10000)
+            self.assertEqual(bep_metrics.total_actions, 100)
+            self.assertEqual(bep_metrics.remote_and_disk_cache_hits, 50)
             self.assertEqual(bep_metrics.failed_test_count, 0)
-            self.assertEqual(bep_metrics.critical_path_s, 5.0)
+            self.assertEqual(bep_metrics.critical_path_s, 15.0)
             self.assertEqual(bep_metrics.exit_code, 0)
 
             # Verify Targets are empty


### PR DESCRIPTION
Generate build-bep-file and parse it to collect build data for CI metrics.
This may cause a very small increase in the build time but will give us good insights to the build metrics.