### PR TITLE
Use updated `--bes_instance_name` flag

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -4942,3 +4942,4 @@ def main(argv=None):
 
 if __name__ == "__main__":
     sys.exit(main())
+

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2091,7 +2091,7 @@ def remote_caching_flags(platform, accept_cached=True):
                 # Enable BES / Build Results reporting.
                 "--bes_backend=buildeventservice.googleapis.com",
                 "--bes_timeout=360s",
-                "--project_id=bazel-untrusted",
+                "--bes_instance_name=bazel-untrusted",
             ]
         )
     )
@@ -2202,7 +2202,7 @@ def rbe_flags(original_flags, accept_cached):
     flags += [
         "--bes_backend=buildeventservice.googleapis.com",
         "--bes_timeout=360s",
-        "--project_id=bazel-untrusted",
+        "--bes_instance_name=bazel-untrusted",
     ]
 
     if not accept_cached:


### PR DESCRIPTION
The legacy `--project_id` flag was renamed to `--bes_instance_name` in 2021, which is far outside of the 2 year Bazel LTS window. We should not be testing Bazel binaries from ~2021 any more.