### PR TITLE
Make the BES result clickable

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2090,6 +2090,7 @@ def remote_caching_flags(platform, accept_cached=True):
             else [  # Re-enable on macOS once b/346751326 is resolved.
                 # Enable BES / Build Results reporting.
                 "--bes_backend=buildeventservice.googleapis.com",
+                "--bes_results_url=https://btx.cloud.google.com/invocations/",
                 "--bes_timeout=360s",
                 "--bes_instance_name=bazel-untrusted",
             ]
@@ -2201,6 +2202,7 @@ def rbe_flags(original_flags, accept_cached):
     # Enable BES / Build Results reporting.
     flags += [
         "--bes_backend=buildeventservice.googleapis.com",
+        "--bes_results_url=https://btx.cloud.google.com/invocations/",
         "--bes_timeout=360s",
         "--bes_instance_name=bazel-untrusted",
     ]


### PR DESCRIPTION
We already upload the BEP to the GCP Build Event Service (BES) API. This change makes the resulting Build Test eXplorer (BTX) page clickable.

(dupe of #2622)

Example BES result: https://btx.cloud.google.com/invocations/26a14903-0d90-4e77-9d3c-de4e4b264330/targets

From https://buildkite.com/bazel/rules-android/builds/4498/canvas?sid=019e2cdc-d098-447b-ad14-636d484f5788&tab=output