### PR TITLE
build: pin all actions to commit SHA in release workflows

### DIFF
--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -43,7 +43,7 @@ jobs:
           echo "version is: ${{ env.AGENT_VERSION }}"
       - name: Create GitHub release
         id: release
-        uses: actions/create-release@v1 → actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -117,7 +117,7 @@ jobs:
     - name: Build release binary (linux-aarch64)
       if: matrix.build == 'linux-aarch64'
       working-directory: agent
-      run: CC=/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc cargo build --verbose --release --target ${{ matrix.target }} --config target.${{ matrix.target }}.linker=\"/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-ld\"
+      run: CC=/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc cargo build --verbose --release --target ${{ matrix.target }} --config target.${{ matrix.target }}.linker="/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-ld"
 
     - name: Strip release binary (linux and macos)
       if: matrix.build == 'linux' || matrix.build == 'macos-intel' || matrix.build == 'macos-m1'

--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -43,7 +43,7 @@ jobs:
           echo "version is: ${{ env.AGENT_VERSION }}"
       - name: Create GitHub release
         id: release
-        uses: actions/create-release@v1
+        uses: actions/create-release@v1 → actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -92,12 +92,12 @@ jobs:
       run: sudo apt-get install -y musl-tools
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       with:
         fetch-depth: 1
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
       with:
         toolchain: ${{ matrix.rust }}
         profile: minimal
@@ -141,7 +141,7 @@ jobs:
           echo "ASSET=$staging" >> $GITHUB_ENV
         fi
     - name: Upload release asset
-      uses: actions/upload-release-asset@v1.0.1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -117,7 +117,7 @@ jobs:
     - name: Build release binary (linux-aarch64)
       if: matrix.build == 'linux-aarch64'
       working-directory: agent
-      run: CC=/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc cargo build --verbose --release --target ${{ matrix.target }} --config target.${{ matrix.target }}.linker="/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-ld"
+      run: CC=/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc cargo build --verbose --release --target ${{ matrix.target }} --config target.${{ matrix.target }}.linker=\"/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-ld\"
 
     - name: Strip release binary (linux and macos)
       if: matrix.build == 'linux' || matrix.build == 'macos-intel' || matrix.build == 'macos-m1'
@@ -141,7 +141,7 @@ jobs:
           echo "ASSET=$staging" >> $GITHUB_ENV
         fi
     - name: Upload release asset
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.1
+      uses: actions/upload-release-asset@64e5e85fc528f162d7ba7ce2d15a3bb67efb3d80 # v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
 Pin all GitHub Actions to full commit SHAs in release-agent.yml.

  These workflows create release assets with access to `secrets.GITHUB_TOKEN`.
  Several actions used are deprecated (`actions-rs/toolchain`, `actions/create-release`)
  and no longer maintained, making them higher risk for supply chain compromise.

  Pinning to SHA ensures immutability regardless of upstream maintenance status.

  Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions