### PR TITLE
rbe-configs: add ubuntu2204 for Bazel 9.1.0.

### DIFF
--- a/rbe-configs/data.py
+++ b/rbe-configs/data.py
@@ -5,6 +5,10 @@ configs = [
       {
           'toolchain_name': 'ubuntu2404',
           'cpp_env_json': 'cpp_env/ubuntu2404.json'
+      },
+      {
+          'toolchain_name': 'ubuntu2204',
+          'cpp_env_json': 'cpp_env/ubuntu2004.json'
       }
     ]
   },


### PR DESCRIPTION
address https://github.com/bazel-contrib/rules_python/pull/3778.