### PR TITLE
Pass deleted_packages to blaze query for test resolution.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2498,6 +2498,7 @@ def expand_test_target_patterns(bazel_binary, test_targets, test_flags):
     output = execute_command_and_get_output(
         [bazel_binary]
         + common_startup_flags()
+        + get_query_flags(test_flags)
         + [
             "--nosystem_rc",
             "--nohome_rc",
@@ -2546,6 +2547,13 @@ def get_test_query(test_targets, test_flags):
 
     return query
 
+def get_query_flags(test_flags):
+    wanted_prefixes = ("--deleted_packages")
+    query_flags = []
+    for f in test_flags:
+        if f.startswith(wanted_prefixes):
+            query_flags.append(f)
+    return query_flags
 
 def get_test_tags(test_flags):
     wanted_prefix = "--test_tag_filters="


### PR DESCRIPTION
This would be convenient for tests that need to run with specific versions of bazel or other rules for compatibility.

A recent rules_cc change https://github.com/bazelbuild/rules_cc/pull/556 tried to use it to exclude tests that would fail to parse under some blaze versions. However, this didn't get passed to the query and caused failures anyway (these were presubmit-only, continuous integration ran fine, making it hard to debug (I assumed we had an inconsistency in our exported presubmit versions)).

As a workaround we wrap these rules in macros that check bazel_features. https://github.com/bazelbuild/rules_cc/commit/eed4b510fde0c8ddca659d575c21dc943d857d3a