### PR TITLE
bcr-pr-reviewer: pin auto-merge to the analyzed head SHA

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -530,6 +530,11 @@ async function reviewPR(octokit, owner, repo, prNumber) {
         owner,
         repo,
         pull_number: prNumber,
+        // Pin the merge to the exact commit that was analyzed and approved. If
+        // new commits were pushed in the window between the staleness check
+        // above and this merge, GitHub rejects the merge (409) instead of
+        // merging unreviewed content.
+        sha: currentHeadSha,
         merge_method: 'squash',
       });
 

--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -533,6 +533,11 @@ async function reviewPR(octokit, owner, repo, prNumber) {
         owner,
         repo,
         pull_number: prNumber,
+        // Pin the merge to the exact commit that was analyzed and approved. If
+        // new commits were pushed in the window between the staleness check
+        // above and this merge, GitHub rejects the merge (409) instead of
+        // merging unreviewed content.
+        sha: currentHeadSha,
         merge_method: 'squash',
       });
 


### PR DESCRIPTION
## Problem

In `actions/bcr-pr-reviewer/index.js`, `reviewPR()` re-fetches the PR head SHA and aborts if it changed since the analysis began (the `initialHeadSha !== currentHeadSha` check). However, the subsequent auto-merge call:

```js
await octokit.rest.pulls.merge({
  owner, repo, pull_number: prNumber, merge_method: 'squash',
});
```

does not pass a `sha`, so it merges whatever the PR head is at merge time. There is a window between the staleness check / approval and this merge in which a new commit could be pushed, causing the bot to merge content that was not the analyzed and approved commit.

## Change

Pass `sha: currentHeadSha` (the commit that was analyzed and approved) to `pulls.merge`. GitHub's merge API rejects the merge with `409 Conflict` if the provided SHA is not the current head, so the bot will not merge commits that were pushed after analysis.

This is a defense-in-depth hardening of the existing staleness check; it does not change behavior for PRs whose head is unchanged.
