### PR TITLE
bcr-pr-reviewer: restrict skip_check to the PR author or a module maintainer

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -801,6 +801,32 @@ async function runSkipCheck(octokit) {
   const check = commentBody.slice(SKIP_CHECK_TRIGGER.length);
   const owner = payload.repository.owner.login;
   const repo = payload.repository.name;
+
+  // Only the PR author or a maintainer of a modified module may skip presubmit
+  // checks, so that a third party cannot disable checks on someone else's PR.
+  const commenter = payload.comment.user.login.toLowerCase();
+  const prAuthor = ((payload.issue.user && payload.issue.user.login) || '').toLowerCase();
+  let authorized = commenter === prAuthor;
+  if (!authorized) {
+    const modifiedModuleVersions = await fetchAllModifiedModuleVersions(octokit, owner, repo, payload.issue.number);
+    const modifiedModules = new Set(Array.from(modifiedModuleVersions || []).map(module => module.split('@')[0]));
+    if (modifiedModules.size > 0) {
+      const result = await generateMaintainersMap(octokit, owner, repo, modifiedModules, /* toNotifyOnly= */ false);
+      const maintainersMap = result ? result[0] : new Map();
+      authorized = maintainersMap.has(commenter);
+    }
+  }
+  if (!authorized) {
+    console.log(`@${commenter} is not the PR author or a maintainer of a modified module; ignoring skip_check.`);
+    await octokit.rest.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: payload.comment.id,
+      content: 'confused',
+    });
+    return;
+  }
+
   if (check == "unstable_url") {
     await octokit.rest.issues.addLabels({
       owner,


### PR DESCRIPTION
## Problem

`runSkipCheck` in `actions/bcr-pr-reviewer/index.js` adds presubmit-skip labels (`skip-url-stability-check`, `skip-compatibility-level-check`, `skip-incompatible-flags-test`) in response to a `@bazel-io skip_check <type>` comment, but does not check who the commenter is. The `skip_check.yml` workflow only gates on the comment prefix. As a result any GitHub user can comment on any PR — including someone else's — and disable presubmit checks on it.

This is inconsistent with the sibling `@bazel-io abandon` command (`runHandleComment`), which already verifies the commenter is a maintainer of a modified module before acting.

## Change

Before applying any skip label, require the commenter to be either the PR author or a maintainer of one of the PR's modified modules (reusing the existing `fetchAllModifiedModuleVersions` + `generateMaintainersMap` helpers). Unauthorized commenters get a `confused` reaction and no label is applied. The maintainer lookup fails closed.

This keeps the documented use case working (a contributor running `@bazel-io skip_check incompatible_flags` on their own PR) while preventing a third party from disabling checks on other contributors' PRs.
