### PR TITLE
Bring back CentOS hack.

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -21,7 +21,6 @@
 
 
 import argparse
-import json
 import os
 import pathlib
 import re
@@ -29,7 +28,6 @@ import sys
 import subprocess
 import shutil
 import time
-import requests
 import yaml
 
 import bazelci
@@ -152,7 +150,7 @@ def get_test_module_task_config(module_name, module_version, bazel_version=None)
 
 def add_presubmit_jobs(module_name, module_version, task_configs, pipeline_steps, is_test_module=False, overwrite_bazel_version=None, low_priority=False):
     for task_id, task_config in task_configs.items():
-        platform_name = bazelci.get_platform_for_task(task_id, task_config)
+        platform_name = get_platform(task_id, task_config)
         platform_label = bazelci.PLATFORMS[platform_name]["emoji-name"]
         task_name = task_config.get("name", "")
         label = f"{module_name}@{module_version} - {platform_label} - {task_name}"
@@ -183,6 +181,13 @@ def add_presubmit_jobs(module_name, module_version, task_configs, pipeline_steps
             concurrency = 5 if concurrency is None else min(5, concurrency)
             concurrency_group = f"bcr-presubmit-test-queue-{queue}-low-priority"
         pipeline_steps.append(bazelci.create_step(label, commands, platform_name, concurrency=concurrency, concurrency_group=concurrency_group, priority=-100 if low_priority else None))
+
+
+def get_platform(task_id, task_config):
+    original = bazelci.get_platform_for_task(task_id, task_config)
+    # TODO(#2272): delete once centos references have been removed
+    # from all module configs.
+    return original.replace("centos7", "rockylinux8")
 
 
 def scratch_file(root, relative_path, lines=None, mode="w"):


### PR DESCRIPTION
It was removed in https://github.com/bazelbuild/continuous-integration/pull/2630, but there are still 20ish configs that use the centos7 platform, thus breaking BCR Bazel Compatibility Test: https://buildkite.com/bazel/bcr-bazel-compatibility-test/builds/1041

This is a temporary solution - eventually we should migrate all configs via https://github.com/bazelbuild/bazel-central-registry/pull/9102