### PR TITLE
Fix Buildkite scheduled job api

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -793,9 +793,11 @@ class BuildkiteClient(object):
 
     def get_active_builds(self, retries=5):
         url = self._BUILDS_URL_TEMPLATE.format(self._org)
-        builds = self._fetch_all_pages_as_json(url, params=[("state", "scheduled")], retries=retries)
-        builds.extend(self._fetch_all_pages_as_json(url, params=[("state", "running")], retries=retries))
-        return builds
+        return self._fetch_all_pages_as_json(
+            url,
+            params=[("state[]", "scheduled"), ("state[]", "running")],
+            retries=retries
+        )
 
     @staticmethod
     def _check_response(response, expected_status_code):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -791,9 +791,11 @@ class BuildkiteClient(object):
         url = self._AGENTS_URL_TEMPLATE.format(self._org)
         return self._fetch_all_pages_as_json(url, retries=retries)
 
-    def get_scheduled_jobs(self, retries=5):
+    def get_active_builds(self, retries=5):
         url = self._BUILDS_URL_TEMPLATE.format(self._org)
-        return self._fetch_all_pages_as_json(url, params=[("state", "scheduled")], retries=retries)
+        builds = self._fetch_all_pages_as_json(url, params=[("state", "scheduled")], retries=retries)
+        builds.extend(self._fetch_all_pages_as_json(url, params=[("state", "running")], retries=retries))
+        return builds
 
     @staticmethod
     def _check_response(response, expected_status_code):

--- a/buildkite/collect_infra_metrics.py
+++ b/buildkite/collect_infra_metrics.py
@@ -56,7 +56,7 @@ def get_org_metrics(org):
 
   # 2. Get ALL Scheduled Jobs (Queue Depth)
   builds = bk_client.get_active_builds()
-  logging.info(f"Builds pulled sucessfully")
+  logging.info(f"Builds data pulled sucessfully")
   scheduled_jobs = 0
   for build in builds:
     for job in build.get("jobs", []):

--- a/buildkite/collect_infra_metrics.py
+++ b/buildkite/collect_infra_metrics.py
@@ -55,13 +55,18 @@ def get_org_metrics(org):
       bootstrap_samples) if bootstrap_samples else 0.0
 
   # 2. Get ALL Scheduled Jobs (Queue Depth)
-  scheduled_jobs_list = bk_client.get_scheduled_jobs()
-  logging.info(f"Scheduled Jobs pulled sucessfully")
+  builds = bk_client.get_active_builds()
+  logging.info(f"Builds pulled sucessfully")
+  scheduled_jobs = 0
+  for build in builds:
+    for job in build.get("jobs", []):
+      if job.get("state") == "scheduled":
+        scheduled_jobs += 1
 
   return {
       "timestamp": datetime.utcnow().isoformat(),
       "org": org,
-      "scheduled_jobs": len(scheduled_jobs_list),
+      "scheduled_jobs": scheduled_jobs,
       "total_agents": len(agents),
       "busy_agents": busy_agents,
       "idle_agents": idle_agents,


### PR DESCRIPTION
The old API call returned scheduled builds, but the script counted them as jobs.

Fix: The script now checks the nested "jobs" array within all active (scheduled/running) builds and counts only the individual jobs that are in the "scheduled" state.