### PR TITLE
Add zstd python requirement for BCR CI

### DIFF
--- a/buildkite/docker/ubuntu2404/Dockerfile
+++ b/buildkite/docker/ubuntu2404/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get -y update && \
     python3-six \
     python3-wheel \
     python3-yaml \
+    python3-zstandard \
     software-properties-common \
     sudo \
     unzip \


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/bazelbuild/bazel-central-registry/pull/9106. It seems the requirements file in BCR is not used for CI.

```
Traceback (most recent call last):
  File "/workdir/./tools/bcr_validation.py", line 43, in <module>
    import zstandard
ModuleNotFoundError: No module named 'zstandard'
Traceback (most recent call last):
  File "/workdir/bcr_presubmit.py", line 582, in <module>
    sys.exit(main())
             ^^^^^^
  File "/workdir/bcr_presubmit.py", line 562, in main
    if should_wait_bcr_maintainer_review(modules, pr_labels):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workdir/bcr_presubmit.py", line 434, in should_wait_bcr_maintainer_review
    return should_bcr_validation_block_presubmit(modules, modules_with_metadata_change, pr_labels)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workdir/bcr_presubmit.py", line 405, in should_bcr_validation_block_presubmit
    raise BcrPipelineException("BCR validation failed!")
BcrPipelineException: BCR validation failed!
```