### PR TITLE
Shell-quote task names when building Buildkite step commands

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -32,6 +32,7 @@ import platform as platform_module
 import random
 import re
 import requests
+import shlex
 import shutil
 import stat
 import subprocess
@@ -3463,15 +3464,15 @@ def runner_step(
     soft_fail=None,
 ):
     py = PLATFORMS[platform]["python"]
-    command = f"{py} {RUNNER_CMD} --task={task}"
+    command = f"{py} {RUNNER_CMD} --task={shlex.quote(task)}"
     if http_config:
-        command += " --http_config=" + http_config
+        command += " --http_config=" + shlex.quote(http_config)
     if file_config:
-        command += " --file_config=" + file_config
+        command += " --file_config=" + shlex.quote(file_config)
     if git_repository:
-        command += " --git_repository=" + git_repository
+        command += " --git_repository=" + shlex.quote(git_repository)
     if git_commit:
-        command += " --git_commit=" + git_commit
+        command += " --git_commit=" + shlex.quote(git_commit)
     if monitor_flaky_tests:
         command += " --monitor_flaky_tests"
     if use_but:
@@ -3563,10 +3564,10 @@ def bazel_build_step(
     if test_only:
         pipeline_command += " --test_only"
     if http_config:
-        pipeline_command += " --http_config=" + http_config
+        pipeline_command += " --http_config=" + shlex.quote(http_config)
     if file_config:
-        pipeline_command += " --file_config=" + file_config
-    pipeline_command += " --task=" + task
+        pipeline_command += " --file_config=" + shlex.quote(file_config)
+    pipeline_command += " --task=" + shlex.quote(task)
 
     step = create_step(
         label=create_label(platform, project_name, build_only, test_only),

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -447,5 +447,70 @@ tasks:
         ])
 
 
+class ShellQuoting(unittest.TestCase):
+    """Regression tests: values interpolated into generated Buildkite step
+    commands must be shell-quoted so that unusual task names (which come from
+    user-controlled `.bazelci/presubmit.yml` dict keys) cannot break out of the
+    --task argument and inject extra shell commands."""
+
+    # A task name containing shell metacharacters. If interpolated unquoted into
+    # a command that the Buildkite agent runs via `bash -c`, the `;` would
+    # terminate the runner invocation and `touch` would run as a new command.
+    _MALICIOUS_TASK = "x; touch /tmp/pwned; #"
+
+    def _runner_command(self, step):
+        # create_step stores the list of shell commands under "command".
+        commands = step["command"]
+        for cmd in commands:
+            if "--task=" in cmd:
+                return cmd
+        self.fail("no command containing --task= was generated")
+
+    def test_runner_step_quotes_task_name(self):
+        import shlex
+
+        step = bazelci.runner_step(
+            platform=bazelci.DEFAULT_PLATFORM,
+            task=self._MALICIOUS_TASK,
+            project_name="test",
+        )
+        cmd = self._runner_command(step)
+        # Parse the command exactly as a shell would.
+        tokens = shlex.split(cmd)
+        # The whole task name must survive as a single --task= argument...
+        self.assertIn("--task=" + self._MALICIOUS_TASK, tokens)
+        # ...and the injected `touch` must NOT appear as its own token.
+        self.assertNotIn("touch", tokens)
+
+    def test_bazel_build_step_quotes_task_name(self):
+        import shlex
+
+        step = bazelci.bazel_build_step(
+            task=self._MALICIOUS_TASK,
+            platform=bazelci.DEFAULT_PLATFORM,
+            project_name="test",
+        )
+        cmd = self._runner_command(step)
+        tokens = shlex.split(cmd)
+        self.assertIn("--task=" + self._MALICIOUS_TASK, tokens)
+        self.assertNotIn("touch", tokens)
+
+    def test_runner_step_quotes_config_arguments(self):
+        import shlex
+
+        step = bazelci.runner_step(
+            platform=bazelci.DEFAULT_PLATFORM,
+            task="ok",
+            project_name="test",
+            file_config="x; touch /tmp/pwned2; #",
+            git_commit="$(touch /tmp/pwned3)",
+        )
+        cmd = self._runner_command(step)
+        tokens = shlex.split(cmd)
+        self.assertIn("--file_config=x; touch /tmp/pwned2; #", tokens)
+        self.assertIn("--git_commit=$(touch /tmp/pwned3)", tokens)
+        self.assertNotIn("touch", tokens)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -20,6 +20,8 @@ os.environ["BUILDKITE_ORGANIZATION_SLUG"] = "bazel"
 os.environ["BUILDKITE_PIPELINE_SLUG"] = "test"
 
 import bazelci
+import shlex
+import tempfile
 import unittest
 import yaml
 
@@ -453,11 +455,6 @@ class ShellQuoting(unittest.TestCase):
     user-controlled `.bazelci/presubmit.yml` dict keys) cannot break out of the
     --task argument and inject extra shell commands."""
 
-    # A task name containing shell metacharacters. If interpolated unquoted into
-    # a command that the Buildkite agent runs via `bash -c`, the `;` would
-    # terminate the runner invocation and `touch` would run as a new command.
-    _MALICIOUS_TASK = "x; touch /tmp/pwned; #"
-
     def _runner_command(self, step):
         # create_step stores the list of shell commands under "command".
         commands = step["command"]
@@ -466,50 +463,66 @@ class ShellQuoting(unittest.TestCase):
                 return cmd
         self.fail("no command containing --task= was generated")
 
+    def _sentinel_path(self):
+        # A uniquely-named path that an unquoted injection would create as its
+        # side effect. We never create it ourselves, so it must not exist after
+        # the command is generated.
+        path = tempfile.mktemp(prefix="pwned.")
+        self.addCleanup(lambda: os.remove(path) if os.path.exists(path) else None)
+        return path
+
     def test_runner_step_quotes_task_name(self):
-        import shlex
+        sentinel = self._sentinel_path()
+        # If interpolated unquoted, the `;` would end the runner invocation and
+        # `touch <sentinel>` would run as a separate command.
+        task = "x; touch %s; #" % sentinel
 
         step = bazelci.runner_step(
             platform=bazelci.DEFAULT_PLATFORM,
-            task=self._MALICIOUS_TASK,
+            task=task,
             project_name="test",
         )
         cmd = self._runner_command(step)
         # Parse the command exactly as a shell would.
         tokens = shlex.split(cmd)
         # The whole task name must survive as a single --task= argument...
-        self.assertIn("--task=" + self._MALICIOUS_TASK, tokens)
-        # ...and the injected `touch` must NOT appear as its own token.
+        self.assertIn("--task=" + task, tokens)
+        # ...the injected `touch` must NOT appear as its own token...
         self.assertNotIn("touch", tokens)
+        # ...and the injection's side-effect file must never be created.
+        self.assertFalse(os.path.exists(sentinel))
 
     def test_bazel_build_step_quotes_task_name(self):
-        import shlex
+        sentinel = self._sentinel_path()
+        task = "x; touch %s; #" % sentinel
 
         step = bazelci.bazel_build_step(
-            task=self._MALICIOUS_TASK,
+            task=task,
             platform=bazelci.DEFAULT_PLATFORM,
             project_name="test",
         )
         cmd = self._runner_command(step)
         tokens = shlex.split(cmd)
-        self.assertIn("--task=" + self._MALICIOUS_TASK, tokens)
+        self.assertIn("--task=" + task, tokens)
         self.assertNotIn("touch", tokens)
+        self.assertFalse(os.path.exists(sentinel))
 
     def test_runner_step_quotes_config_arguments(self):
-        import shlex
+        sentinel = self._sentinel_path()
 
         step = bazelci.runner_step(
             platform=bazelci.DEFAULT_PLATFORM,
             task="ok",
             project_name="test",
-            file_config="x; touch /tmp/pwned2; #",
-            git_commit="$(touch /tmp/pwned3)",
+            file_config="x; touch %s; #" % sentinel,
+            git_commit="$(touch %s)" % sentinel,
         )
         cmd = self._runner_command(step)
         tokens = shlex.split(cmd)
-        self.assertIn("--file_config=x; touch /tmp/pwned2; #", tokens)
-        self.assertIn("--git_commit=$(touch /tmp/pwned3)", tokens)
+        self.assertIn("--file_config=x; touch %s; #" % sentinel, tokens)
+        self.assertIn("--git_commit=$(touch %s)" % sentinel, tokens)
         self.assertNotIn("touch", tokens)
+        self.assertFalse(os.path.exists(sentinel))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While reading how the pipeline steps get generated, I noticed the task name is interpolated straight into the runner command with no quoting:

```python
command = f"{py} {RUNNER_CMD} --task={task}"
```

The task name is just a key under `tasks:` in a project's `.bazelci/presubmit.yml`, so it's whatever the config author wrote. If a task name contains shell metacharacters it breaks out of the `--task=` argument when the agent runs the command — e.g. a task key like `foo; echo hi; #` turns into two separate shell commands.

This wraps the interpolated values in `shlex.quote` so they're always passed as a single argument. I applied the same to the other concatenated values (`http_config`, `file_config`, `git_repository`, `git_commit`) for consistency. `shlex.quote` is a no-op for normal values — paths, URLs and commit hashes only use shell-safe characters — so existing pipelines are unaffected.

Added tests under `ShellQuoting` that build a step with a `;`-containing task name and assert, via `shlex.split`, that it stays one `--task=` argument and that no injected command leaks out as its own token.

Tested with `python3 -m unittest bazelci_test` — all green.
