### PR TITLE
Set `RBE_CONFIG_BAZEL_PATH` for downstream jobs on RBE

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -1415,8 +1415,12 @@ def execute_commands(
     bazel_binary = "bazel"
     if use_but:
         print_collapsed_group(":gcloud: Downloading Bazel Under Test")
-        os.environ["USE_BAZEL_VERSION"] = download_bazel_binary(tmpdir, binary_platform)
-        print_collapsed_group(":bazel: Using Bazel at " + os.environ["USE_BAZEL_VERSION"])
+        bazel_path = download_bazel_binary(tmpdir, binary_platform)
+        os.environ["USE_BAZEL_VERSION"] = bazel_path
+        # The following is for downstream jobs that use RBE; see
+        # https://github.com/bazelbuild/continuous-integration/blob/master/rules/README.md#5-advanced-bazel-version--binary-resolution-strategy
+        os.environ["RBE_CONFIG_BAZEL_PATH"] = bazel_path
+        print_collapsed_group(":bazel: Using Bazel at " + bazel_path)
     else:
         if bazel_version:
             print_collapsed_group(f":bazel: Using Bazel version {bazel_version}")


### PR DESCRIPTION
We're seeing failures in the downstream pipeline for jobs on RBE (currently just Bazel itself: for example https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/5517/list?sid=019e90d4-7293-4dbe-bc2f-b581c15d379b&tab=output)

The reason is that, when the downstream pipeline builds Bazel at HEAD, it supplies a fake embed label ([code](https://github.com/bazelbuild/continuous-integration/blob/b5ad6d8958275f2ed873df9a5e2c834b0cad22b6/buildkite/bazelci.py#L1541)). This fake label is synthesized, and looks something like `10.0.0-pre-<commit_hash>`. The RBE config generator then tries to fetch this nonexistent Bazel version from Bazelisk, running into the error reported above.

This fix sets the `RBE_CONFIG_BAZEL_PATH` for all downstream jobs that use this "Bazel built from HEAD". This environment variable tells the RBE config generator to just use this Bazel instead of fetching something from Bazelisk, which should fix the error.