### PR TITLE
Re-enable BazelCI for rules_android_ndk

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -223,7 +223,6 @@ DOWNSTREAM_PROJECTS_PRODUCTION = {
         "git_repository": "https://github.com/bazelbuild/rules_android_ndk.git",
         "pipeline_slug": "rules-android-ndk",
         "owned_by_bazel": True,
-        "disabled_reason": "https://github.com/bazelbuild/rules_android_ndk/issues/83, https://github.com/bazelbuild/rules_android_ndk/issues/86, https://github.com/bazelbuild/rules_android_ndk/issues/88",
     },
     "rules_cc": {
         "git_repository": "https://github.com/bazelbuild/rules_cc.git",


### PR DESCRIPTION
All linked github issues are now closed (and have been for some time).