### PR TITLE
Add "project" attribute to gcloud calls

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -653,23 +653,17 @@ class BuildkiteClient(object):
         self._token = self._get_buildkite_token()
 
     def _get_buildkite_token(self):
-        args = [
-            gcloud_command(),
-            "secrets",
-            "versions",
-            "access",
-            "latest",
-            f"--secret={self._org}-bazelcipy-BuildkiteClient-token",
-        ]
-
         project = CLOUD_PROJECTS_PER_ORG[self._org]
-        if project != CLOUD_PROJECT:
-            # Needed for cross-project access, e.g. in
-            # trusted metrics collection pipeline.
-            args.append(f"--project={project}")
-
         return execute_command_and_get_output(
-            args,
+            [
+                gcloud_command(),
+                "secrets",
+                "versions",
+                "access",
+                "latest",
+                f"--secret={self._org}-bazelcipy-BuildkiteClient-token",
+                f"--project={project}",
+            ],
             print_output=False,
         )
 


### PR DESCRIPTION
Fixes [this error](https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/33494#019e88da-a199-4425-94ed-f9cb5955cd1c/L1125) by adding the project to the call.
It seems like mac doesn't have a default project in the gcloud configs.