### PR TITLE
Disable bazel-diff for rules_cc presubmit.

### DIFF
--- a/buildkite/terraform/bazel/pipelines_rules.tf
+++ b/buildkite/terraform/bazel/pipelines_rules.tf
@@ -752,7 +752,9 @@ resource "buildkite_pipeline" "google-rules-cc-presubmit" {
   repository     = "https://bazel.googlesource.com/rules_cc.git"
   default_branch = "main"
   steps = templatefile("pipeline.yml.tpl", {
-    envs = {}
+    envs = {
+      DISABLE_BAZEL_DIFF = "1"
+    }
     steps = {
       commands = [
         "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py",


### PR DESCRIPTION
bazel-diff appears to often filter out the analysis tests. Since these
are a major part of the testing done for rules_cc, this is bad, and we
should simply turn it off.