### PR TITLE
Add authorization check to skip_check command in bcr-pr-reviewer

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -798,9 +798,41 @@ async function runSkipCheck(octokit) {
   if (!commentBody.startsWith(SKIP_CHECK_TRIGGER)) {
     return;
   }
-  const check = commentBody.slice(SKIP_CHECK_TRIGGER.length);
+
+  const commenter = payload.comment.user.login;
   const owner = payload.repository.owner.login;
   const repo = payload.repository.name;
+
+  // Verify the commenter has write access to the repository.
+  try {
+    const { data: permissionData } = await octokit.rest.repos.getCollaboratorPermissionLevel({
+      owner,
+      repo,
+      username: commenter,
+    });
+    const permission = permissionData.permission;
+    if (permission !== 'admin' && permission !== 'write') {
+      console.log(`@${commenter} does not have write access (permission: ${permission}), ignoring skip_check command.`);
+      await octokit.rest.reactions.createForIssueComment({
+        owner,
+        repo,
+        comment_id: payload.comment.id,
+        content: 'confused',
+      });
+      return;
+    }
+  } catch (error) {
+    console.error(`Failed to check permissions for @${commenter}: ${error.message}`);
+    await octokit.rest.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: payload.comment.id,
+      content: 'confused',
+    });
+    return;
+  }
+
+  const check = commentBody.slice(SKIP_CHECK_TRIGGER.length);
   if (check == "unstable_url") {
     await octokit.rest.issues.addLabels({
       owner,


### PR DESCRIPTION
## Summary

Add a collaborator permission check to `runSkipCheck()` to ensure only users with write or admin access can trigger `@bazel-io skip_check` commands.

## Problem

`runSkipCheck()` processes skip_check commands from any commenter without verifying their permissions. This is inconsistent with `runHandleComment()`, which checks that the commenter is a module maintainer before acting on the `@bazel-io abandon` command.

## Fix

Before processing a skip_check command, verify the commenter has write or admin permission on the repository using `repos.getCollaboratorPermissionLevel()`. Unauthorized users receive a `confused` reaction, matching the existing pattern used for unrecognized commands.