### PR TITLE
Correctly calculate CI prep time

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2321,8 +2321,18 @@ def kythe_build_flags():
         f"--override_repository=kythe_release={KYTHE_DIR}",
     ]
 
+def calculate_prep_duration():
+    try:
+        CHECKOUT_END_TIME_S = float(os.getenv("CHECKOUT_END_TIME")) / 1000.0
+        os.environ["PREP_DURATION_S"] = str(time.time() - CHECKOUT_END_TIME_S)
+        eprint(f"Prep duration: {os.getenv('PREP_DURATION_S')}")
+    except (ValueError, TypeError):
+        pass
 
 def execute_bazel_build(bazel_version, bazel_binary, platform, flags, targets, bep_file):
+    # The start of the build stage marks the end of the preparation stage; calculate prep duration here.
+    calculate_prep_duration()
+
     print_collapsed_group(":bazel: Computing flags for build step")
     aggregated_flags = compute_flags(
         platform,
@@ -2348,6 +2358,9 @@ def execute_bazel_build(bazel_version, bazel_binary, platform, flags, targets, b
 
 
 def execute_bazel_build_with_kythe(bazel_version, bazel_binary, platform, flags, targets, bep_file):
+    # The start of the build stage marks the end of the preparation stage; calculate prep duration here.
+    calculate_prep_duration()
+    
     print_collapsed_group(":bazel: Computing flags for build step")
     aggregated_flags = compute_flags(
         platform,
@@ -3035,7 +3048,7 @@ def create_step(
 
 
 def create_docker_step(label, image, commands=None, additional_env_vars=None, queue="default", enable_soft_fail=False):
-    env = ["ANDROID_HOME", "ANDROID_NDK_HOME", "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION", "CHECKOUT_DURATION_S", "PREP_DURATION_S"]
+    env = ["ANDROID_HOME", "ANDROID_NDK_HOME", "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION", "CHECKOUT_DURATION_S", "CHECKOUT_END_TIME"]
     if THIS_IS_TRUSTED:
         # For the trusted Linux arm64 machine to upload artifacts
         env += ["GOOGLE_APPLICATION_CREDENTIALS"]

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2327,7 +2327,7 @@ def calculate_prep_duration():
         os.environ["PREP_DURATION_S"] = str(time.time() - CHECKOUT_END_TIME_S)
         eprint(f"Prep duration: {os.getenv('PREP_DURATION_S')}")
     except (ValueError, TypeError):
-        pass
+        eprint("Warning: CHECKOUT_END_TIME is missing or invalid; skipping prep duration calculation.")
 
 def execute_bazel_build(bazel_version, bazel_binary, platform, flags, targets, bep_file):
     # The start of the build stage marks the end of the preparation stage; calculate prep duration here.

--- a/buildkite/startup-docker-pdssd.sh
+++ b/buildkite/startup-docker-pdssd.sh
@@ -109,20 +109,6 @@ buildkite-agent env set "CHECKOUT_END_TIME=${CHECKOUT_END_TIME}"
 buildkite-agent env set "CHECKOUT_DURATION_S=${CHECKOUT_DURATION_S}"
 EOF
 
-### 3. Calculate Prep Duration
-cat > /etc/buildkite-agent/hooks/pre-command <<'EOF'
-#!/bin/bash
-PREP_END_TIME=$(date +%s%3N)
-CHECKOUT_END=$(buildkite-agent env get CHECKOUT_END_TIME)
-if [[ -n "$CHECKOUT_END" && "$CHECKOUT_END" =~ ^[0-9]+$ ]]; then
-  DIFF=$((PREP_END_TIME - CHECKOUT_END))
-  PREP_DURATION_S=$(printf "%d.%03d" $((DIFF / 1000)) $((DIFF % 1000)))
-else
-  PREP_DURATION_S="unknown"
-fi
-echo "PREP_DURATION_S: ${PREP_DURATION_S}"
-buildkite-agent env set "PREP_DURATION_S=${PREP_DURATION_S}"
-EOF
 
 ### Fix permissions of the Buildkite agent configuration files and hooks.
 chmod 0400 /etc/buildkite-agent/buildkite-agent.cfg

--- a/buildkite/startup-windows-pdssd.ps1
+++ b/buildkite/startup-windows-pdssd.ps1
@@ -82,24 +82,6 @@ buildkite-agent env set "CHECKOUT_DURATION_S=$CHECKOUT_DURATION_S"
 '@
 [System.IO.File]::WriteAllLines("c:\buildkite\hooks\post-checkout.ps1", $buildkite_postcheckout_hook)
 
-$buildkite_precommand_hook = @'
-$PREP_END_TIME = [long]([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())
-$START_TIME_STR = buildkite-agent env get CHECKOUT_END_TIME
-if ([string]::IsNullOrWhiteSpace($START_TIME_STR)) {
-    Write-Host "CHECKOUT_END_TIME is not set or empty; skipping PREP_DURATION_S calculation."
-    return
-}
-$START_TIME = 0
-if (-not [long]::TryParse($START_TIME_STR.Trim(), [ref]$START_TIME)) {
-    Write-Host "CHECKOUT_END_TIME ('$START_TIME_STR') is not a valid integer; skipping PREP_DURATION_S calculation."
-    return
-}
-$DIFF = $PREP_END_TIME - $START_TIME
-$PREP_DURATION_S = [math]::Round($DIFF / 1000.0, 3).ToString([cultureinfo]::InvariantCulture)
-Write-Host "PREP_DURATION_S: $PREP_DURATION_S"
-buildkite-agent env set "PREP_DURATION_S=$PREP_DURATION_S"
-'@
-[System.IO.File]::WriteAllLines("c:\buildkite\hooks\pre-command.ps1", $buildkite_precommand_hook)
 
 ## Enable support for symlinks.
 Write-Host "Enabling SECreateSymbolicLinkPrivilege permission..."


### PR DESCRIPTION
Previously, we used a pre-command hook to calculate the prep time. However, because it runs immediately after the post-checkout hook, it did not accurately represent the actual preparation time.

The fix, we calculate the prep time directly before the build phase starts. This is the correct place to capture the elapsed time between the checkout phase and the build phase.

Also removed the pre command hook as we don't need it any more