### PR TITLE
Add full path to the bigquery command on mac

### DIFF
--- a/buildkite/collect_metrics.py
+++ b/buildkite/collect_metrics.py
@@ -259,8 +259,13 @@ def publish_to_bigquery(row):
 
     bazelci.eprint(f"Publishing Metrics to BigQuery ...")
     table_ref = f"{PROJECT_ID}:{DATASET_ID}.{TABLE_ID}"        
-    bq_cmd = "bq.cmd" if bazelci.is_windows() else "bq"
-
+    if bazelci.is_windows():
+        bq_cmd = "bq.cmd"
+    elif bazelci.is_mac() and not bazelci.is_64_bit():
+        bq_cmd = "/usr/local/bin/google-cloud-sdk/bin/bq"
+    else:
+        bq_cmd = "bq"
+        
     try:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tf:
             json.dump(row, tf)


### PR DESCRIPTION
Quick fix to collect the CI metrics from macOs