### PR TITLE
Update upstream repo for rules_shell

### DIFF
--- a/buildkite/terraform/bazel/pipelines_rules.tf
+++ b/buildkite/terraform/bazel/pipelines_rules.tf
@@ -2115,7 +2115,7 @@ resource "buildkite_pipeline" "rules-jvm-external" {
 
 resource "buildkite_pipeline" "rules-shell" {
   name           = "rules_shell"
-  repository     = "https://github.com/bazelbuild/rules_shell.git"
+  repository     = "https://github.com/bazel-contrib/rules_shell.git"
   description    = "Shell rules for Bazel"
   default_branch = "main"
   steps = templatefile("pipeline.yml.tpl", {


### PR DESCRIPTION
rules_shell was moved to bazel-contrib. You'd think having a redirect left behind would be fine, but we keep getting emails about "commit status have been disabled for rules_shell". Let's see if updating the repo fixes it.