### PR TITLE
ci(terraform): restrict the privileged terraform job to non-fork PRs

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -54,8 +54,14 @@ jobs:
   # Job 2: Terraform Execution
   terraform:
     needs: detect-changes
-    # Run only if we have changed orgs AND (it's a push to master OR PR from trusted users)
-    if: needs.detect-changes.outputs.orgs != '[]'
+    # Run only if we have changed orgs AND (it's a push to master OR a PR from this
+    # repository, not a fork). Fork pull requests must not reach this job: it loads
+    # GCP credentials and runs `terraform plan` over the PR's .tf files, which executes
+    # attacker-controlled HCL (module sources, `external` data sources).
+    if: >-
+      needs.detect-changes.outputs.orgs != '[]'
+      && (github.event_name == 'push'
+          || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
 
     # Lock per organization. Cancels old runs on PRs (saves time), but queues pushes (safe apply).


### PR DESCRIPTION
## Problem

`.github/workflows/terraform.yml` triggers on `pull_request` for `buildkite/terraform/**`, and the privileged `terraform` job:

- authenticates to GCP with `credentials_json: ${{ secrets.GCP_SA_KEY }}`, and
- runs `terraform init` / `terraform plan` over the pull request's own `.tf` files, with `TF_VAR_buildkite_api_token: ${{ secrets.BUILDKITE_API_TOKEN }}` in the environment.

On a `pull_request` event the default `actions/checkout` checks out the **fork's** code, and `terraform init`/`plan` execute attacker-controlled HCL — module `source` fetching and `data "external"` blocks run arbitrary programs during `plan`. So a fork PR that edits a file under `buildkite/terraform/<org>/` can run arbitrary commands in a job that already holds the GCP service-account key and the Buildkite API token, which is enough to exfiltrate both.

The job's guard only checks that orgs changed:

```yaml
    # Run only if we have changed orgs AND (it's a push to master OR PR from trusted users)
    if: needs.detect-changes.outputs.orgs != '[]'
```

The "PR from trusted users" part of that comment was never implemented, and the `bazel` / `bazel-trusted` / `bazel-testing` environments have no required reviewers, so nothing currently prevents a fork PR from reaching this job (the only remaining barrier is GitHub's "approve fork PR workflows" click, which is routinely granted to prior contributors).

## Fix

Gate the privileged job so fork pull requests can no longer reach it, while keeping `push` and same-repo PR behaviour unchanged:

```yaml
    if: >-
      needs.detect-changes.outputs.orgs != '[]'
      && (github.event_name == 'push'
          || github.event.pull_request.head.repo.full_name == github.repository)
```

This implements the originally-intended "trusted users" guard. (Alternatively / additionally, the three environments could be configured with required reviewers.)
