### PR TITLE
Add block step for untrusted config changes.

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2360,7 +2360,7 @@ def execute_bazel_build(bazel_version, bazel_binary, platform, flags, targets, b
 def execute_bazel_build_with_kythe(bazel_version, bazel_binary, platform, flags, targets, bep_file):
     # The start of the build stage marks the end of the preparation stage; calculate prep duration here.
     calculate_prep_duration()
-    
+
     print_collapsed_group(":bazel: Computing flags for build step")
     aggregated_flags = compute_flags(
         platform,
@@ -3106,7 +3106,7 @@ def print_project_pipeline(
     if not task_configs:
         raise BuildkiteException("{0} pipeline configuration is empty.".format(project_name))
 
-    pipeline_steps = []
+    pipeline_steps = create_initial_steps()
     # If the repository is hosted on Git-on-borg, we show the link to the commit Gerrit review
     buildkite_repo = os.getenv("BUILDKITE_REPO")
     if is_git_on_borg_repo(buildkite_repo):
@@ -3275,6 +3275,25 @@ def print_project_pipeline(
         )
 
     print_pipeline_steps(pipeline_steps, handle_emergencies=not is_downstream_pipeline())
+
+
+def create_initial_steps():
+    steps = []
+    default_branch = os.getenv("BUILDKITE_PIPELINE_DEFAULT_BRANCH")
+    if THIS_IS_TRUSTED or os.getenv("BUILDKITE_BRANCH") == default_branch:
+        return steps
+
+    modified_files = get_modified_files(os.getenv("BUILDKITE_COMMIT"))
+    modified_config_files = [f for f in modified_files if ".bazelci" in f]
+    if modified_config_files:
+        steps.append(
+            {
+                "block": "Please review changes to the following file(s) "
+                f"before unblocking the build: {' ,'.join(modified_config_files)}"
+            }
+        )
+
+    return steps
 
 
 def create_buildifier_step(buildifier_config):
@@ -3658,7 +3677,7 @@ def print_bazel_publish_binaries_pipeline(task_configs, http_config, file_config
     if not task_configs:
         raise BuildkiteException("Bazel publish binaries pipeline configuration is empty.")
 
-    pipeline_steps = []
+    pipeline_steps = create_initial_steps()
     task_configs = filter_tasks_that_should_be_skipped(task_configs, pipeline_steps)
 
     platforms = [get_platform_for_task(t, tc) for t, tc in task_configs.items()]
@@ -3814,7 +3833,7 @@ def fetch_incompatible_flags():
 def print_bazel_downstream_pipeline(
     task_configs, http_config, file_config, test_disabled_projects, notify
 ):
-    pipeline_steps = []
+    pipeline_steps = create_initial_steps()
 
     info_box_step = print_disabled_projects_info_box_step()
     if info_box_step is not None:


### PR DESCRIPTION
This should reduce some of the noise from AI-based security reviews while not impacting CI productivity too much.
I still have more ideas that we should implement later.