### PR TITLE
Upgrade Bazel CI machines

### DIFF
--- a/buildkite/create_images.py
+++ b/buildkite/create_images.py
@@ -23,7 +23,7 @@ import gcloud
 import gcloud_utils
 
 DEBUG = False
-DEFAULT_MACHINE_TYPE = "c2-standard-8"
+DEFAULT_MACHINE_TYPE = "c3d-standard-8"
 DEFAULT_BOOT_DISK_TYPE = "pd-ssd"
 
 IMAGE_CREATION_VMS = {
@@ -33,7 +33,7 @@ IMAGE_CREATION_VMS = {
         "source_image_project": "ubuntu-os-cloud",
         "source_image_family": "ubuntu-2204-lts",
         "setup_script": "setup-docker.sh",
-        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE"],
+        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE", "GVNIC"],
         "licenses": [
             "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
         ],
@@ -44,7 +44,7 @@ IMAGE_CREATION_VMS = {
         "source_image_project": "ubuntu-os-cloud",
         "source_image_family": "ubuntu-2204-lts-arm64",
         "setup_script": "setup-docker.sh",
-        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE"],
+        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE", "GVNIC"],
         "licenses": [
             "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
         ],
@@ -57,7 +57,7 @@ IMAGE_CREATION_VMS = {
         "source_image_project": "windows-cloud",
         "source_image_family": "windows-2022", # vs build tools failed to install on windows-2022-core
         "setup_script": "setup-windows.ps1",
-        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE"],
+        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE", "GVNIC"],
     },
     "windows-playground": {
         "project": "di-cloud-exp",
@@ -66,7 +66,7 @@ IMAGE_CREATION_VMS = {
         "source_image_project": "windows-cloud",
         "source_image_family": "windows-2022",
         "setup_script": "setup-windows.ps1",
-        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE"],
+        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE", "GVNIC"],
     },
 }
 

--- a/buildkite/instances.yml
+++ b/buildkite/instances.yml
@@ -26,7 +26,7 @@ default_vm:
   initial_delay: 60
 instance_groups:
   - name: bk-docker
-    count: 200
+    count: 140
     project: bazel-untrusted
     service_account: buildkite@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-docker
@@ -71,7 +71,7 @@ instance_groups:
     zone: us-central1-c
     boot_disk_type: hyperdisk-balanced
   - name: bk-windows
-    count: 60
+    count: 40
     project: bazel-untrusted
     service_account: buildkite@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-windows

--- a/buildkite/instances.yml
+++ b/buildkite/instances.yml
@@ -14,7 +14,7 @@
 default_vm:
   boot_disk_size: 500GB
   boot_disk_type: pd-ssd
-  machine_type: c2-standard-30
+  machine_type: c3d-standard-30
   network: default
   region: us-central1
   restart-on-failure: False
@@ -26,13 +26,13 @@ default_vm:
   initial_delay: 60
 instance_groups:
   - name: bk-docker
-    count: 140
+    count: 200
     project: bazel-untrusted
     service_account: buildkite@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-docker
     metadata_from_file: startup-script=startup-docker-pdssd.sh
   - name: bk-testing-docker
-    count: 10
+    count: 30
     project: bazel-untrusted
     service_account: buildkite-testing@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-testing-docker
@@ -71,14 +71,14 @@ instance_groups:
     zone: us-central1-c
     boot_disk_type: hyperdisk-balanced
   - name: bk-windows
-    count: 40
+    count: 60
     project: bazel-untrusted
     service_account: buildkite@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-windows
     metadata_from_file: windows-startup-script-ps1=startup-windows-pdssd.ps1
     zone: us-central1-c
   - name: bk-testing-windows
-    count: 5
+    count: 10
     project: bazel-untrusted
     service_account: buildkite-testing@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-testing-windows

--- a/buildkite/instances.yml
+++ b/buildkite/instances.yml
@@ -26,7 +26,7 @@ default_vm:
   initial_delay: 60
 instance_groups:
   - name: bk-docker
-    count: 140
+    count: 200
     project: bazel-untrusted
     service_account: buildkite@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-docker
@@ -71,7 +71,7 @@ instance_groups:
     zone: us-central1-c
     boot_disk_type: hyperdisk-balanced
   - name: bk-windows
-    count: 40
+    count: 60
     project: bazel-untrusted
     service_account: buildkite@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-windows

--- a/buildkite/instances.yml
+++ b/buildkite/instances.yml
@@ -32,7 +32,7 @@ instance_groups:
     image_family: bk-docker
     metadata_from_file: startup-script=startup-docker-pdssd.sh
   - name: bk-testing-docker
-    count: 30
+    count: 10
     project: bazel-untrusted
     service_account: buildkite-testing@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-testing-docker
@@ -78,7 +78,7 @@ instance_groups:
     metadata_from_file: windows-startup-script-ps1=startup-windows-pdssd.ps1
     zone: us-central1-c
   - name: bk-testing-windows
-    count: 10
+    count: 5
     project: bazel-untrusted
     service_account: buildkite-testing@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-testing-windows

--- a/buildkite/promote_images.py
+++ b/buildkite/promote_images.py
@@ -27,7 +27,7 @@ IMAGE_PROMOTIONS = {
         "project": "bazel-public",
         "source_image_project": "bazel-public",
         "source_image_family": "bk-testing-docker",
-        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE"],
+        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE", "GVNIC"],
         "licenses": [
             "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
         ],
@@ -36,7 +36,7 @@ IMAGE_PROMOTIONS = {
         "project": "bazel-public",
         "source_image_project": "bazel-public",
         "source_image_family": "bk-testing-docker-arm64",
-        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE"],
+        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE", "GVNIC"],
         "licenses": [
             "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
         ],
@@ -45,7 +45,7 @@ IMAGE_PROMOTIONS = {
         "project": "bazel-public",
         "source_image_project": "bazel-public",
         "source_image_family": "bk-testing-windows",
-        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE"],
+        "guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE", "GVNIC"],
     },
 }
 


### PR DESCRIPTION
Migrate Bazel CI runner fleet to C3D instances and scale pools

- Upgrades CI runner pools from `c2-standard-30` to `c3d-standard-30` and scales the untrusted fleet sizes (Linux to 200, Windows to 60) to improve build speed and queue throughput.
- Enables Google Virtual NIC (`GVNIC`) support on all custom runner images. This is mandatory for GCP 3rd-generation machine types (like C3D) because they do not support legacy VirtIO networking.
- Upgrades the base image builder VM to `c3d-standard-8`.
