### PR TITLE
Update setup-docker.sh script to support C3D machines/NVMe root disk names

### DIFF
--- a/buildkite/setup-docker.sh
+++ b/buildkite/setup-docker.sh
@@ -50,7 +50,8 @@ EOF
 ### Patch the filesystem options to increase I/O performance
 {
   if [[ "$(uname -m)" != "aarch64" ]]; then
-    tune2fs -o ^acl,journal_data_writeback,nobarrier /dev/sda1
+    ROOT_DEV=$(findmnt -n -o SOURCE /)
+    tune2fs -o ^acl,journal_data_writeback,nobarrier "${ROOT_DEV}"
     cat > /etc/fstab <<'EOF'
 LABEL=cloudimg-rootfs    /            ext4    defaults,noatime,commit=300,journal_async_commit    0 0
 LABEL=UEFI               /boot/efi    vfat    defaults,noatime                                    0 0


### PR DESCRIPTION
Context: We upgraded the linux machines to use C3D instead of C2. #2689 

Unlike C2, C3D virtual machines use NVMe disks by default.
This changes the boot disk partition device name from `/dev/sda1` (SCSI) --to--> `/dev/nvme0n1p1` (NVMe), causing a failure during the VM's startup script execution while booting. ([example](https://buildkite.com/bazel-trusted/create-linux-vm-image/builds/31#019efa4a-9655-4656-a25b-75445ef9d1d3/L889))

Updated `setup-docker.sh` to resolve the root disk partition dynamically at runtime.