### PR TITLE
Add buildkite-agent to the docker group

### DIFF
--- a/buildkite/setup-docker.sh
+++ b/buildkite/setup-docker.sh
@@ -125,6 +125,9 @@ EOF
   # Disable the Docker service, as the startup script has to mount /var/lib/docker first.
   systemctl disable docker
   systemctl stop docker
+
+  # Add buildkite-agent to the docker group to grant it permissions to the Docker socket
+  usermod -aG docker buildkite-agent
 }
 
 ## Add our minimum uptime enforcer.


### PR DESCRIPTION
Add `buildkite` user to the host's docker group in `setup-docker.sh` to resolve the Docker socket [permission denied error](https://buildkite.com/bazel-testing/bazel-bazel/builds/9826#019efb8a-3972-4b78-b9ad-91beb67b165e/L85) on new VM images.


Commit #2573 hardened GCE VM security by changing `/var/run/docker.sock` permissions from `0666` (world-writable) to `0660` (restricted to root and the docker group). 

Because the `buildkite-agent` user was never added to the host's docker group, newly compiled VM images (which are built for the first time since that commit) block the Buildkite agent from executing Docker commands.