### PR TITLE
Add docker group to Buildkite docker plugin config

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3062,6 +3062,7 @@ def create_docker_step(label, image, commands=None, additional_env_vars=None, qu
         "plugins": {
             "docker#v3.8.0": {
                 "always-pull": True,
+                "additional-groups": ["docker"],
                 "environment": env,
                 "image": image,
                 "network": "host",


### PR DESCRIPTION
Fix [this error](https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/34290#019f1cb3-0d36-48f5-8f69-f4bba4be27cc/L906), caused by the [security hardening commit](https://github.com/bazelbuild/continuous-integration/commit/c1c1db8dbd0cff3b8d00d79530329878082d4f89), which restricted the host's Docker socket permissions to 0660 (allowing access only to root and members of the docker group).

Because the Buildkite agent runs CI build steps inside Docker containers under a custom user ID, the containerized processes lacked permission to communicate with the host's hardened docker.sock. Adding "docker" group to our Buildkite Docker plugin configuration resolves this by granting the containers the necessary group membership to access the socket and execute Docker commands successfully.