### PR TITLE
Create the docker group with GID ensure a stable GID across all containers

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3062,7 +3062,7 @@ def create_docker_step(label, image, commands=None, additional_env_vars=None, qu
         "plugins": {
             "docker#v3.8.0": {
                 "always-pull": True,
-                "additional-groups": ["docker"],
+                "additional-groups": ["999"],
                 "environment": env,
                 "image": image,
                 "network": "host",

--- a/buildkite/setup-docker.sh
+++ b/buildkite/setup-docker.sh
@@ -111,8 +111,13 @@ EOF
       "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
       $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-  # Pre-create the docker group with GID 999 to ensure a stable GID across all runner images
+  # Pre-create the docker group with GID 999 to ensure a stable GID across all runner images.
+  # We fail the image build if GID 999 is already taken to avoid silent runtime mismatches.
   groupadd -g 999 docker || true
+  if [[ "$(getent group docker | cut -d: -f3)" != "999" ]]; then
+    echo "ERROR: Failed to allocate GID 999 to docker group."
+    exit 1
+  fi
 
   apt-get -y update
   apt-get -y install docker-ce docker-ce-cli containerd.io

--- a/buildkite/setup-docker.sh
+++ b/buildkite/setup-docker.sh
@@ -111,6 +111,9 @@ EOF
       "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
       $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
+  # Pre-create the docker group with GID 999 to ensure a stable GID across all runner images
+  groupadd -g 999 docker || true
+
   apt-get -y update
   apt-get -y install docker-ce docker-ce-cli containerd.io
 

--- a/pipelines/docker-update.yml
+++ b/pipelines/docker-update.yml
@@ -6,6 +6,8 @@ steps:
     plugins:
       docker#v3.8.0:
         always-pull: true
+        additional-groups:
+          - "999"
         environment:
           - ANDROID_HOME
           - ANDROID_NDK_HOME


### PR DESCRIPTION
A security update hardened the host VM's Docker socket to 0660 (accessible only by the docker group). Because Buildkite runs your build steps inside Docker containers under a custom user ID, Docker automatically dropped the host's docker group membership from the containerized processes, blocking them from accessing the socket and causing build failures.

The Fix
To restore socket access inside the build containers without compromising security:
VM Host Setup (setup-docker.sh): Pre-created the docker group on the GCE host VM with a fixed, stable Group ID (GID 999).
CI Pipeline Config (bazelci.py): Added "additional-groups": ["999"] to the Buildkite Docker plugin. This forces Docker to attach GID 999 to the container process. Using a GID number instead of the group name "docker" bypasses GID name-lookup issues inside base compiler images (like Fedora).

Release Pipeline (pipelines/docker-update.yml): Applied the same "additional-groups": ["999"] fix to prevent future automated release pipeline failures.