### PR TITLE
Revert "fix: replace host docker.sock mount with Docker-in-Docker (#2573)"

### DIFF
--- a/buildkite/setup-docker.sh
+++ b/buildkite/setup-docker.sh
@@ -122,12 +122,12 @@ EOF
   apt-get -y update
   apt-get -y install docker-ce docker-ce-cli containerd.io
 
-  # Restrict Docker socket to the docker group. Containers that need Docker access
-  # should use Docker-in-Docker rather than mounting the host socket.
+  # Allow everyone access to the Docker socket. Usually this would be insane from a security point
+  # of view, but these are untrusted throw-away machines anyway, so the risk is acceptable.
   mkdir /etc/systemd/system/docker.socket.d
   cat > /etc/systemd/system/docker.socket.d/override.conf <<'EOF'
 [Socket]
-SocketMode=0660
+SocketMode=0666
 EOF
 
   # Disable the Docker service, as the startup script has to mount /var/lib/docker first.


### PR DESCRIPTION
This reverts commit c1c1db8dbd0cff3b8d00d79530329878082d4f89.

CI is currently broken since too many tests still require access to the Docker socket. We have to fix them first before rolling this improvement forward.