### PR TITLE
Stop updating Mintlify CLI at runtime

### DIFF
--- a/mintlify/Dockerfile
+++ b/mintlify/Dockerfile
@@ -51,6 +51,7 @@ WORKDIR /usr/local/lib/mintlify
 COPY package.json package-lock.json ./
 RUN npm ci && npm cache clean --force
 ENV PATH="/usr/local/lib/mintlify/node_modules/.bin:${PATH}"
+RUN mint update
 
 WORKDIR /
 

--- a/mintlify/check_docs.sh
+++ b/mintlify/check_docs.sh
@@ -5,9 +5,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/download_json.sh"
 
-echo "--- Updating Mintlify CLI"
-mint version
-mint update
+echo "--- Checking Mintlify CLI"
 mint version
 
 if [[ "$(git config --get remote.origin.url)" == */bazel.git ]]; then


### PR DESCRIPTION
The update step introduced another source of flakiness. We will have to rebuild the Docker image more often, but that's ok.