### PR TITLE
Promote `--build_event_json_file_path_conversion` flag

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -2172,7 +2172,7 @@ def common_build_flags(bep_file, platform):
 
     if bep_file:
         flags += [
-            "--experimental_build_event_json_file_path_conversion=false",
+            "--build_event_json_file_path_conversion=false",
             "--build_event_json_file=" + bep_file,
         ]
 


### PR DESCRIPTION
Replace `--experimental_build_event_json_file_path_conversion` with `--build_event_json_file_path_conversion`

Fixes warning:

```
WARNING: Option 'experimental_build_event_json_file_path_conversion' is deprecated: Use --build_event_json_file_path_conversion instead
```