### PR TITLE
Move ci-metrics tables to untrusted

### DIFF
--- a/buildkite/collect_infra_metrics.py
+++ b/buildkite/collect_infra_metrics.py
@@ -10,7 +10,7 @@ from bazelci import BuildkiteClient
 
 # --- Configuration ---
 ORGs = ["bazel-testing", "bazel", "bazel-trusted"]
-PROJECT_ID = "bazel-public"
+PROJECT_ID = "bazel-untrusted"
 DATASET_ID = "bazel_ci_metrics"
 TABLE_ID = "infra_stats"
 

--- a/buildkite/collect_metrics.py
+++ b/buildkite/collect_metrics.py
@@ -29,7 +29,7 @@ class TestTarget:
     shard_durations: List[float] = dataclasses.field(default_factory=list)
 
 # --- BigQuery Configuration constants ---
-PROJECT_ID = "bazel-public"
+PROJECT_ID = "bazel-untrusted"
 DATASET_ID = "bazel_ci_metrics"
 TABLE_ID = "ci_builds"
 

--- a/buildkite/collect_metrics_test.py
+++ b/buildkite/collect_metrics_test.py
@@ -249,8 +249,8 @@ class TestPublishMetrics(unittest.TestCase):
         self.assertEqual(row["test"]["failed_test_count"], 0)
         self.assertEqual(row.get("queue_duration_s"), 300.0)
         self.assertIsNone(row["task_label"])
-        self.assertEqual(row["build_shard_id"], -1)
-        self.assertEqual(row["build_shard_count"], -1)
+        self.assertEqual(row["build_shard_id"], 0)
+        self.assertEqual(row["build_shard_count"], 1)
 
     @patch("collect_metrics.publish_to_bigquery")
     @patch("collect_metrics.parse_bep")


### PR DESCRIPTION
Tables are already created with needed permissions and this change will update the code to write to them.

+ small test fix