### PR TITLE
Relax BCR presubmit config block check.

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -548,16 +548,8 @@ def main(argv=None):
         pr_labels = get_labels_from_pr()
         low_priority = "low-ci-priority" in pr_labels
         pipeline_steps = []
-        risky_presubmit_yml_files = set()
         for module_name, module_version in modules:
             previous_size = len(pipeline_steps)
-
-            with open(get_presubmit_yml(module_name, module_version), "rt") as f:
-                presubmit_content = f.read()
-
-            if bazelci.contains_user_commands(presubmit_content):
-                risky_presubmit_yml_files.add(f"modules/{module_name}/{module_version}/presubmit.yml")
-
             configs = get_anonymous_module_task_config(module_name, module_version)
             add_presubmit_jobs(module_name, module_version, configs.get("tasks", {}), pipeline_steps, low_priority=low_priority)
             configs = get_test_module_task_config(module_name, module_version)
@@ -566,15 +558,8 @@ def main(argv=None):
             if len(pipeline_steps) == previous_size:
                 error("No pipeline steps generated for %s@%s. Please check the configuration." % (module_name, module_version))
 
-        if should_wait_bcr_maintainer_review(modules, pr_labels) or risky_presubmit_yml_files:
-            suffix = (
-                f" - also check shell_commands in {', '.join(risky_presubmit_yml_files)}!"
-                if risky_presubmit_yml_files
-                else ""
-            )
-            pipeline_steps.insert(
-                0, {"block": f"Wait on BCR maintainer review{suffix}", "blocked_state": "running"}
-            )
+        if should_wait_bcr_maintainer_review(modules, pr_labels):
+            pipeline_steps.insert(0, {"block": "Wait on BCR maintainer review", "blocked_state": "running"})
 
         upload_jobs_to_pipeline(pipeline_steps)
     elif args.subparsers_name == "anonymous_module_runner":

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -564,6 +564,8 @@ RELEASE_BRANCH_RE = re.compile(r"\brelease-(\d+\.\d+\.\d+(rc\d+)?)\b")
 
 CONFIG_FILE_EXTENSIONS = {".yml", ".yaml"}
 
+DEFAULT_PRESUBMIT_CONFIG_PATH = ".bazelci/presubmit.yml"
+
 KYTHE_DIR = "/usr/local/kythe"
 
 INDEX_UPLOAD_POLICY_ALWAYS = "Always"
@@ -1170,7 +1172,7 @@ def load_config(http_url, file_config, allow_imports=True, bazel_version=None):
     if http_url:
         config = load_remote_yaml_file(http_url)
     else:
-        file_config = file_config or ".bazelci/presubmit.yml"
+        file_config = file_config or DEFAULT_PRESUBMIT_CONFIG_PATH
         with open(file_config, "r") as fd:
             config = yaml.safe_load(fd)
 
@@ -3307,10 +3309,11 @@ def create_initial_steps():
     modified_config_files = [f for f in modified_files if is_config_file(f)]
 
     if os.getenv("BUILDKITE_PIPELINE_SLUG", "") == "bazel-central-registry":
-        # Blocking all yml changes in BCR PRs would be too annoying,
-        # so we only block those with shell/batch commands.
-        # This is the same behavior as in bcr_presubmit.py.
-        modified_config_files = [p for p in modified_config_files if is_risky_bcr_config(p)]
+        # BCR: Only block changes to BCR's own presubmit.yml file.
+        # yml files in modules are checked by bcr_presubmit.py.
+        modified_config_files = set([DEFAULT_PRESUBMIT_CONFIG_PATH]).intersection(
+            modified_config_files
+        )
 
     if modified_config_files:
         steps.append(
@@ -3325,15 +3328,6 @@ def create_initial_steps():
 
 def is_config_file(path):
     return ".bazelci" in path or path.endswith(".yml")
-
-
-def is_risky_bcr_config(path):
-    with open(path, "rt") as f:
-        return contains_user_commands(f.read())
-
-
-def contains_user_commands(yml_content):
-    return  "shell_commands" in yml_content or "batch_commands" in yml_content
 
 
 def create_buildifier_step(buildifier_config):


### PR DESCRIPTION
bcr_presubmit: This commit reverts "Require maintainer review of risky config changes. (#2685)" (36dd157dc727d2787c4f8f515825e63bdb52e4be) since existing checks are good enough.

bazelci.py: Only block if BCR's own presubmit.yml file is being changed.