### PR TITLE
Allow presubmit-auto-run to be used on other repos

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -391,7 +391,7 @@ def should_bcr_validation_block_presubmit(modules, modules_with_metadata_change,
         skip_validation_flags.append("--skip_validation=url_stability")
     if "skip-compatibility-level-check" in pr_labels:
         skip_validation_flags.append("--skip_validation=compatibility_level")
-    if "presubmit-auto-run" in pr_labels:
+    if bazelci.PRESUBMIT_AUTO_RUN_LABEL in pr_labels:
         skip_validation_flags.append("--skip_validation=presubmit_yml")
     returncode = subprocess.run(
         ["bazel", "run", "//tools:bcr_validation", "--"]

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -566,6 +566,8 @@ CONFIG_FILE_EXTENSIONS = {".yml", ".yaml"}
 
 DEFAULT_PRESUBMIT_CONFIG_PATH = ".bazelci/presubmit.yml"
 
+PRESUBMIT_AUTO_RUN_LABEL = "presubmit-auto-run"
+
 KYTHE_DIR = "/usr/local/kythe"
 
 INDEX_UPLOAD_POLICY_ALWAYS = "Always"
@@ -3303,7 +3305,11 @@ def print_project_pipeline(
 def create_initial_steps():
     steps = []
     default_branch = os.getenv("BUILDKITE_PIPELINE_DEFAULT_BRANCH")
-    if THIS_IS_TRUSTED or os.getenv("BUILDKITE_BRANCH") == default_branch:
+    if (
+        THIS_IS_TRUSTED
+        or os.getenv("BUILDKITE_BRANCH") == default_branch
+        or has_presubmit_auto_run_label()
+    ):
         return steps
 
     modified_files = get_modified_files(os.getenv("BUILDKITE_COMMIT"))
@@ -3325,6 +3331,10 @@ def create_initial_steps():
         )
 
     return steps
+
+
+def has_presubmit_auto_run_label():
+    return PRESUBMIT_AUTO_RUN_LABEL in os.getenv("BUILDKITE_PULL_REQUEST_LABELS", "").split(",")
 
 
 def is_config_file(path):

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -23,6 +23,7 @@ import bazelci
 import shlex
 import tempfile
 import unittest
+from unittest import mock
 import yaml
 
 
@@ -523,6 +524,38 @@ class ShellQuoting(unittest.TestCase):
         self.assertIn("--git_commit=$(touch %s)" % sentinel, tokens)
         self.assertNotIn("touch", tokens)
         self.assertFalse(os.path.exists(sentinel))
+
+
+class InitialSteps(unittest.TestCase):
+    def test_blocks_config_changes_without_presubmit_auto_run_label(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "BUILDKITE_BRANCH": "feature",
+                "BUILDKITE_PIPELINE_DEFAULT_BRANCH": "main",
+                "BUILDKITE_PULL_REQUEST_LABELS": "",
+            },
+        ), mock.patch.object(
+            bazelci, "get_modified_files", return_value=[".bazelci/presubmit.yml"]
+        ):
+            steps = bazelci.create_initial_steps()
+
+        self.assertEqual(len(steps), 1)
+        self.assertIn("block", steps[0])
+
+    def test_presubmit_auto_run_label_skips_config_change_block(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "BUILDKITE_BRANCH": "feature",
+                "BUILDKITE_PIPELINE_DEFAULT_BRANCH": "main",
+                "BUILDKITE_PULL_REQUEST_LABELS": "foo,presubmit-auto-run,bar",
+            },
+        ), mock.patch.object(bazelci, "get_modified_files") as get_modified_files:
+            steps = bazelci.create_initial_steps()
+
+        self.assertEqual(steps, [])
+        get_modified_files.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/buildkite/terraform/bazel/pipelines_misc.tf
+++ b/buildkite/terraform/bazel/pipelines_misc.tf
@@ -1097,7 +1097,7 @@ resource "buildkite_pipeline" "apple-support-darwin" {
     build_tags                                    = false
     build_pull_request_forks                      = true
     build_pull_request_ready_for_review           = false
-    build_pull_request_labels_changed             = false
+    build_pull_request_labels_changed             = true
     build_pull_request_base_branch_changed        = false
     prefix_pull_request_fork_branch_names         = true
     filter_enabled                                = false

--- a/buildkite/terraform/bazel/pipelines_rules.tf
+++ b/buildkite/terraform/bazel/pipelines_rules.tf
@@ -185,7 +185,7 @@ resource "buildkite_pipeline" "rules-apple-darwin" {
     build_tags                                    = false
     build_pull_request_forks                      = true
     build_pull_request_ready_for_review           = false
-    build_pull_request_labels_changed             = false
+    build_pull_request_labels_changed             = true
     build_pull_request_base_branch_changed        = false
     prefix_pull_request_fork_branch_names         = true
     filter_enabled                                = false
@@ -1320,7 +1320,7 @@ resource "buildkite_pipeline" "rules-swift-swift" {
     build_tags                                    = false
     build_pull_request_forks                      = true
     build_pull_request_ready_for_review           = false
-    build_pull_request_labels_changed             = false
+    build_pull_request_labels_changed             = true
     build_pull_request_base_branch_changed        = false
     prefix_pull_request_fork_branch_names         = true
     filter_enabled                                = false


### PR DESCRIPTION
The biggest downside here is it requires rerunning jobs when labels
change. Technically people could also have access to change labels
without having access to run jobs on buildkite, but IMO that's a minor
risk

Fixes https://github.com/bazelbuild/continuous-integration/issues/2719
