### PR TITLE
Fix linux docker images pipeline

### DIFF
--- a/buildkite/docker/debian10/Dockerfile
+++ b/buildkite/docker/debian10/Dockerfile
@@ -6,6 +6,12 @@ ENV LANG "C.UTF-8"
 ENV LANGUAGE "C.UTF-8"
 ENV LC_ALL "C.UTF-8"
 
+# Update repository URLs to archive.debian.org for EOL Debian 10 buster and disable expiration checks
+RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list && \
+    sed -i '/buster-updates/d' /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+
 ### Install packages required by Bazel and its tests
 RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \

--- a/buildkite/docker/ubuntu2004/Dockerfile
+++ b/buildkite/docker/ubuntu2004/Dockerfile
@@ -78,7 +78,7 @@ FROM ubuntu2004-bazel-nojdk AS ubuntu2004-nojdk
 ### https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
-    apt-get update -y && apt-get install google-cloud-sdk=466.0.0-0 google-cloud-cli=466.0.0-0 -y && \
+    apt-get update -y && apt-get install google-cloud-sdk=466.0.0-0 -y && \
     rm -rf /var/lib/apt/lists/*
 
 ### Docker (for legacy rbe_autoconfig)

--- a/buildkite/docker/ubuntu2004/Dockerfile
+++ b/buildkite/docker/ubuntu2004/Dockerfile
@@ -78,7 +78,7 @@ FROM ubuntu2004-bazel-nojdk AS ubuntu2004-nojdk
 ### https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
-    apt-get update -y && apt-get install google-cloud-sdk -y && \
+    apt-get update -y && apt-get install google-cloud-sdk=466.0.0-0 google-cloud-cli=466.0.0-0 -y && \
     rm -rf /var/lib/apt/lists/*
 
 ### Docker (for legacy rbe_autoconfig)
@@ -121,10 +121,10 @@ ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-${TARGETARCH}
 FROM ubuntu2004-nojdk AS ubuntu2004
 
 RUN apt-get -y update && \
-    apt-get -y install openjdk-21-jdk-headless && \
+    apt-get -y install openjdk-17-jdk-headless && \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk-${TARGETARCH}
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-${TARGETARCH}
 
 FROM ubuntu2004 AS ubuntu2004-kythe
 


### PR DESCRIPTION
Fix Create Linux Docker Image pipeline [Failures](https://buildkite.com/bazel-trusted/create-linux-docker-images
)

This is a quick fix for Debian 10 and Ubuntu 20.04 Docker image builds.
A full migration of CI pipelines to Debian 13 and Ubuntu 24.04 LTS is needed as a long-term solution.

Debian 10 reached End-of-Life (EOL) in June 2024. Active APT mirrors (deb.debian.org and security.debian.org) removed buster indices, causing 404 Not Found errors during apt-get update.
Fix:
Re-pointed EOL APT repositories to archive.debian.org and disabled repo expiration checks to resolve 404 Not Found build failures.

Ubuntu 20.04:
ARM64 Google Cloud SDK failure: Recent SDK versions require Python 3.10+ on ARM64, conflicting with Ubuntu 20.04's default Python 3.8.
Fix: Pinned google-cloud-sdk=466.0.0-0 (to resolve Python 3.8 dependency conflicts on ARM64) 

Missing OpenJDK 21 package: Canonical's official Ubuntu 20.04 APT repositories do not carry Java 21 (they top out at Java 17).
Fix: switched to openjdk-17-jdk-headless (as OpenJDK 21 is not available in Ubuntu 20.04 repositories).

Changes are tested on the [testing branch](https://buildkite.com/bazel-trusted/create-linux-docker-images/builds/67)