### PR TITLE
Add permission to post the terraform plan in a comment

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -66,6 +66,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
+      issues: write
 
     # Lock per organization. Cancels old runs on PRs (saves time), but queues pushes (safe apply).
     concurrency:


### PR DESCRIPTION
After [restricting the id-token permission](https://github.com/bazelbuild/continuous-integration/pull/2679/changes) to the "detect-changes" steponly, it was stripped off any other general permissions like: "pull-requests: write" (which was defined at the top of the workflow) 

We need to re-add it to this step to be able to post a comment with the plan