### PR TITLE
Don't block for any postsubmit runs on release branches

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -561,6 +561,7 @@ DISABLE_BAZEL_DIFF_IF_MODIFIED = (
 
 COMMIT_RE = re.compile(r"[0-9a-z]{40}")
 MERGE_QUEUE_BRANCH_RE = re.compile(r"gh-readonly-queue\/(release-\d+\.\d+\.\d+(rc\d+)?)\/")
+RELEASE_BRANCH_RE = re.compile(r"release-\d+\.\d+\.\d+(rc\d+)?")
 
 CONFIG_FILE_EXTENSIONS = {".yml", ".yaml"}
 
@@ -3308,6 +3309,7 @@ def create_initial_steps():
     if (
         THIS_IS_TRUSTED
         or os.getenv("BUILDKITE_BRANCH") == default_branch
+        or RELEASE_BRANCH_RE.fullmatch(os.getenv("BUILDKITE_BRANCH"))
         or has_presubmit_auto_run_label()
     ):
         return steps


### PR DESCRIPTION
Currently, Bazel postsubmit pipelines are completely blocked (except for a few runs that I manually unblocked; https://buildkite.com/bazel/bazel-bazel/builds?branch=release-8.8.0) because they have config file changes compared to the "default branch", which is master.

This PR makes it so that runs on release branches are never blocked. PR branches whose base branch are release branches are unaffected (they would still be blocked).