### PR TITLE
Do not set Android env variables in release yml

### DIFF
--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -50,8 +50,6 @@ steps:
       docker#v3.8.0:
         always-pull: true
         environment:
-          - ANDROID_HOME
-          - ANDROID_NDK_HOME
           - BUILDKITE_ARTIFACT_UPLOAD_DESTINATION
         image: gcr.io/bazel-public/rockylinux8-releaser
         network: host
@@ -294,8 +292,6 @@ steps:
       docker#v3.8.0:
         always-pull: true
         environment:
-          - ANDROID_HOME
-          - ANDROID_NDK_HOME
           - BUILDKITE_ARTIFACT_UPLOAD_DESTINATION
         image: gcr.io/bazel-public/rockylinux8-java8
         network: host
@@ -444,8 +440,6 @@ steps:
       docker#v3.8.0:
         always-pull: true
         environment:
-          - ANDROID_HOME
-          - ANDROID_NDK_HOME
           - BUILDKITE_ARTIFACT_UPLOAD_DESTINATION
         image: gcr.io/bazel-public/ubuntu2004-java11
         network: host

--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -7,8 +7,6 @@ steps:
       docker#v3.8.0:
         always-pull: true
         environment:
-          - ANDROID_HOME
-          - ANDROID_NDK_HOME
           - BUILDKITE_ARTIFACT_UPLOAD_DESTINATION
         image: gcr.io/bazel-public/ubuntu2004-java11
         network: host


### PR DESCRIPTION
These are not necessary to build bazel, and are currently causing the rolling release build to break.