### PR TITLE
Explicitly unset android env vars for macos

### DIFF
--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -162,6 +162,8 @@ steps:
     command: |
       git fetch origin ${BUILDKITE_BRANCH}
       git checkout ${BUILDKITE_BRANCH}
+      unset ANDROID_HOME
+      unset ANDROID_NDK_HOME
 
       release_name=$(buildkite-agent meta-data get "release_name")
       echo "release_name = \"\$release_name\""


### PR DESCRIPTION
Seems that removing their values from the `environment` dict was insufficient.