### PR TITLE
Use `bazel mod deps` to update lockfile

### DIFF
--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -78,7 +78,7 @@ steps:
       cp bazel-bin/src/bazel output/bazel
 
       rm -f MODULE.bazel.lock
-      output/bazel build --nobuild :bazel-srcs :bootstrap-jars :maven-srcs //src:derived_java_srcs
+      output/bazel mod deps --lockfile_mode=update
 
       output/bazel build \
           -c opt \


### PR DESCRIPTION
Can't rely on `bazel build --nobuild` since not all of the requisite module extensions are dumped into the lockfile for whatever reason.