### PR TITLE
Revert docker installation and add golang and RBE_CONFIG_CONTAINER in…

### DIFF
--- a/buildkite/docker/ubuntu2404/Dockerfile
+++ b/buildkite/docker/ubuntu2404/Dockerfile
@@ -16,13 +16,13 @@ RUN apt-get -y update && \
     clang-tools \
     coreutils \
     curl \
-    docker.io \
     dnsutils \
     ed \
     expect \
     file \
     git \
     gnupg2 \
+    golang \
     iproute2 \
     iputils-ping \
     lcov \
@@ -90,6 +90,9 @@ RUN apt-get -y update && \
     rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME /usr/lib/jvm/java-21-openjdk-${TARGETARCH}
+# Authoritative target container image used by rules/rbe_config.bzl to automatically activate
+# --exec_mode=host and prevent toolchain/ABI discrepancies in CI.
+ENV RBE_CONFIG_CONTAINER="gcr.io/bazel-public/ubuntu2404:latest"
 
 FROM ubuntu2404 AS ubuntu2404-kythe
 


### PR DESCRIPTION
… ubuntu2404 image

With dual execution mode support (--exec_mode=host) added to rbe_config.bzl (#2747), Docker-in-Docker is no longer needed in CI containers for dynamic RBE toolchain generation.

This commit updates buildkite/docker/ubuntu2404/Dockerfile:
- Reverts #2642 by removing `docker.io` from apt-get install.
- Adds `golang` so that rbe_configs_gen can be compiled natively from source in host mode.
- Sets `ENV RBE_CONFIG_CONTAINER="gcr.io/bazel-public/ubuntu2404:latest"` so that rbe_config.bzl automatically activates host mode when running inside this container.