### PR TITLE
Temporarily restore docker.io in ubuntu2404 image for backwards compa…

### DIFF
--- a/buildkite/docker/ubuntu2404/Dockerfile
+++ b/buildkite/docker/ubuntu2404/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get -y update && \
     clang-tools \
     coreutils \
     curl \
+    docker.io \
     dnsutils \
     ed \
     expect \


### PR DESCRIPTION
…tibility

This restores `docker.io` in buildkite/docker/ubuntu2404/Dockerfile so that worker containers support both legacy docker mode (--exec_mode=docker) and the new host mode (--exec_mode=host) during the rollout of bazel_ci_rules 2.1.0.