### PR TITLE
Release bazel_ci_rules 2.1.0

### DIFF
--- a/rules/MODULE.bazel
+++ b/rules/MODULE.bazel
@@ -1,4 +1,4 @@
-module(name = "bazel_ci_rules", version = "2.0.0")
+module(name = "bazel_ci_rules", version = "2.1.0")
 
 # Expose platforms and compiler rules to generated toolchain repositories
 bazel_dep(name = "platforms", version = "0.0.8")


### PR DESCRIPTION
# Release Notes: `bazel_ci_rules` v2.1.0 🚀
`bazel_ci_rules` v2.1.0 introduces **automatic dual execution mode support (`docker` vs `host`)** for dynamic RBE toolchain generation.

## 🌟 Key Highlights
* **Automatic Dual Execution Modes**: Dynamically detects the execution environment. By default (`RBE_CONFIG_CONTAINER` unset), it uses Docker-out-of-Docker (`--exec_mode=docker`). In containerized CI pipelines where `RBE_CONFIG_CONTAINER` is exported, it automatically switches to host mode (`--exec_mode=host`), compiling `rbe_configs_gen` natively on the host via `go build` without requiring Docker daemon access.
* **Host Container Authority**: In `--exec_mode=host`, the target container image string in `@rbe_ubuntu//config:platform` is authoritatively determined by the `RBE_CONFIG_CONTAINER` environment variable to prevent toolchain and ABI discrepancies.
* **Zero Docker Socket Dependency in CI**: Eliminates `/var/run/docker.sock` volume mounting requirements in worker containers and CI pipelines.

---
## 🛠 Quick Start & Usage
### Bzlmod (Bazel 8+)
```bazel
bazel_dep(name = "bazel_ci_rules", version = "2.1.0")
rbe = use_extension("@bazel_ci_rules//:rbe_config.bzl", "rbe_config_extension")
rbe.config(name = "rbe_ubuntu", preset = "ubuntu")
use_repo(rbe, "rbe_ubuntu")
```
### Legacy WORKSPACE
```python
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
http_archive(
    name = "bazel_ci_rules",
    strip_prefix = "continuous-integration-rules-2.1.0",
    url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-2.1.0/bazel_ci_rules-2.1.0.tar.gz",
)
load("@bazel_ci_rules//:rbe_config.bzl", "rbe_config")
rbe_config(name = "rbe_ubuntu", preset = "ubuntu")
```