### PR TITLE
docker: fail the image build when the containerd store is disabled

### DIFF
--- a/buildkite/docker/build.sh
+++ b/buildkite/docker/build.sh
@@ -18,12 +18,15 @@ esac
 # See https://docs.docker.com/develop/develop-images/build_enhancements/ for details.
 export DOCKER_BUILDKIT=1
 
-# Check whether containerd image store is enabled.
-# We need it to make --load work with multi-platform images.
-# This seems to be the only way to make these images
-# available outside of the Docker cache other than
-# using a local registry.
-docker info -f '{{ .DriverStatus }}'
+# --load only keeps all platforms of a multi-platform build when Docker uses
+# the containerd image store. With the classic store it silently keeps just
+# the host arch, and the push then wipes the other platforms from the tag.
+# Refuse to build in that case.
+if ! docker info -f '{{ .DriverStatus }}' | grep -q 'io.containerd.snapshotter'; then
+    echo "ERROR: containerd image store not enabled, multi-platform builds would" >&2
+    echo "drop non-native platforms. See https://docs.docker.com/engine/storage/containerd/" >&2
+    exit 1
+fi
 
 # We need a new builder using the docker-container driver in order
 # to build multi-platform images.


### PR DESCRIPTION
build.sh builds several images as multi-platform (amd64 + arm64) with buildx --load, which only retains both platforms when Docker uses the containerd image store. On a classic-store machine, --load silently keeps just the host-native platform, and push.sh then replaces the multi-arch tag in gcr.io with a single-arch manifest.

This is what happened to gcr.io/bazel-public/ubuntu2404 after the 2026-07-31 rebuild (#2748, #2750): the tag currently serves a plain amd64 manifest with no manifest list, and every ubuntu2404_arm64 BCR presubmit job since then dies before bcr_presubmit.py runs.

The script already acknowledged the requirement with a comment and a docker info printout, but nothing enforced it. This turns the printout into a hard failure so an incomplete image set can't be built, and therefore can't be pushed. 

The broken tag itself still needs a rebuild + re-push from a containerd-store machine, but this prevents the next occurrence.