### PR TITLE
Accept more content types of Docker manifests

### DIFF
--- a/rules/rbe_config.bzl
+++ b/rules/rbe_config.bzl
@@ -124,7 +124,7 @@ def _resolve_container_digest(repository_ctx, container_image):
 
     res = repository_ctx.execute([
         "curl", "-sI",
-        "-H", "Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json",
+        "-H", "Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json",
         url,
     ])
     if res.return_code == 0:


### PR DESCRIPTION
The old code accepts only application/vnd.docker.distribution.manifest.v2+json and application/vnd.oci.image.manifest.v1+json, but GCP artifact registry returns application/vnd.oci.image.index.v1+json for gcr.io/bazel-public/ubuntu2404

Should fix issues such as https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/35379#019fcd81-ba85-4e4a-a516-6b889a3851bd