### PR TITLE
Fix stale-approval bypass in BCR PR reviewer's review-freshness check

### DIFF
--- a/actions/bcr-pr-reviewer/index.js
+++ b/actions/bcr-pr-reviewer/index.js
@@ -261,11 +261,14 @@ async function getPrApprovers(octokit, owner, repo, prNumber) {
     pull_number: prNumber,
   });
 
-  // Filter out the merge commits whose parents length is larger than 1
-  const nonMergeCommits = commits.filter(commit => commit.parents.length === 1);
-
-  // Get the latest commit submitted time
-  const latestCommit = nonMergeCommits[nonMergeCommits.length - 1];
+  // Use the PR's actual current head commit as the review-freshness cutoff. This must
+  // NOT exclude merge commits: a merge commit can itself introduce diff content (e.g.
+  // conflict resolution, or content brought in from the merged branch), so treating it
+  // as if it doesn't exist lets a stale approval of an earlier commit keep counting as
+  // approving a HEAD the reviewer never actually saw -- a pusher could get an innocuous
+  // early commit approved, then push a merge commit that changes the content, and the
+  // stale approval would still be considered valid for the new HEAD.
+  const latestCommit = commits[commits.length - 1];
   const latestCommitTime = new Date(latestCommit.commit.author.date);
   console.log(`Latest commit: ${latestCommit.sha}`);
   console.log(`Latest commit time: ${latestCommitTime}`);
@@ -277,7 +280,7 @@ async function getPrApprovers(octokit, owner, repo, prNumber) {
     pull_number: prNumber,
   });
 
-  // For each reviewer, collect their latest review that are newer than the latest non-merge commit
+  // For each reviewer, collect their latest review that are newer than the latest commit
   // Key: reviewer, Value: review
   const latestReviews = new Map();
   reviewEvents.forEach(review => {
@@ -292,8 +295,8 @@ async function getPrApprovers(octokit, owner, repo, prNumber) {
       return;
     }
 
-    existingSubmittedAt = new Date(latestReviews.get(reviewer).submitted_at);
-    submittedAt = new Date(review.submitted_at);
+    const existingSubmittedAt = new Date(latestReviews.get(reviewer).submitted_at);
+    const submittedAt = new Date(review.submitted_at);
     if (submittedAt > existingSubmittedAt) {
       latestReviews.set(reviewer, review);
     }
@@ -1032,7 +1035,11 @@ async function run() {
   }
 }
 
-run().catch(err => {
-  console.error(err);
-  setFailed(err.message);
-});
+if (require.main === module) {
+  run().catch(err => {
+    console.error(err);
+    setFailed(err.message);
+  });
+}
+
+module.exports = { getPrApprovers };

--- a/actions/bcr-pr-reviewer/index.test.js
+++ b/actions/bcr-pr-reviewer/index.test.js
@@ -1,0 +1,65 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { getPrApprovers } = require('./index.js');
+
+function fakeOctokit({ commits, reviews }) {
+  return {
+    paginate: async (fn, params) => {
+      if (fn === fakeOctokit.pullsListCommitsMarker) return commits;
+      if (fn === fakeOctokit.pullsListReviewsMarker) return reviews;
+      throw new Error('unexpected paginate call');
+    },
+    rest: {
+      pulls: {
+        listCommits: fakeOctokit.pullsListCommitsMarker,
+        listReviews: fakeOctokit.pullsListReviewsMarker,
+      },
+    },
+  };
+}
+fakeOctokit.pullsListCommitsMarker = Symbol('listCommits');
+fakeOctokit.pullsListReviewsMarker = Symbol('listReviews');
+
+test('getPrApprovers: a stale approval does not count once a merge commit changes the PR head', async () => {
+  // C1 gets approved by a maintainer, then C2 (a merge commit -- 2 parents) is
+  // pushed afterwards and becomes the PR's real HEAD. The maintainer's review
+  // predates C2 and never saw its content.
+  const commits = [
+    { sha: 'C1', parents: [{ sha: 'base' }], commit: { author: { date: '2026-08-06T00:00:00Z' } } },
+    { sha: 'C2-merge', parents: [{ sha: 'C1' }, { sha: 'other' }], commit: { author: { date: '2026-08-06T00:20:00Z' } } },
+  ];
+  const reviews = [
+    { user: { login: 'maintainer' }, state: 'APPROVED', submitted_at: '2026-08-06T00:10:00Z' },
+  ];
+
+  const approvers = await getPrApprovers(fakeOctokit({ commits, reviews }), 'owner', 'repo', 1);
+
+  assert.equal(approvers.has('maintainer'), false, 'a review submitted before the real HEAD must not count as approving it');
+});
+
+test('getPrApprovers: an approval submitted after a merge commit still counts', async () => {
+  const commits = [
+    { sha: 'C1', parents: [{ sha: 'base' }], commit: { author: { date: '2026-08-06T00:00:00Z' } } },
+    { sha: 'C2-merge', parents: [{ sha: 'C1' }, { sha: 'other' }], commit: { author: { date: '2026-08-06T00:20:00Z' } } },
+  ];
+  const reviews = [
+    { user: { login: 'maintainer' }, state: 'APPROVED', submitted_at: '2026-08-06T00:30:00Z' },
+  ];
+
+  const approvers = await getPrApprovers(fakeOctokit({ commits, reviews }), 'owner', 'repo', 1);
+
+  assert.equal(approvers.has('maintainer'), true, 'a review submitted after the real HEAD should still count');
+});
+
+test('getPrApprovers: works normally when the PR has no merge commits at all', async () => {
+  const commits = [
+    { sha: 'C1', parents: [{ sha: 'base' }], commit: { author: { date: '2026-08-06T00:00:00Z' } } },
+  ];
+  const reviews = [
+    { user: { login: 'maintainer' }, state: 'APPROVED', submitted_at: '2026-08-06T00:05:00Z' },
+  ];
+
+  const approvers = await getPrApprovers(fakeOctokit({ commits, reviews }), 'owner', 'repo', 1);
+
+  assert.equal(approvers.has('maintainer'), true);
+});

--- a/actions/bcr-pr-reviewer/package.json
+++ b/actions/bcr-pr-reviewer/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary

`actions/bcr-pr-reviewer/index.js`'s `getPrApprovers()` decides whether an existing GitHub review is still valid by comparing its `submitted_at` against the timestamp of "the latest commit" -- but it computes that timestamp only from commits whose `parents.length === 1`, explicitly filtering out merge commits:

```js
// Filter out the merge commits whose parents length is larger than 1
const nonMergeCommits = commits.filter(commit => commit.parents.length === 1);
const latestCommit = nonMergeCommits[nonMergeCommits.length - 1];
const latestCommitTime = new Date(latestCommit.commit.author.date);
...
reviewEvents.forEach(review => {
  if (new Date(review.submitted_at) < latestCommitTime) {
    return; // review is stale, ignore it
  }
  ...
});
```

A merge commit can itself carry diff content -- conflict resolution, or content brought in from whatever was merged -- so excluding it from "the latest commit" means a review submitted *before* that merge commit still counts as approving the PR's *current* head, even though the reviewer never saw the merge commit's content.

Concretely: a contributor gets an early, innocuous commit approved by a maintainer, then pushes a merge commit that changes the PR's actual content. `getPrApprovers()` still returns that maintainer as a current approver, because the merge commit is invisible to its freshness calculation.

`reviewPR()` (in the same file) uses `getPrApprovers()`'s output to decide whether to submit its own `APPROVE` review and call `pulls.merge()`:

```js
if (allModulesApproved && !hasSensitiveMetadataChange) {
  if (!approvers.has(myLogin)) {
    await octokit.rest.pulls.createReview({ ..., event: 'APPROVE', ... });
  }
  await octokit.rest.pulls.merge({ ... });
  ...
}
```

So this bug lets the bot submit its own fresh `APPROVE` review and merge a PR based on a maintainer's approval of content that is no longer what's actually being merged.

**Why this is the sole gate, not defense-in-depth:** `bazel-central-registry`'s `CODEOWNERS` file explicitly excludes `modules/` from GitHub's native code-owner review requirement:
```
*          @bazelbuild/bcr-maintainers
/modules/
```
with the comment "which has a bot that manages review requests" -- i.e. this bot's own approval decision is the *only* review gate for module changes, there's no redundant native check backing it up for that path.

I verified the mechanics with a standalone script (not just by reading the source) that reproduces `getPrApprovers()`'s exact logic against fabricated commit/review data shaped like the real GitHub API responses: a review approving commit C1, followed by a 2-parent merge commit C2 as the new PR head, still returns the reviewer as an approver of C2's content.

## Fix

Use the PR's actual last commit (`commits[commits.length - 1]`) as the freshness cutoff, without excluding merge commits. `pulls.listCommits` already returns commits in chronological order, so the last entry is always the true current PR head regardless of its parent count -- there's no need to special-case merge commits at all.

Also fixed two accidentally-undeclared variables (`existingSubmittedAt`, `submittedAt`) in the same block (missing `const`, silently created implicit globals in this non-strict-mode script).

## Test plan

- `node -c index.js`: parses cleanly.
- Added `index.test.js` (Node's built-in `node:test` runner, zero new dependencies -- this action's `package.json` had no test setup at all before this) with a fake `octokit` object supplying fabricated `listCommits`/`listReviews` data directly, covering:
  1. The bypass scenario above -- asserts the stale approval no longer counts.
  2. A review genuinely submitted *after* a merge commit -- asserts it still counts (no regression for the legitimate "approve after syncing with main" case).
  3. The plain no-merge-commits case -- asserts unaffected.
- `npm test` (updated from the placeholder `"no test specified"` script to `node --test`): all 3 pass.

Independent from, and a different root cause than, my two earlier fixes in this file's sibling (`buildkite/bazel-central-registry/bcr_presubmit.py`, #2739 and #2759) -- this one's in the PR-reviewer bot's own approval logic, not the presubmit command/Starlark generation.