### PR TITLE
Update docker-buildkite-plugin version for bazel-testing org

### DIFF
--- a/buildkite/terraform/bazel-testing/pipeline.yml.tpl
+++ b/buildkite/terraform/bazel-testing/pipeline.yml.tpl
@@ -16,7 +16,7 @@ steps:
     artifact_paths:%{ for artifact_path in steps.artifact_paths }
       - "${artifact_path}"%{ endfor }%{ endif }
     plugins:
-      - docker#v3.8.0:
+      - docker#v5.14.0:
           always-pull: true
           environment:
             - "ANDROID_HOME"


### PR DESCRIPTION
Update docker-buildkite-plugin to v5.14.0 in buildkite/terraform/bazel-testing/pipeline.yml.tpl.