### PR TITLE
Fix macos build for java_tools-binaries.yml

### DIFF
--- a/pipelines/java_tools-binaries.yml
+++ b/pipelines/java_tools-binaries.yml
@@ -68,6 +68,9 @@ steps:
     label: ":darwin:"
     agents:
       - "queue=macos"
+    env:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
 
   - command: |-
       bazel --ignore_all_rc_files version


### PR DESCRIPTION
Unset `ANDROID` env vars like was done in https://github.com/bazelbuild/bazel/commit/6c9b022cb367c0a0b179c7d6704238e596988ce7