### PR TITLE
BCR presubmit: run the outside-modules check when only metadata.json changes

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -350,9 +350,13 @@ def validate_existing_modules_are_not_modified():
         bazelci.eprint("No existing module was changed.")
 
 
-def validate_files_outside_of_modules_dir_are_not_modified(modules):
-    # If no modules are changed at the same time, then we don't need to perform this check.
-    if not modules:
+def validate_files_outside_of_modules_dir_are_not_modified(modules, modules_with_metadata_change):
+    # If nothing under modules/ is changed at the same time, then we don't need to perform this
+    # check. Both kinds of change have to be considered: a pull request that touches only
+    # modules/<name>/metadata.json produces no entries in `modules`, because that list is built from
+    # the modules/<name>/<version>/ pattern, and the check would otherwise be skipped even though the
+    # pull request goes on to run //tools:bcr_validation from its own checkout.
+    if not modules and not modules_with_metadata_change:
         return
     bazelci.print_expanded_group("Checking if any file changes outside of modules/")
     output = subprocess.check_output(
@@ -424,11 +428,11 @@ def should_wait_bcr_maintainer_review(modules, pr_labels):
     # If existing modules are changed, fail the presubmit.
     validate_existing_modules_are_not_modified()
 
-    # If files outside of the modules/ directory are changed, fail the presubmit.
-    validate_files_outside_of_modules_dir_are_not_modified(modules)
-
     # Get modules with metadata.json changes.
     modules_with_metadata_change = get_modules_with_metadata_change()
+
+    # If files outside of the modules/ directory are changed, fail the presubmit.
+    validate_files_outside_of_modules_dir_are_not_modified(modules, modules_with_metadata_change)
 
     # Run BCR validations on target modules and decide if the presubmit jobs should be blocked.
     return should_bcr_validation_block_presubmit(modules, modules_with_metadata_change, pr_labels)


### PR DESCRIPTION
`validate_files_outside_of_modules_dir_are_not_modified()` returns early when `get_target_modules()`
is empty:

```python
def validate_files_outside_of_modules_dir_are_not_modified(modules):
    # If no modules are changed at the same time, then we don't need to perform this check.
    if not modules:
        return
```

`get_target_modules()` builds its list from the `modules/<name>/<version>/` pattern
(`bcr_presubmit.py:87-90`), so a pull request that touches **only** `modules/<name>/metadata.json`
produces an empty list and the check is skipped — even when the same pull request also changes files
outside `modules/`. `get_modules_with_metadata_change()` does see that pull request, and
`should_wait_bcr_maintainer_review()` goes on to call `should_bcr_validation_block_presubmit()`, which
runs `bazel run //tools:bcr_validation` from the pull request's own checkout.

The change passes the metadata-change list to the check as well, and moves the
`get_modules_with_metadata_change()` call above it so both kinds of `modules/` change are considered.

### Behaviour, before and after

Driven against real temporary git repositories, running the old and the new guard body over the same
diff. The first two rows are controls — the second exists to show the guard is not simply firing on
everything, and the first to show the patch does not make ordinary module pull requests noisy:

| case | old guard | new guard | expected |
|---|---|---|---|
| clean version add, nothing outside `modules/` | skipped | skipped | skipped |
| version add **+** a file outside `modules/` | CAUGHT | CAUGHT | CAUGHT |
| **metadata.json only + a file outside `modules/`** | **skipped** | **CAUGHT** | CAUGHT |

Happy to attach the harness if it is useful, or to turn it into a test in whatever form you prefer —
I left it out to keep the diff to one file.

### Context

I reported this through the Google OSS VRP as issue **543941141**. It was closed as
*"not severe enough for us to track it as a security bug"*, and the response said: *"Please feel free
to publicly disclose this issue on GitHub as a public issue."* This pull request is that disclosure,
with the fix attached rather than filed separately.

The behaviour is worth closing regardless of severity rating, because the skipped check is the one
that keeps a module pull request from carrying repository files, and the validation that follows it
executes `tools/` from the pull request's checkout.
