### PR TITLE
Fix exec'ing half downloaded script

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3607,8 +3607,8 @@ def runner_step(
 
 
 def fetch_ci_scripts_command():
-    command = "curl -q --noproxy '*' -sS {0}?{1} -o bazelci.py".format(SCRIPT_URL, int(time.time()))
-    command += " && curl -q --noproxy '*' -sS {0}?{1} -o collect_metrics.py".format(METRICS_SCRIPT_URL, int(time.time()))
+    command = "curl -q --noproxy '*' -sS {0}?{1} -o bazelci.py;".format(SCRIPT_URL, int(time.time()))
+    command += " curl -q --noproxy '*' -sS {0}?{1} -o collect_metrics.py".format(METRICS_SCRIPT_URL, int(time.time()))
     return command
 
 


### PR DESCRIPTION
If the first curl failed this kept going because of the `&&`:

```
$ which python3
python3 -V
curl -q --noproxy '*' -sS https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?1786467898 -o bazelci.py && curl -q --noproxy '*' -sS https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/collect_metrics.py?1786467898 -o collect_metrics.py
python3 bazelci.py runner --task=macos_8.x
/opt/homebrew/bin/python3
Python 3.12.11
curl: (56) Recv failure: Connection reset by peer
  File "/Users/buildkite/builds/bk-macos-arm64-fwlz/bazel/rules-apple-darwin/bazelci.py", line 3117
    env = ["ANDROID_HOME", "ANDROID_NDK_HOME", "BUILDKITE_ARTIFACT_UPLOAD_
                                               ^
SyntaxError: unterminated string literal (detected at line 3117)
```

https://buildkite.com/bazel/rules-apple-darwin/builds/11880/list?jid=019ff1c8-d3fb-47d5-b1a2-5df8635ef63a&tab=output
