### PR TITLE
Avoid pinning docker image hash in bazel-testing org

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -318,7 +318,7 @@ IMAGE_HASHES = {
 
 
 def get_docker_image(image_name):
-    if BUILDKITE_ORG == "bazel-testing":
+    if THIS_IS_TESTING:
         return f"gcr.io/{DOCKER_REGISTRY_PREFIX}/{image_name}"
     digest = IMAGE_HASHES.get(image_name)
     if not digest:

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -318,6 +318,8 @@ IMAGE_HASHES = {
 
 
 def get_docker_image(image_name):
+    if BUILDKITE_ORG == "bazel-testing":
+        return f"gcr.io/{DOCKER_REGISTRY_PREFIX}/{image_name}"
     digest = IMAGE_HASHES.get(image_name)
     if not digest:
         raise ValueError(f"No digest found for docker image: {image_name}")


### PR DESCRIPTION
In the `bazel-testing` Buildkite org, newly built test images are pushed to `gcr.io/bazel-public/testing/` without updating the pinned production hashes in `IMAGE_HASHES`.

This change ensures that jobs running in `bazel-testing` resolve Docker image tags dynamically from the testing registry prefix rather than requiring a pinned SHA256 digest.