### PR TITLE
Add retry and resilience flags to curl across CI scripts

### DIFF
--- a/buildkite/bazel-central-registry/bcr_compatibility.py
+++ b/buildkite/bazel-central-registry/bcr_compatibility.py
@@ -34,7 +34,7 @@ SCRIPT_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integratio
 
 
 def fetch_generate_report_py_command():
-    return "curl -s {0} -o generate_report.py".format(SCRIPT_URL)
+    return bazelci.curl_download_command(SCRIPT_URL, "generate_report.py")
 
 
 def select_modules_from_env_vars():

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -62,7 +62,7 @@ CI_RESOURCE_PERCENTAGE = int(os.environ.get('CI_RESOURCE_PERCENTAGE', -1))
 
 
 def fetch_bcr_presubmit_py_command():
-    return "curl -s {0} -o bcr_presubmit.py".format(SCRIPT_URL)
+    return bazelci.curl_download_command(SCRIPT_URL, "bcr_presubmit.py")
 
 
 class BcrPipelineException(Exception):

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -77,6 +77,27 @@ EMERGENCY_FILE_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-in
     GITHUB_BRANCH, int(time.time())
 )
 
+CURL_FLAGS = [
+    "-q",
+    "--noproxy",
+    "'*'",
+    "-fsSL",
+    "--retry",
+    "5",
+    "--retry-delay",
+    "2",
+    "--retry-max-time",
+    "60",
+    "--retry-connrefused",
+    "--connect-timeout",
+    "10",
+]
+CURL_FLAGS_STR = " ".join(CURL_FLAGS)
+
+
+def curl_download_command(url, output_file):
+    return f"curl {CURL_FLAGS_STR} {url} -o {output_file}"
+
 FLAKY_TESTS_BUCKET = {
     "bazel-testing": "gs://bazel-testing-buildkite-stats/flaky-tests-bep/",
     "bazel-trusted": "gs://bazel-buildkite-stats/flaky-tests-bep/",
@@ -1956,7 +1977,7 @@ def download_bazelci_agent(dest_dir):
     name = "bazelci-agent-{}-{}".format(version, postfix)
     url = "https://github.com/{}/releases/download/agent-{}/{}".format(repo, version, name)
     path = os.path.join(dest_dir, "bazelci-agent.exe" if is_windows() else "bazelci-agent")
-    execute_command(["curl", "-q", "--noproxy", "'*'", "-sSL", url, "-o", path])
+    execute_command(["curl", *CURL_FLAGS, url, "-o", path])
     st = os.stat(path)
     os.chmod(path, st.st_mode | stat.S_IEXEC)
     return path
@@ -2803,9 +2824,7 @@ def extract_archive(archive_path, dest_dir, strip_top_level_dir):
 def download_file(url, dest_dir, dest_filename):
     local_path = os.path.join(dest_dir, dest_filename)
     try:
-        execute_command(
-            ["curl", "-q", "-sSL", "--noproxy", "'*'", url, "-o", local_path], capture_stderr=True
-        )
+        execute_command(["curl", *CURL_FLAGS, url, "-o", local_path], capture_stderr=True)
     except subprocess.CalledProcessError as ex:
         raise BuildkiteInfraException("Failed to download {}: {}\n{}".format(url, ex, ex.stderr))
     return local_path
@@ -3617,16 +3636,16 @@ def runner_step(
 
 def fetch_ci_scripts_command():
     return [
-        "curl -q --noproxy '*' -sS {0}?{1} -o bazelci.py".format(SCRIPT_URL, int(time.time())),
-        "curl -q --noproxy '*' -sS {0}?{1} -o collect_metrics.py".format(
-            METRICS_SCRIPT_URL, int(time.time())
+        curl_download_command("{0}?{1}".format(SCRIPT_URL, int(time.time())), "bazelci.py"),
+        curl_download_command(
+            "{0}?{1}".format(METRICS_SCRIPT_URL, int(time.time())), "collect_metrics.py"
         ),
     ]
 
 
 def fetch_aggregate_incompatible_flags_test_result_command():
-    return "curl -q --noproxy '*' -sS {0} -o aggregate_incompatible_flags_test_result.py".format(
-        AGGREGATE_INCOMPATIBLE_TEST_RESULT_URL
+    return curl_download_command(
+        AGGREGATE_INCOMPATIBLE_TEST_RESULT_URL, "aggregate_incompatible_flags_test_result.py"
     )
 
 
@@ -3903,10 +3922,7 @@ def fetch_incompatible_flags():
         [
             # Query for open issues with "incompatible-change" and "migration-ready" label.
             "curl",
-            "-q",
-            "--noproxy",
-            "'*'",
-            "-sS",
+            *CURL_FLAGS,
             "https://api.github.com/search/issues?per_page=100&q=repo:bazelbuild/bazel+label:incompatible-change+label:migration-ready+state:open",
         ]
     ).decode("utf-8")

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -555,13 +555,20 @@ class InitialSteps(unittest.TestCase):
             steps = bazelci.create_initial_steps()
 
 class FetchCiScripts(unittest.TestCase):
+    def test_curl_download_command(self):
+        cmd = bazelci.curl_download_command("https://example.com/foo.py", "foo.py")
+        self.assertEqual(
+            cmd,
+            f"curl {bazelci.CURL_FLAGS_STR} https://example.com/foo.py -o foo.py",
+        )
+
     def test_fetch_ci_scripts_command_returns_list_of_curl_commands(self):
         cmds = bazelci.fetch_ci_scripts_command()
         self.assertIsInstance(cmds, list)
         self.assertEqual(len(cmds), 2)
-        self.assertTrue(cmds[0].startswith("curl -q --noproxy '*' -sS"))
+        self.assertTrue(cmds[0].startswith(f"curl {bazelci.CURL_FLAGS_STR}"))
         self.assertIn("bazelci.py", cmds[0])
-        self.assertTrue(cmds[1].startswith("curl -q --noproxy '*' -sS"))
+        self.assertTrue(cmds[1].startswith(f"curl {bazelci.CURL_FLAGS_STR}"))
         self.assertIn("collect_metrics.py", cmds[1])
         # Verify no shell delimiter like ';' or '&&' is appended
         self.assertFalse(cmds[0].endswith(";"))

--- a/buildkite/culprit_finder.py
+++ b/buildkite/culprit_finder.py
@@ -34,7 +34,7 @@ SCRIPT_URL = {
 
 
 def fetch_culprit_finder_py_command():
-    return "curl -s {0} -o culprit_finder.py".format(SCRIPT_URL)
+    return bazelci.curl_download_command(SCRIPT_URL, "culprit_finder.py")
 
 
 def get_bazel_commits_between(first_commit, second_commit):


### PR DESCRIPTION
### Summary of Changes

macOS runner jobs (and other high-concurrency jobs) were hitting `curl: (56) Recv failure: Connection reset by peer` when downloading `bazelci.py` and other CI scripts from `raw.githubusercontent.com` during presubmit bursts (see e.g. https://buildkite.com/bazel/google-bazel-presubmit/builds/107235#019ffa4b-8415-4f2b-82ee-44ea81ad81c4).

This adds `-fsSL --retry 5 --retry-delay 2 --retry-max-time 60 --retry-connrefused --connect-timeout 10` via a shared `CURL_FLAGS` constant and `curl_download_command()` helper in `bazelci.py` across all CI download sites.

These flags are supported across all CI runner platforms (including older platforms like Rocky Linux 8 and Ubuntu 20.04).