### PR TITLE
Release bazel_ci_rules 2.1.1

### DIFF
--- a/rules/MODULE.bazel
+++ b/rules/MODULE.bazel
@@ -1,4 +1,4 @@
-module(name = "bazel_ci_rules", version = "2.1.0")
+module(name = "bazel_ci_rules", version = "2.1.1")
 
 # Expose platforms and compiler rules to generated toolchain repositories
 bazel_dep(name = "platforms", version = "0.0.8")


### PR DESCRIPTION
# Release Notes: `bazel_ci_rules` v2.1.1 🚀
`bazel_ci_rules` v2.1.1 is a patch release improving container manifest resolution compatibility.

## 🌟 Key Highlights
* **Broader Docker & OCI Manifest Content-Type Support**: Added `application/vnd.oci.image.index.v1+json` to accepted manifest HTTP headers when resolving container digests. This resolves manifest retrieval failures for multi-arch image indexes and images hosted on GCP Artifact Registry / Container Registry (such as `gcr.io/bazel-public/ubuntu2404`).

---
## 🛠 Quick Start & Usage
### Bzlmod (Bazel 8+)
```bazel
bazel_dep(name = "bazel_ci_rules", version = "2.1.1")
rbe = use_extension("@bazel_ci_rules//:rbe_config.bzl", "rbe_config_extension")
rbe.config(name = "rbe_ubuntu", preset = "ubuntu")
use_repo(rbe, "rbe_ubuntu")
```
### Legacy WORKSPACE
```python
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
http_archive(
    name = "bazel_ci_rules",
    strip_prefix = "continuous-integration-rules-2.1.1",
    url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-2.1.1/bazel_ci_rules-2.1.1.tar.gz",
)
load("@bazel_ci_rules//:rbe_config.bzl", "rbe_config")
rbe_config(name = "rbe_ubuntu", preset = "ubuntu")
```