### PR TITLE
Fix GCE VM image creation pipelines (part 1)

### DIFF
--- a/buildkite/create_images.py
+++ b/buildkite/create_images.py
@@ -40,7 +40,7 @@ IMAGE_CREATION_VMS = {
     },
     "bk-testing-docker-arm64": {
         "project": "bazel-public",
-        "zone": "us-central1-c",
+        "zone": "us-central1-f",
         "source_image_project": "ubuntu-os-cloud",
         "source_image_family": "ubuntu-2204-lts-arm64",
         "setup_script": "setup-docker.sh",

--- a/buildkite/terraform/bazel-trusted/pipelines_misc.tf
+++ b/buildkite/terraform/bazel-trusted/pipelines_misc.tf
@@ -119,8 +119,9 @@ resource "buildkite_pipeline" "create-linux-vm-image" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {
-      BAZEL_TEST_VM_NAMES = "bk-testing-docker,bk-testing-docker-arm64"
-      BAZEL_VM_NAMES      = "bk-docker,bk-docker-arm64"
+      BAZEL_TEST_VM_NAMES        = "bk-testing-docker,bk-testing-docker-arm64"
+      BAZEL_VM_NAMES             = "bk-docker,bk-docker-arm64"
+      BAZEL_PROD_INSTANCE_GROUPS = "bk-docker,bk-docker-arm64,bk-trusted-docker,bk-trusted-docker-arm64"
     },
     steps = {
       commands = [
@@ -256,8 +257,9 @@ resource "buildkite_pipeline" "create-windows-vm-image" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {
-      BAZEL_TEST_VM_NAMES = "bk-testing-windows"
-      BAZEL_VM_NAMES      = "bk-windows"
+      BAZEL_TEST_VM_NAMES        = "bk-testing-windows"
+      BAZEL_VM_NAMES             = "bk-windows"
+      BAZEL_PROD_INSTANCE_GROUPS = "bk-windows,bk-trusted-windows"
     },
     steps = {
       commands = [


### PR DESCRIPTION
- Introduce new env variable to also re-create trusted instance groups in the final step. This is currently a no-op - we need to deploy this change via TF, then update https://github.com/bazelbuild/continuous-integration/blob/master/pipelines/publish-vm-image.yml.
- Change image VM location - https://github.com/bazelbuild/continuous-integration/commit/8b0cc1baa274f7e575cdf1e2c3103879ad26027b wasn't enough, we're still running into quota issues in us-central1-c