### PR TITLE
Add smoke test workspace and pipeline for testing Bazel CI changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 
 # Bazel output files.
 /bazel-*
+/smoke_test/bazel-*
 MODULE.bazel.lock
 
 # Intermediate files created by the gitbundle tool.

--- a/buildkite/terraform/bazel-testing/pipelines_misc.tf
+++ b/buildkite/terraform/bazel-testing/pipelines_misc.tf
@@ -64,8 +64,8 @@ resource "buildkite_pipeline" "fwe-test" {
   }
 }
 
-resource "buildkite_pipeline" "smoke-test" {
-  name        = "Smoke Test"
+resource "buildkite_pipeline" "ci-smoke-test" {
+  name        = "CI Smoke Test"
   repository  = "https://github.com/bazelbuild/continuous-integration.git"
   description = "Cross-platform smoke tests on smoke_test/ workspace for validating Bazel CI script changes"
   steps = templatefile("pipeline.yml.tpl", {

--- a/buildkite/terraform/bazel-testing/pipelines_misc.tf
+++ b/buildkite/terraform/bazel-testing/pipelines_misc.tf
@@ -22,15 +22,15 @@ resource "buildkite_pipeline" "fwe-test" {
   repository = "https://github.com/fweikert/bazel"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {
-      LC_ALL = "en_US.UTF-8"
+      LC_ALL                    = "en_US.UTF-8"
       ENABLE_METRICS_COLLECTION = "true"
     }
     steps = {
       commands = [
-         "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py",
-         "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/collect_metrics.py?$(date +%s)\" -o collect_metrics.py",
-         "/bin/bash -c 'set -euo pipefail; python3 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/fweikert/bazel/refs/heads/qa/.bazelci/postsubmit.yml | tee /dev/tty | buildkite-agent pipeline upload'"
-       ]
+        "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py",
+        "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/testing/buildkite/collect_metrics.py?$(date +%s)\" -o collect_metrics.py",
+        "/bin/bash -c 'set -euo pipefail; python3 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/fweikert/bazel/refs/heads/qa/.bazelci/postsubmit.yml | tee /dev/tty | buildkite-agent pipeline upload'"
+      ]
     }
   })
   default_branch             = "master"
@@ -63,3 +63,48 @@ resource "buildkite_pipeline" "fwe-test" {
     use_merge_group_base_commit_for_git_diff_base = false
   }
 }
+
+resource "buildkite_pipeline" "smoke-test" {
+  name        = "Smoke Test"
+  repository  = "https://github.com/bazelbuild/continuous-integration.git"
+  description = "Cross-platform smoke tests on smoke_test/ workspace for validating Bazel CI script changes"
+  steps = templatefile("pipeline.yml.tpl", {
+    envs = {}
+    steps = {
+      commands = [
+        "/bin/bash -c 'set -euo pipefail; python3 buildkite/bazelci.py project_pipeline --file_config=smoke_test/smoke_test.yml | tee /dev/tty | buildkite-agent pipeline upload'"
+      ]
+    }
+  })
+  default_branch             = "master"
+  allow_rebuilds             = true
+  cancel_intermediate_builds = false
+  skip_intermediate_builds   = false
+  tags                       = []
+  provider_settings = {
+    trigger_mode                                  = "code"
+    build_branches                                = false
+    build_pull_requests                           = true
+    build_tags                                    = false
+    build_pull_request_forks                      = true
+    build_pull_request_ready_for_review           = false
+    build_pull_request_labels_changed             = true
+    build_pull_request_base_branch_changed        = false
+    prefix_pull_request_fork_branch_names         = true
+    filter_enabled                                = true
+    filter_condition                              = "build.pull_request.labels includes \"CI:run\" || build.branch !~ /.+:.+/"
+    pull_request_branch_filter_enabled            = false
+    publish_commit_status                         = true
+    publish_commit_status_per_step                = false
+    separate_pull_request_statuses                = false
+    publish_blocked_as_pending                    = true
+    cancel_deleted_branch_builds                  = false
+    skip_builds_for_existing_commits              = false
+    skip_pull_request_builds_for_existing_commits = false
+    ignore_default_branch_pull_requests           = false
+    build_merge_group_checks_requested            = false
+    cancel_when_merge_group_destroyed             = false
+    use_merge_group_base_commit_for_git_diff_base = false
+  }
+}
+

--- a/smoke_test/BUILD.bazel
+++ b/smoke_test/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
+
+cc_binary(
+    name = "hello",
+    srcs = ["hello.cc"],
+)
+
+cc_test(
+    name = "hello_test",
+    srcs = ["hello_test.cc"],
+)

--- a/smoke_test/MODULE.bazel
+++ b/smoke_test/MODULE.bazel
@@ -4,3 +4,15 @@ module(
 )
 
 bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "bazel_ci_rules", version = "2.1.1")
+local_path_override(
+    module_name = "bazel_ci_rules",
+    path = "../rules",
+)
+
+rbe = use_extension("@bazel_ci_rules//:rbe_config.bzl", "rbe_config_extension")
+rbe.config(
+    name = "buildkite_config",
+    preset = "ubuntu",
+)
+use_repo(rbe, "buildkite_config")

--- a/smoke_test/MODULE.bazel
+++ b/smoke_test/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "smoke_test",
+    version = "1.0.0",
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/smoke_test/hello.cc
+++ b/smoke_test/hello.cc
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello from Bazel CI Smoke Test!" << std::endl;
+    return 0;
+}

--- a/smoke_test/hello_test.cc
+++ b/smoke_test/hello_test.cc
@@ -1,0 +1,7 @@
+#include <cassert>
+#include <iostream>
+
+int main() {
+    std::cout << "Smoke test running successfully on target platform." << std::endl;
+    return 0;
+}

--- a/smoke_test/smoke_test.yml
+++ b/smoke_test/smoke_test.yml
@@ -32,6 +32,10 @@ matrix:
     # Windows (x86_64 & arm64)
     - windows
     - windows_arm64
+    # RBE platforms
+    - rbe_ubuntu2004
+    - rbe_ubuntu2204
+    - rbe_ubuntu2404
 
 tasks:
   smoke_test:

--- a/smoke_test/smoke_test.yml
+++ b/smoke_test/smoke_test.yml
@@ -1,0 +1,44 @@
+---
+matrix:
+  platform:
+    # Linux (x86_64) Docker platforms
+    - debian10
+    - debian11
+    - debian12
+    - debian13
+    - fedora39
+    - fedora40
+    - fedora43
+    - rockylinux8
+    - rockylinux8_java11
+    - rockylinux8_java11_devtoolset10
+    - ubuntu1604
+    - ubuntu1804
+    - ubuntu2004
+    - ubuntu2004_java11
+    - ubuntu2204
+    - ubuntu2204_java17
+    - ubuntu2404
+    # Linux (arm64) Docker platforms
+    - debian12_arm64
+    - debian13_arm64
+    - rockylinux8_arm64
+    - ubuntu2004_arm64
+    - ubuntu2204_arm64
+    - ubuntu2404_arm64
+    # macOS (Intel & Apple Silicon)
+    - macos
+    - macos_arm64
+    # Windows (x86_64 & arm64)
+    - windows
+    - windows_arm64
+
+tasks:
+  smoke_test:
+    name: "Smoke Test on {platform}"
+    platform: ${{ platform }}
+    working_directory: smoke_test
+    build_targets:
+      - "//:hello"
+    test_targets:
+      - "//:hello_test"


### PR DESCRIPTION
This PR adds a minimal, self-contained smoke test workspace and a corresponding Buildkite pipeline in the `bazel-testing` org to enable testing Bazel CI script changes across all supported platforms without colliding on a shared branch.

### Changes
1. **Smoke Test Workspace** (`smoke_test/`):
   - `smoke_test/MODULE.bazel`: Bzlmod configuration with `rules_cc` dependency.
   - `smoke_test/BUILD.bazel`: Defines a minimal `:hello` binary and `:hello_test` test target.
   - `smoke_test/hello.cc` & `smoke_test/hello_test.cc`: C++ binary and test sources.
   - `smoke_test/smoke_test.yml`: Task matrix covering all 27 supported platforms.
2. **Terraform Pipeline** (`buildkite/terraform/bazel-testing/pipelines_misc.tf`):
   - Added `buildkite_pipeline.smoke-test` which runs `project_pipeline --file_config=smoke_test/smoke_test.yml`.
   - Configured with `filter_condition = "build.pull_request.labels includes \"CI:run\" || build.branch !~ /.+:.+/"`.
3. **`.gitignore`**:
   - Added `/smoke_test/bazel-*` to ignore Bazel symlinks in `smoke_test/`.