### PR TITLE
Support dynamic CI script ref resolution in bazel-testing org

### DIFF
--- a/buildkite/bazel-central-registry/bcr_compatibility.py
+++ b/buildkite/bazel-central-registry/bcr_compatibility.py
@@ -29,7 +29,7 @@ import bazelci
 import bcr_presubmit
 
 SCRIPT_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/bazel-central-registry/generate_report.py?{}".format(
-    bazelci.GITHUB_BRANCH, int(time.time())
+    bazelci.GITHUB_REF, int(time.time())
 )
 
 

--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -37,7 +37,7 @@ BCR_REPO_DIR = pathlib.Path(os.getcwd())
 BUILDKITE_ORG = os.environ.get("BUILDKITE_ORGANIZATION_SLUG", "bazel")
 
 SCRIPT_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/bazel-central-registry/bcr_presubmit.py?{}".format(
-    bazelci.GITHUB_BRANCH, int(time.time())
+    bazelci.GITHUB_REF, int(time.time())
 )
 
 CI_MACHINE_NUM = {

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -57,24 +57,45 @@ THIS_IS_SPARTA = True
 CLOUD_PROJECTS_PER_ORG = {"bazel": "bazel-untrusted", "bazel-trusted": "bazel-public", "bazel-testing": "bazel-untrusted"}
 CLOUD_PROJECT = CLOUD_PROJECTS_PER_ORG[BUILDKITE_ORG]
 
-GITHUB_BRANCH = {"bazel": "master", "bazel-trusted": "master", "bazel-testing": "testing"}[
-    BUILDKITE_ORG
-]
+def get_ci_script_ref():
+    if not THIS_IS_TESTING:
+        return "master"
+
+    # Allow explicit override via environment variable
+    if "BAZELCI_COMMIT" in os.environ:
+        return os.environ["BAZELCI_COMMIT"]
+    if "BAZELCI_BRANCH" in os.environ:
+        return os.environ["BAZELCI_BRANCH"]
+
+    # If the pipeline itself is for the official bazelbuild/continuous-integration repo, use the build's commit or branch
+    repo = os.environ.get("BUILDKITE_REPO", "")
+    if "bazelbuild/continuous-integration" in repo:
+        commit = os.environ.get("BUILDKITE_COMMIT")
+        if commit and commit != "HEAD":
+            return commit
+        branch = os.environ.get("BUILDKITE_BRANCH")
+        if branch:
+            return branch
+
+    return "testing"
+
+
+GITHUB_REF = get_ci_script_ref()
 
 SCRIPT_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/bazelci.py".format(
-    GITHUB_BRANCH
+    GITHUB_REF
 )
 
 METRICS_SCRIPT_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/collect_metrics.py".format(
-    GITHUB_BRANCH
+    GITHUB_REF
 )
 
 AGGREGATE_INCOMPATIBLE_TEST_RESULT_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/aggregate_incompatible_flags_test_result.py?{}".format(
-    GITHUB_BRANCH, int(time.time())
+    GITHUB_REF, int(time.time())
 )
 
 EMERGENCY_FILE_URL = "https://raw.githubusercontent.com/bazelbuild/continuous-integration/{}/buildkite/emergency.yml?{}".format(
-    GITHUB_BRANCH, int(time.time())
+    GITHUB_REF, int(time.time())
 )
 
 CURL_FLAGS = [

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -61,12 +61,6 @@ def get_ci_script_ref():
     if not THIS_IS_TESTING:
         return "master"
 
-    # Allow explicit override via environment variable
-    if "BAZELCI_COMMIT" in os.environ:
-        return os.environ["BAZELCI_COMMIT"]
-    if "BAZELCI_BRANCH" in os.environ:
-        return os.environ["BAZELCI_BRANCH"]
-
     # If the pipeline itself is for the official bazelbuild/continuous-integration repo, use the build's commit or branch
     if os.environ.get("BUILDKITE_REPO") in (
         "https://github.com/bazelbuild/continuous-integration",

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -68,7 +68,11 @@ def get_ci_script_ref():
         return os.environ["BAZELCI_BRANCH"]
 
     # If the pipeline itself is for the official bazelbuild/continuous-integration repo, use the build's commit or branch
-    if "bazelbuild/continuous-integration" in os.environ.get("BUILDKITE_REPO", ""):
+    if os.environ.get("BUILDKITE_REPO") in (
+        "https://github.com/bazelbuild/continuous-integration",
+        "https://github.com/bazelbuild/continuous-integration.git",
+        "git@github.com:bazelbuild/continuous-integration.git",
+    ):
         commit = os.environ.get("BUILDKITE_COMMIT")
         if commit and commit != "HEAD":
             return commit

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -68,8 +68,7 @@ def get_ci_script_ref():
         return os.environ["BAZELCI_BRANCH"]
 
     # If the pipeline itself is for the official bazelbuild/continuous-integration repo, use the build's commit or branch
-    repo = os.environ.get("BUILDKITE_REPO", "")
-    if "bazelbuild/continuous-integration" in repo:
+    if "bazelbuild/continuous-integration" in os.environ.get("BUILDKITE_REPO", ""):
         commit = os.environ.get("BUILDKITE_COMMIT")
         if commit and commit != "HEAD":
             return commit

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -601,5 +601,72 @@ class FetchCiScripts(unittest.TestCase):
         self.assertIn("--task=basic", commands[2])
 
 
+class GetCiScriptRefTest(unittest.TestCase):
+
+    def test_production_returns_master(self):
+        with mock.patch.object(bazelci, "THIS_IS_TESTING", False):
+            self.assertEqual(bazelci.get_ci_script_ref(), "master")
+
+    def test_bazelci_commit_override(self):
+        with mock.patch.object(bazelci, "THIS_IS_TESTING", True):
+            with mock.patch.dict(os.environ, {"BAZELCI_COMMIT": "custom_commit_sha"}):
+                self.assertEqual(bazelci.get_ci_script_ref(), "custom_commit_sha")
+
+    def test_bazelci_branch_override(self):
+        with mock.patch.object(bazelci, "THIS_IS_TESTING", True):
+            with mock.patch.dict(os.environ, {"BAZELCI_BRANCH": "custom_branch"}, clear=True):
+                self.assertEqual(bazelci.get_ci_script_ref(), "custom_branch")
+
+    def test_ci_repo_with_commit(self):
+        with mock.patch.object(bazelci, "THIS_IS_TESTING", True):
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "BUILDKITE_REPO": "https://github.com/bazelbuild/continuous-integration.git",
+                    "BUILDKITE_COMMIT": "deadbeef1234",
+                },
+                clear=True,
+            ):
+                self.assertEqual(bazelci.get_ci_script_ref(), "deadbeef1234")
+
+    def test_ci_repo_with_head_commit_uses_branch(self):
+        with mock.patch.object(bazelci, "THIS_IS_TESTING", True):
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "BUILDKITE_REPO": "https://github.com/bazelbuild/continuous-integration.git",
+                    "BUILDKITE_COMMIT": "HEAD",
+                    "BUILDKITE_BRANCH": "pr-branch-name",
+                },
+                clear=True,
+            ):
+                self.assertEqual(bazelci.get_ci_script_ref(), "pr-branch-name")
+
+    def test_other_repo_defaults_to_testing(self):
+        with mock.patch.object(bazelci, "THIS_IS_TESTING", True):
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "BUILDKITE_REPO": "https://github.com/bazelbuild/bazel.git",
+                    "BUILDKITE_COMMIT": "some_bazel_commit",
+                },
+                clear=True,
+            ):
+                self.assertEqual(bazelci.get_ci_script_ref(), "testing")
+
+    def test_fork_repo_defaults_to_testing(self):
+        with mock.patch.object(bazelci, "THIS_IS_TESTING", True):
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "BUILDKITE_REPO": "https://github.com/forkuser/continuous-integration.git",
+                    "BUILDKITE_COMMIT": "fork_commit",
+                },
+                clear=True,
+            ):
+                self.assertEqual(bazelci.get_ci_script_ref(), "testing")
+
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -89,29 +89,27 @@ tasks:
         flags, json_profile_out, capture_corrupted_outputs_dir = bazelci.calculate_flags(
             tasks.get("json_profile"), "build_flags", "build", "/tmp", ["HOME"]
         )
-        expected_profile = os.path.join("/tmp", "build.profile.gz")
         self.assertEqual(
             flags,
-            ["--enable_x", "--enable_y", "--profile={}".format(expected_profile), "--test_env=HOME"],
+            ["--enable_x", "--enable_y", "--profile=/tmp/build.profile.gz", "--test_env=HOME"],
         )
-        self.assertEqual(json_profile_out, expected_profile)
+        self.assertEqual(json_profile_out, "/tmp/build.profile.gz")
 
     def test_capture_corrupted(self):
         tasks = self._CONFIGS.get("tasks")
         flags, json_profile_out, capture_corrupted_outputs_dir = bazelci.calculate_flags(
             tasks.get("capture_corrupted"), "build_flags", "build", "/tmp", ["HOME"]
         )
-        expected_corrupted_dir = os.path.join("/tmp", "build_corrupted_outputs")
         self.assertEqual(
             flags,
             [
                 "--enable_x",
                 "--enable_y",
-                "--experimental_remote_capture_corrupted_outputs={}".format(expected_corrupted_dir),
+                "--experimental_remote_capture_corrupted_outputs=/tmp/build_corrupted_outputs",
                 "--test_env=HOME",
             ],
         )
-        self.assertEqual(capture_corrupted_outputs_dir, expected_corrupted_dir)
+        self.assertEqual(capture_corrupted_outputs_dir, "/tmp/build_corrupted_outputs")
 
     def test_no_flags_in_config(self):
         tasks = self._CONFIGS.get("tasks")

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -607,16 +607,6 @@ class GetCiScriptRefTest(unittest.TestCase):
         with mock.patch.object(bazelci, "THIS_IS_TESTING", False):
             self.assertEqual(bazelci.get_ci_script_ref(), "master")
 
-    def test_bazelci_commit_override(self):
-        with mock.patch.object(bazelci, "THIS_IS_TESTING", True):
-            with mock.patch.dict(os.environ, {"BAZELCI_COMMIT": "custom_commit_sha"}):
-                self.assertEqual(bazelci.get_ci_script_ref(), "custom_commit_sha")
-
-    def test_bazelci_branch_override(self):
-        with mock.patch.object(bazelci, "THIS_IS_TESTING", True):
-            with mock.patch.dict(os.environ, {"BAZELCI_BRANCH": "custom_branch"}, clear=True):
-                self.assertEqual(bazelci.get_ci_script_ref(), "custom_branch")
-
     def test_ci_repo_with_commit(self):
         with mock.patch.object(bazelci, "THIS_IS_TESTING", True):
             with mock.patch.dict(

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -89,27 +89,29 @@ tasks:
         flags, json_profile_out, capture_corrupted_outputs_dir = bazelci.calculate_flags(
             tasks.get("json_profile"), "build_flags", "build", "/tmp", ["HOME"]
         )
+        expected_profile = os.path.join("/tmp", "build.profile.gz")
         self.assertEqual(
             flags,
-            ["--enable_x", "--enable_y", "--profile=/tmp/build.profile.gz", "--test_env=HOME"],
+            ["--enable_x", "--enable_y", "--profile={}".format(expected_profile), "--test_env=HOME"],
         )
-        self.assertEqual(json_profile_out, "/tmp/build.profile.gz")
+        self.assertEqual(json_profile_out, expected_profile)
 
     def test_capture_corrupted(self):
         tasks = self._CONFIGS.get("tasks")
         flags, json_profile_out, capture_corrupted_outputs_dir = bazelci.calculate_flags(
             tasks.get("capture_corrupted"), "build_flags", "build", "/tmp", ["HOME"]
         )
+        expected_corrupted_dir = os.path.join("/tmp", "build_corrupted_outputs")
         self.assertEqual(
             flags,
             [
                 "--enable_x",
                 "--enable_y",
-                "--experimental_remote_capture_corrupted_outputs=/tmp/build_corrupted_outputs",
+                "--experimental_remote_capture_corrupted_outputs={}".format(expected_corrupted_dir),
                 "--test_env=HOME",
             ],
         )
-        self.assertEqual(capture_corrupted_outputs_dir, "/tmp/build_corrupted_outputs")
+        self.assertEqual(capture_corrupted_outputs_dir, expected_corrupted_dir)
 
     def test_no_flags_in_config(self):
         tasks = self._CONFIGS.get("tasks")

--- a/pipelines/continuous-integration.yml
+++ b/pipelines/continuous-integration.yml
@@ -1,7 +1,7 @@
 steps:
-  - label: "Project pipeline :ubuntu: 18.04 (JDK 8)"
+  - label: "Unit tests :ubuntu: 18.04"
     command:
-      - python3 buildkite/bazelci.py project_pipeline --file_config=pipelines/tensorflow.yml
+      - python3 buildkite/bazelci_test.py
     agents: &linux_agents { queue: default }
     plugins: &plugins
       - docker#v3.8.0:
@@ -24,6 +24,11 @@ steps:
             - "/var/lib/buildkite-agent:/var/lib/buildkite-agent"
             - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
             - "/var/run/docker.sock:/var/run/docker.sock"
+  - label: "Project pipeline :ubuntu: 18.04 (JDK 8)"
+    command:
+      - python3 buildkite/bazelci.py project_pipeline --file_config=pipelines/tensorflow.yml
+    agents: *linux_agents
+    plugins: *plugins
   - label: "Downstream pipeline :ubuntu: 18.04 (JDK 8)"
     command:
       - python3 buildkite/bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml
@@ -36,10 +41,14 @@ steps:
     agents: *linux_agents
     plugins: *plugins
 
+  - label: "Unit tests :darwin:"
+    command:
+      - python3 buildkite/bazelci_test.py
+    agents: &mac_agents { queue: macos }
   - label: "Project pipeline :darwin: (JDK 8)"
     command:
       - python3 buildkite/bazelci.py project_pipeline --file_config=pipelines/tensorflow.yml
-    agents: &mac_agents { queue: macos }
+    agents: *mac_agents
   - label: "Downstream pipeline :darwin: (JDK 8)"
     command:
       - python3 buildkite/bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml
@@ -50,10 +59,14 @@ steps:
       - python3 buildkite/bazelci.py bazel_publish_binaries_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/build_bazel_binaries.yml
     agents: *mac_agents
 
+  - label: "Unit tests :windows:"
+    command:
+      - python.exe buildkite/bazelci_test.py
+    agents: &win_agents { queue: windows }
   - label: "Project pipeline :windows: (JDK 8)"
     command:
       - python.exe buildkite/bazelci.py project_pipeline --file_config=pipelines/tensorflow.yml
-    agents: &win_agents { queue: windows }
+    agents: *win_agents
   - label: "Downstream pipeline :windows: (JDK 8)"
     command:
       - python.exe buildkite/bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml

--- a/pipelines/continuous-integration.yml
+++ b/pipelines/continuous-integration.yml
@@ -1,7 +1,7 @@
 steps:
-  - label: "Unit tests :ubuntu: 18.04"
+  - label: "Project pipeline :ubuntu: 18.04 (JDK 8)"
     command:
-      - python3 buildkite/bazelci_test.py
+      - python3 buildkite/bazelci.py project_pipeline --file_config=pipelines/tensorflow.yml
     agents: &linux_agents { queue: default }
     plugins: &plugins
       - docker#v3.8.0:
@@ -24,11 +24,6 @@ steps:
             - "/var/lib/buildkite-agent:/var/lib/buildkite-agent"
             - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
             - "/var/run/docker.sock:/var/run/docker.sock"
-  - label: "Project pipeline :ubuntu: 18.04 (JDK 8)"
-    command:
-      - python3 buildkite/bazelci.py project_pipeline --file_config=pipelines/tensorflow.yml
-    agents: *linux_agents
-    plugins: *plugins
   - label: "Downstream pipeline :ubuntu: 18.04 (JDK 8)"
     command:
       - python3 buildkite/bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml
@@ -41,14 +36,10 @@ steps:
     agents: *linux_agents
     plugins: *plugins
 
-  - label: "Unit tests :darwin:"
-    command:
-      - python3 buildkite/bazelci_test.py
-    agents: &mac_agents { queue: macos }
   - label: "Project pipeline :darwin: (JDK 8)"
     command:
       - python3 buildkite/bazelci.py project_pipeline --file_config=pipelines/tensorflow.yml
-    agents: *mac_agents
+    agents: &mac_agents { queue: macos }
   - label: "Downstream pipeline :darwin: (JDK 8)"
     command:
       - python3 buildkite/bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml
@@ -59,14 +50,10 @@ steps:
       - python3 buildkite/bazelci.py bazel_publish_binaries_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/build_bazel_binaries.yml
     agents: *mac_agents
 
-  - label: "Unit tests :windows:"
-    command:
-      - python.exe buildkite/bazelci_test.py
-    agents: &win_agents { queue: windows }
   - label: "Project pipeline :windows: (JDK 8)"
     command:
       - python.exe buildkite/bazelci.py project_pipeline --file_config=pipelines/tensorflow.yml
-    agents: *win_agents
+    agents: &win_agents { queue: windows }
   - label: "Downstream pipeline :windows: (JDK 8)"
     command:
       - python.exe buildkite/bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml


### PR DESCRIPTION
This PR enables `bazelci.py` to dynamically resolve the Git ref (commit SHA or branch) for CI scripts when running in the `bazel-testing` Buildkite organization for a pipeline configured with the CI repo.

### Motivation
When testing changes to CI scripts in `bazel-testing`, jobs previously downloaded scripts from the hardcoded `testing` branch. This required coordinating pushes to `testing` and caused collisions when multiple contributors tested changes simultaneously.

### Changes
1. **`get_ci_script_ref()` and `GITHUB_REF` in `buildkite/bazelci.py`**:
   - In production orgs (`bazel`, `bazel-trusted`), always returns `"master"`.
   - In `bazel-testing`:
     - If `$BUILDKITE_REPO` matches the official `bazelbuild/continuous-integration` repo URLs, dynamically resolves to the build's exact commit SHA (`$BUILDKITE_COMMIT`) or branch (`$BUILDKITE_BRANCH`).
     - For builds on all other repositories (e.g. `bazelbuild/bazel`), defaults to `"testing"`.
2. **Updated Script Download URLs**:
   - Updated `SCRIPT_URL`, `METRICS_SCRIPT_URL`, `AGGREGATE_INCOMPATIBLE_TEST_RESULT_URL`, and `EMERGENCY_FILE_URL` in `bazelci.py` to format using `GITHUB_REF`.
   - Updated `bcr_presubmit.py` and `bcr_compatibility.py` to use `bazelci.GITHUB_REF`.
3. **Unit Tests in `buildkite/bazelci_test.py`**:
   - Added `GetCiScriptRefTest` test suite covering production behavior, official CI repo commit/branch resolution, and safe fallback for external and fork repositories.