### PR TITLE
Run bazelci_test.py unit tests in continuous-integration pipeline

### DIFF
--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -89,27 +89,29 @@ tasks:
         flags, json_profile_out, capture_corrupted_outputs_dir = bazelci.calculate_flags(
             tasks.get("json_profile"), "build_flags", "build", "/tmp", ["HOME"]
         )
+        expected_profile = os.path.join("/tmp", "build.profile.gz")
         self.assertEqual(
             flags,
-            ["--enable_x", "--enable_y", "--profile=/tmp/build.profile.gz", "--test_env=HOME"],
+            ["--enable_x", "--enable_y", "--profile={}".format(expected_profile), "--test_env=HOME"],
         )
-        self.assertEqual(json_profile_out, "/tmp/build.profile.gz")
+        self.assertEqual(json_profile_out, expected_profile)
 
     def test_capture_corrupted(self):
         tasks = self._CONFIGS.get("tasks")
         flags, json_profile_out, capture_corrupted_outputs_dir = bazelci.calculate_flags(
             tasks.get("capture_corrupted"), "build_flags", "build", "/tmp", ["HOME"]
         )
+        expected_corrupted_dir = os.path.join("/tmp", "build_corrupted_outputs")
         self.assertEqual(
             flags,
             [
                 "--enable_x",
                 "--enable_y",
-                "--experimental_remote_capture_corrupted_outputs=/tmp/build_corrupted_outputs",
+                "--experimental_remote_capture_corrupted_outputs={}".format(expected_corrupted_dir),
                 "--test_env=HOME",
             ],
         )
-        self.assertEqual(capture_corrupted_outputs_dir, "/tmp/build_corrupted_outputs")
+        self.assertEqual(capture_corrupted_outputs_dir, expected_corrupted_dir)
 
     def test_no_flags_in_config(self):
         tasks = self._CONFIGS.get("tasks")

--- a/pipelines/continuous-integration.yml
+++ b/pipelines/continuous-integration.yml
@@ -1,7 +1,7 @@
 steps:
-  - label: "Project pipeline :ubuntu: 18.04 (JDK 8)"
+  - label: "Unit tests :ubuntu: 18.04"
     command:
-      - python3 buildkite/bazelci.py project_pipeline --file_config=pipelines/tensorflow.yml
+      - python3 buildkite/bazelci_test.py
     agents: &linux_agents { queue: default }
     plugins: &plugins
       - docker#v3.8.0:
@@ -24,6 +24,11 @@ steps:
             - "/var/lib/buildkite-agent:/var/lib/buildkite-agent"
             - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
             - "/var/run/docker.sock:/var/run/docker.sock"
+  - label: "Project pipeline :ubuntu: 18.04 (JDK 8)"
+    command:
+      - python3 buildkite/bazelci.py project_pipeline --file_config=pipelines/tensorflow.yml
+    agents: *linux_agents
+    plugins: *plugins
   - label: "Downstream pipeline :ubuntu: 18.04 (JDK 8)"
     command:
       - python3 buildkite/bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml
@@ -36,10 +41,14 @@ steps:
     agents: *linux_agents
     plugins: *plugins
 
+  - label: "Unit tests :darwin:"
+    command:
+      - python3 buildkite/bazelci_test.py
+    agents: &mac_agents { queue: macos }
   - label: "Project pipeline :darwin: (JDK 8)"
     command:
       - python3 buildkite/bazelci.py project_pipeline --file_config=pipelines/tensorflow.yml
-    agents: &mac_agents { queue: macos }
+    agents: *mac_agents
   - label: "Downstream pipeline :darwin: (JDK 8)"
     command:
       - python3 buildkite/bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml
@@ -50,10 +59,14 @@ steps:
       - python3 buildkite/bazelci.py bazel_publish_binaries_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/build_bazel_binaries.yml
     agents: *mac_agents
 
+  - label: "Unit tests :windows:"
+    command:
+      - python.exe buildkite/bazelci_test.py
+    agents: &win_agents { queue: windows }
   - label: "Project pipeline :windows: (JDK 8)"
     command:
       - python.exe buildkite/bazelci.py project_pipeline --file_config=pipelines/tensorflow.yml
-    agents: &win_agents { queue: windows }
+    agents: *win_agents
   - label: "Downstream pipeline :windows: (JDK 8)"
     command:
       - python.exe buildkite/bazelci.py bazel_downstream_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/bazel/master/.bazelci/presubmit.yml


### PR DESCRIPTION
This PR adds steps to run `bazelci_test.py` unit tests on Ubuntu, Darwin, and Windows agents in `pipelines/continuous-integration.yml`.