### PR TITLE
Remove legacy and broken platforms

### DIFF
--- a/smoke_test/smoke_test.yml
+++ b/smoke_test/smoke_test.yml
@@ -28,7 +28,7 @@ matrix:
 
 tasks:
   smoke_test:
-    name: "Smoke Test on {platform}"
+    name: "Smoke Test"
     platform: ${{ platform }}
     working_directory: smoke_test
     build_targets:

--- a/smoke_test/smoke_test.yml
+++ b/smoke_test/smoke_test.yml
@@ -5,8 +5,6 @@ matrix:
     - debian11
     - debian12
     - debian13
-    - fedora39
-    - fedora40
     - fedora43
     - rockylinux8
     - ubuntu2004

--- a/smoke_test/smoke_test.yml
+++ b/smoke_test/smoke_test.yml
@@ -2,7 +2,6 @@
 matrix:
   platform:
     # Linux (x86_64) Docker platforms
-    - debian10
     - debian11
     - debian12
     - debian13
@@ -10,14 +9,8 @@ matrix:
     - fedora40
     - fedora43
     - rockylinux8
-    - rockylinux8_java11
-    - rockylinux8_java11_devtoolset10
-    - ubuntu1604
-    - ubuntu1804
     - ubuntu2004
-    - ubuntu2004_java11
     - ubuntu2204
-    - ubuntu2204_java17
     - ubuntu2404
     # Linux (arm64) Docker platforms
     - debian12_arm64
@@ -33,8 +26,6 @@ matrix:
     - windows
     - windows_arm64
     # RBE platforms
-    - rbe_ubuntu2004
-    - rbe_ubuntu2204
     - rbe_ubuntu2404
 
 tasks:


### PR DESCRIPTION
Based results from https://buildkite.com/bazel-testing/ci-smoke-test/builds/2#_ and removed platforms that have reached EOL