### PR TITLE
Switch arm64 instance groups to c4a-standard-8

### DIFF
--- a/buildkite/instances.yml
+++ b/buildkite/instances.yml
@@ -49,7 +49,7 @@ instance_groups:
     service_account: buildkite@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-docker-arm64
     metadata_from_file: startup-script=startup-docker-pdssd.sh
-    machine_type: c4a-standard-8-lssd
+    machine_type: c4a-standard-8
     zone: us-central1-c
     boot_disk_type: hyperdisk-balanced
   - name: bk-testing-docker-arm64
@@ -58,7 +58,7 @@ instance_groups:
     service_account: buildkite-testing@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-testing-docker-arm64
     metadata_from_file: startup-script=startup-docker-pdssd.sh
-    machine_type: c4a-standard-8-lssd
+    machine_type: c4a-standard-8
     zone: us-central1-c
     boot_disk_type: hyperdisk-balanced
   - name: bk-trusted-docker-arm64
@@ -67,7 +67,7 @@ instance_groups:
     service_account: buildkite-trusted@bazel-public.iam.gserviceaccount.com
     image_family: bk-docker-arm64
     metadata_from_file: startup-script=startup-docker-pdssd.sh
-    machine_type: c4a-standard-8-lssd
+    machine_type: c4a-standard-8
     zone: us-central1-c
     boot_disk_type: hyperdisk-balanced
   - name: bk-windows

--- a/buildkite/instances.yml
+++ b/buildkite/instances.yml
@@ -53,7 +53,7 @@ instance_groups:
     zone: us-central1-c
     boot_disk_type: hyperdisk-balanced
   - name: bk-testing-docker-arm64
-    count: 5
+    count: 10
     project: bazel-untrusted
     service_account: buildkite-testing@bazel-untrusted.iam.gserviceaccount.com
     image_family: bk-testing-docker-arm64


### PR DESCRIPTION
Switch ARM64 instance groups from `c4a-standard-8-lssd` to standard `c4a-standard-8`.

The instances already use `hyperdisk-balanced` with `startup-docker-pdssd.sh` and do not mount or format the attached Local SSD. Using the `-lssd` variant causes zone capacity exhaustion (`ZONE_RESOURCE_POOL_EXHAUSTED`) in `us-central1-c` and local SSD quota exhaustion.

Also increased the testing machines to 10