### PR TITLE
Allow CI:run as an auto-run label

### DIFF
--- a/buildkite/bazel-central-registry/bcr_presubmit.py
+++ b/buildkite/bazel-central-registry/bcr_presubmit.py
@@ -391,7 +391,7 @@ def should_bcr_validation_block_presubmit(modules, modules_with_metadata_change,
         skip_validation_flags.append("--skip_validation=url_stability")
     if "skip-compatibility-level-check" in pr_labels:
         skip_validation_flags.append("--skip_validation=compatibility_level")
-    if bazelci.PRESUBMIT_AUTO_RUN_LABEL in pr_labels:
+    if any(label in bazelci.PRESUBMIT_AUTO_RUN_LABELS for label in pr_labels):
         skip_validation_flags.append("--skip_validation=presubmit_yml")
     returncode = subprocess.run(
         ["bazel", "run", "//tools:bcr_validation", "--"]

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -695,7 +695,8 @@ CONFIG_FILE_EXTENSIONS = {".yml", ".yaml"}
 
 DEFAULT_PRESUBMIT_CONFIG_PATH = ".bazelci/presubmit.yml"
 
-PRESUBMIT_AUTO_RUN_LABEL = "presubmit-auto-run"
+PRESUBMIT_AUTO_RUN_LABELS = {"presubmit-auto-run", "CI:run"}
+PRESUBMIT_AUTO_RUN_LABEL = PRESUBMIT_AUTO_RUN_LABELS
 
 KYTHE_DIR = "/usr/local/kythe"
 
@@ -3480,7 +3481,10 @@ def create_initial_steps():
 
 
 def has_presubmit_auto_run_label():
-    return PRESUBMIT_AUTO_RUN_LABEL in os.getenv("BUILDKITE_PULL_REQUEST_LABELS", "").split(",")
+    return any(
+        label in PRESUBMIT_AUTO_RUN_LABELS
+        for label in os.getenv("BUILDKITE_PULL_REQUEST_LABELS", "").split(",")
+    )
 
 
 def is_config_file(path):

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -546,15 +546,29 @@ class InitialSteps(unittest.TestCase):
         self.assertIn("block", steps[0])
 
     def test_presubmit_auto_run_label_skips_config_change_block(self):
-        with mock.patch.dict(
-            os.environ,
-            {
-                "BUILDKITE_BRANCH": "feature",
-                "BUILDKITE_PIPELINE_DEFAULT_BRANCH": "main",
-                "BUILDKITE_PULL_REQUEST_LABELS": "foo,presubmit-auto-run,bar",
-            },
-        ), mock.patch.object(bazelci, "get_modified_files") as get_modified_files:
-            steps = bazelci.create_initial_steps()
+        for label in ("presubmit-auto-run", "CI:run"):
+            with self.subTest(label=label):
+                with mock.patch.dict(
+                    os.environ,
+                    {
+                        "BUILDKITE_BRANCH": "feature",
+                        "BUILDKITE_PIPELINE_DEFAULT_BRANCH": "main",
+                        "BUILDKITE_PULL_REQUEST_LABELS": f"foo,{label},bar",
+                    },
+                ), mock.patch.object(bazelci, "get_modified_files") as get_modified_files:
+                    steps = bazelci.create_initial_steps()
+                self.assertEqual(steps, [])
+                get_modified_files.assert_not_called()
+
+    def test_has_presubmit_auto_run_label(self):
+        with mock.patch.dict(os.environ, {"BUILDKITE_PULL_REQUEST_LABELS": ""}):
+            self.assertFalse(bazelci.has_presubmit_auto_run_label())
+        with mock.patch.dict(os.environ, {"BUILDKITE_PULL_REQUEST_LABELS": "foo,bar"}):
+            self.assertFalse(bazelci.has_presubmit_auto_run_label())
+        with mock.patch.dict(os.environ, {"BUILDKITE_PULL_REQUEST_LABELS": "presubmit-auto-run"}):
+            self.assertTrue(bazelci.has_presubmit_auto_run_label())
+        with mock.patch.dict(os.environ, {"BUILDKITE_PULL_REQUEST_LABELS": "foo,CI:run,bar"}):
+            self.assertTrue(bazelci.has_presubmit_auto_run_label())
 
 class FetchCiScripts(unittest.TestCase):
     def test_curl_download_command(self):


### PR DESCRIPTION
Support `CI:run` alongside `presubmit-auto-run` as a label to automatically run presubmits and skip config change review blocks.