### PR TITLE
Remove docker socket mount

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3265,7 +3265,6 @@ def create_docker_step(label, image, commands=None, additional_env_vars=None, qu
                     "/opt/android-sdk-linux:/opt/android-sdk-linux:ro",
                     "/var/lib/buildkite-agent:/var/lib/buildkite-agent",
                     "/var/lib/gitmirrors:/var/lib/gitmirrors:ro",
-                    "/var/run/docker.sock:/var/run/docker.sock",
                 ],
             }
         },


### PR DESCRIPTION
Most uses of this mount point should have been refactored or removed.