### PR TITLE
Shell-quote values interpolated into Buildkite pipeline commands

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3633,7 +3633,7 @@ def create_config_validation_steps(git_commit):
             commands=[
                 fetch_ci_scripts_command(),
                 "{} bazelci.py project_pipeline --file_config={}".format(
-                    PLATFORMS[DEFAULT_PLATFORM]["python"], f
+                    PLATFORMS[DEFAULT_PLATFORM]["python"], shlex.quote(f)
                 ),
             ],
             platform=DEFAULT_PLATFORM,
@@ -3763,16 +3763,18 @@ def fetch_aggregate_incompatible_flags_test_result_command():
 def upload_project_pipeline_step(
     project_name, git_repository, http_config, file_config, git_commit=None
 ):
-    pipeline_command = (
-        '{0} bazelci.py project_pipeline --project_name="{1}" ' + "--git_repository={2}"
-    ).format(PLATFORMS[DEFAULT_PLATFORM]["python"], project_name, git_repository)
+    pipeline_command = "{0} bazelci.py project_pipeline --project_name={1} --git_repository={2}".format(
+        PLATFORMS[DEFAULT_PLATFORM]["python"],
+        shlex.quote(project_name),
+        shlex.quote(git_repository),
+    )
     pipeline_command += " --use_but"
     if http_config:
-        pipeline_command += " --http_config=" + http_config
+        pipeline_command += " --http_config=" + shlex.quote(http_config)
     if file_config:
-        pipeline_command += " --file_config=" + file_config
+        pipeline_command += " --file_config=" + shlex.quote(file_config)
     if git_commit:
-        pipeline_command += " --git_commit=" + git_commit
+        pipeline_command += " --git_commit=" + shlex.quote(git_commit)
     pipeline_command += " | tee /dev/tty | buildkite-agent pipeline upload"
 
     return create_step(

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -686,7 +686,7 @@ class GitBranchHandlingTest(unittest.TestCase):
         commands = step["command"]
         project_pipeline_cmd = [c for c in commands if "project_pipeline" in c][0]
         self.assertIn("--git_commit=origin/35.x", project_pipeline_cmd)
-        self.assertIn('--project_name="Protobuf 35.x"', project_pipeline_cmd)
+        self.assertIn("--project_name='Protobuf 35.x'", project_pipeline_cmd)
         self.assertIn('--file_config=.bazelci/presubmit.yml', project_pipeline_cmd)
 
     def test_print_bazel_downstream_pipeline_passes_origin_branch_as_git_commit(self):


### PR DESCRIPTION
Follow-up to #2666: apply `shlex.quote` consistently to the remaining pipeline-command builders so every value interpolated into a `project_pipeline` command line is quoted the same way.

- `create_config_validation_steps`: quote `--file_config` (the config file name comes from the PR's modified files)
- `upload_project_pipeline_step`: quote `project_name`, `git_repository`, `http_config`, `file_config` and `git_commit` instead of manual double quotes / raw interpolation

Updates the corresponding test expectation to the `shlex.quote` style.