### PR TITLE
Disable Buildkite submodule checkout for Gerrit

### DIFF
--- a/buildkite/terraform/bazel/pipelines_misc.tf
+++ b/buildkite/terraform/bazel/pipelines_misc.tf
@@ -55,7 +55,9 @@ resource "buildkite_pipeline" "gerrit" {
   repository     = "https://gerrit.googlesource.com/gerrit.git"
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
-    envs = {},
+    envs = {
+      BUILDKITE_GIT_SUBMODULES = "false"
+    },
     steps = {
       commands = [
         "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py",


### PR DESCRIPTION
Buildkite's git mirror checkout currently mirrors raw relative URLs from Gerrit's .gitmodules, such as ../java-prettify, from the mirror cache directory. That fails before the pipeline command can upload the Bazel CI steps.

Disable agent-managed submodule checkout for the Gerrit pipeline so the bootstrap step can run. The generated Bazel CI runner still clones Gerrit with --git_repository and runs git submodule update, which resolves relative submodule URLs with Git's normal semantics.

This workaround can be reverted after buildkite/agent#4276 is accepted and the Bazel CI workers run an updated Buildkite agent that includes the fix.

Refs bazelbuild/continuous-integration#2815.
See buildkite/agent#4276 for the upstream agent fix.