### PR TITLE
Skip Buildkite checkout for Gerrit bootstrap

### DIFF
--- a/buildkite/terraform/bazel/pipeline.yml.tpl
+++ b/buildkite/terraform/bazel/pipeline.yml.tpl
@@ -15,6 +15,10 @@ steps:
     %{~ if try(steps.priority, null) != null ~}
     priority: ${steps.priority}
     %{~ endif ~}
+    %{~ if try(steps.skip_checkout, false) ~}
+    checkout:
+      skip: true
+    %{~ endif ~}
     agents:
       - "queue=default"%{ if try(length(steps.artifact_paths), 0) > 0 }
     artifact_paths:%{ for artifact_path in steps.artifact_paths }

--- a/buildkite/terraform/bazel/pipelines_misc.tf
+++ b/buildkite/terraform/bazel/pipelines_misc.tf
@@ -57,6 +57,7 @@ resource "buildkite_pipeline" "gerrit" {
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
     steps = {
+      skip_checkout = true
       commands = [
         "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)\" -o bazelci.py",
         "bash -c 'set -euo pipefail; python3 bazelci.py project_pipeline --http_config=https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/gerrit.yml?$(date +%s) | tee /dev/tty | buildkite-agent pipeline upload'"


### PR DESCRIPTION
Buildkite's git mirror checkout currently mirrors raw relative URLs from Gerrit's .gitmodules, such as ../java-prettify, from the mirror cache directory. That fails before the pipeline command can upload the Bazel CI steps.

Disabling agent-managed submodules avoids that exact failure, but still leaves the bootstrap step doing a full Gerrit checkout and post-checkout clean before running commands. The bootstrap step does not need the checked-out Gerrit tree; it downloads bazelci.py and uploads the generated pipeline.

Add a step-scoped checkout.skip option to the shared pipeline template and enable it only for the Gerrit bootstrap step. Generated build and test steps are uploaded separately and still get their normal checkout.

This workaround can be reverted after buildkite/agent#4276 is accepted and the Bazel CI workers run an updated Buildkite agent that includes the fix.

Refs bazelbuild/continuous-integration#2815.
See buildkite/agent#4276 for the upstream agent fix.