### PR TITLE
Reapply "Fix priority of most important trusted pipelines." (#2822)

### DIFF
--- a/buildkite/terraform/bazel-trusted/pipeline.yml.tpl
+++ b/buildkite/terraform/bazel-trusted/pipeline.yml.tpl
@@ -6,6 +6,7 @@ env:
   ${key}: "${value}"
 %{ endfor ~}
 
+priority: ${try(priority, 0)}
 steps:
   - command: |-%{ for command in steps.commands }
       ${command}%{ endfor }%{ if try(steps.retry, false) }

--- a/buildkite/terraform/bazel-trusted/pipelines_bazel.tf
+++ b/buildkite/terraform/bazel-trusted/pipelines_bazel.tf
@@ -4,6 +4,7 @@ resource "buildkite_pipeline" "mirror-last-green-commit-for-bazel" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "gsutil cp gs://bazel-builds/last_green_commit/github.com/bazelbuild/bazel.git/publish-bazel-binaries gs://bazel-untrusted-builds/last_green_commit/github.com/bazelbuild/bazel.git/bazel-bazel"
@@ -35,6 +36,7 @@ resource "buildkite_pipeline" "java-tools-binaries-java" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/java_tools-binaries.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -87,6 +89,7 @@ resource "buildkite_pipeline" "bazel-java-tools-updates" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/java-tools-testing/pipelines/bazel-java_tools-updates.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -117,6 +120,7 @@ resource "buildkite_pipeline" "java-tools-release" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/java_tools-release.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -147,6 +151,7 @@ resource "buildkite_pipeline" "publish-bazel-binaries" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/publish-bazel-binaries.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -198,6 +203,7 @@ resource "buildkite_pipeline" "bazel-release" {
   default_branch = "release-8.1.0"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 50,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-release.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -250,6 +256,7 @@ resource "buildkite_pipeline" "java-tools-rc" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/java_tools-rc.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"

--- a/buildkite/terraform/bazel-trusted/pipelines_misc.tf
+++ b/buildkite/terraform/bazel-trusted/pipelines_misc.tf
@@ -5,6 +5,7 @@ resource "buildkite_pipeline" "update-git-mirror-tar-ball" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "cd ./gitbundle",
@@ -58,6 +59,7 @@ resource "buildkite_pipeline" "mirror-404-artifacts-for-bazel" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "cd buildkite",
@@ -90,6 +92,7 @@ resource "buildkite_pipeline" "bcr-integrity" {
   default_branch = "main"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/java-tools-testing/pipelines/bcr-integrity.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -123,6 +126,7 @@ resource "buildkite_pipeline" "create-linux-vm-image" {
       BAZEL_VM_NAMES             = "bk-docker,bk-docker-arm64"
       BAZEL_PROD_INSTANCE_GROUPS = "bk-docker,bk-docker-arm64,bk-trusted-docker,bk-trusted-docker-arm64"
     },
+    priority = 100,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/publish-vm-image.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -154,6 +158,7 @@ resource "buildkite_pipeline" "collect-infra-ci-metrics" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "cd buildkite",
@@ -185,7 +190,7 @@ resource "buildkite_pipeline" "create-linux-docker-images" {
   name                       = "Create Linux Docker Images"
   repository                 = "https://github.com/bazelbuild/continuous-integration.git"
   default_branch             = "master"
-  steps                      = "---\nsteps:\n  - command: |-\n      docker builder prune -a -f\n      cd buildkite/docker\n      [ \"$BUILDKITE_BRANCH\" = \"master\" ] || [ \"$BUILDKITE_BRANCH\" = \"testing\" ] && git checkout $BUILDKITE_BRANCH\n      echo \"--- Building docker images...\"\n      ./build.sh\n      echo \"--- Pushing docker images...\"\n      ./push.sh\n    label: \":pipeline: Create images\"\n    agents:\n      - \"queue=default\""
+  steps                      = "---\npriority: 100\nsteps:\n  - command: |-\n      docker builder prune -a -f\n      cd buildkite/docker\n      [ \"$BUILDKITE_BRANCH\" = \"master\" ] || [ \"$BUILDKITE_BRANCH\" = \"testing\" ] && git checkout $BUILDKITE_BRANCH\n      echo \"--- Building docker images...\"\n      ./build.sh\n      echo \"--- Pushing docker images...\"\n      ./push.sh\n    label: \":pipeline: Create images\"\n    agents:\n      - \"queue=default\""
   allow_rebuilds             = true
   cancel_intermediate_builds = false
   skip_intermediate_builds   = false
@@ -228,6 +233,7 @@ resource "buildkite_pipeline" "docgen-bazel-website" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -261,6 +267,7 @@ resource "buildkite_pipeline" "create-windows-vm-image" {
       BAZEL_VM_NAMES             = "bk-windows"
       BAZEL_PROD_INSTANCE_GROUPS = "bk-windows,bk-trusted-windows"
     },
+    priority = 100,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/publish-vm-image.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -291,6 +298,7 @@ resource "buildkite_pipeline" "docgen-bazel-blog" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -343,6 +351,7 @@ resource "buildkite_pipeline" "bcr-postsubmit" {
   default_branch = "main"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 75,
     steps = {
       commands = [
         "curl -sS \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazel-central-registry/bcr_postsubmit.py\" -o bcr_postsubmit.py",
@@ -396,6 +405,7 @@ resource "buildkite_pipeline" "docker-update" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/docker-update.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -427,6 +437,7 @@ resource "buildkite_pipeline" "docgen-bazel" {
   default_branch = "5.1-docs-fixes"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/bazel-docgen.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -455,7 +466,7 @@ resource "buildkite_pipeline" "bazel-ssl-certificate-checker" {
   repository                 = "https://github.com/bazelbuild/bazel.git"
   description                = "a fast, scalable, multi-language and extensible build system"
   default_branch             = "master"
-  steps                      = "---\nsteps:\n  - command: |-\n      python3 .github/scripts/check_ssl.py\n    label: \":lock: SSL Certificate Checker\"\n    agents:\n      - \"queue=default\""
+  steps                      = "---\npriority: 0\nsteps:\n  - command: |-\n      python3 .github/scripts/check_ssl.py\n    label: \":lock: SSL Certificate Checker\"\n    agents:\n      - \"queue=default\""
   allow_rebuilds             = true
   cancel_intermediate_builds = false
   skip_intermediate_builds   = false

--- a/buildkite/terraform/bazel-trusted/pipelines_rules.tf
+++ b/buildkite/terraform/bazel-trusted/pipelines_rules.tf
@@ -6,6 +6,7 @@ resource "buildkite_pipeline" "rules-java-release" {
   default_branch = "master"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/refs/heads/master/pipelines/rules_java-release.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -35,6 +36,7 @@ resource "buildkite_pipeline" "rules-platform-release" {
   default_branch = "main"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/pipelines/rules_platform-release.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"
@@ -65,6 +67,7 @@ resource "buildkite_pipeline" "rules-platform-release-testing" {
   default_branch = "main"
   steps = templatefile("pipeline.yml.tpl", {
     envs = {},
+    priority = 0,
     steps = {
       commands = [
         "bash -c 'set -euo pipefail; curl -s \"https://raw.githubusercontent.com/bazelbuild/continuous-integration/rules_platform-release-testing/pipelines/rules_platform-release-testing.yml?$(date +%s)\" | tee /dev/tty | buildkite-agent pipeline upload --replace'"

--- a/pipelines/bazel-release.yml
+++ b/pipelines/bazel-release.yml
@@ -1,4 +1,5 @@
 ---
+priority: 50
 steps:
   - label: "Set up"
     agents:

--- a/pipelines/publish-vm-image.yml
+++ b/pipelines/publish-vm-image.yml
@@ -1,4 +1,5 @@
 ---
+priority: 100
 steps:
   - command: |-
       cd buildkite


### PR DESCRIPTION
This reverts commit 5b81ed94dbe89092ac599d8d08e9ad72509e95b6.

Additional fix: Explicitly set priority value - TF doesn't like undefined variables, and $try doesn't help either.