### PR TITLE
Remove docker plugin from docker-update pipeline

### DIFF
--- a/pipelines/docker-update.yml
+++ b/pipelines/docker-update.yml
@@ -3,27 +3,6 @@ steps:
   - label: "Docker build and push"
     agents:
       - "queue=default"
-    plugins:
-      docker#v3.8.0:
-        always-pull: true
-        environment:
-          - ANDROID_HOME
-          - ANDROID_NDK_HOME
-          - BUILDKITE_ARTIFACT_UPLOAD_DESTINATION
-        image: gcr.io/bazel-public/ubuntu2004
-        network: host
-        privileged: true
-        propagate-environment: true
-        propagate-uid-gid: true
-        shell: ["/bin/bash", "-e", "-c"]
-        volumes:
-          - "/etc/group:/etc/group:ro"
-          - "/etc/passwd:/etc/passwd:ro"
-          - "/etc/shadow:/etc/shadow:ro"
-          - "/opt/android-ndk-r15c:/opt/android-ndk-r15c:ro"
-          - "/opt/android-sdk-linux:/opt/android-sdk-linux:ro"
-          - "/var/lib/buildkite-agent:/var/lib/buildkite-agent"
-          - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
     command: |
       echo "+++ Checking out Git branch"
       git fetch origin ${BUILDKITE_BRANCH}


### PR DESCRIPTION
Since Docker socket mounting was removed (`/var/run/docker.sock`), docker-in-docker is no longer supported on CI agent containers.

This removes the `docker#v3.8.0` plugin from `pipelines/docker-update.yml` so that Docker commands execute directly on the host VM agent.