### PR TITLE
setup-freebsd.sh: install what building Bazel needs

### DIFF
--- a/buildkite/setup-freebsd.sh
+++ b/buildkite/setup-freebsd.sh
@@ -18,9 +18,17 @@
 set -eux
 
 ## Install Bazel and its dependencies.
+##
+## Building Bazel from source also needs bash, which is not in the base
+## system and which every bootstrap script names in its shebang; a JDK;
+## and python3, since rules_python ships no CPython for FreeBSD and the
+## build falls back to the system interpreter.
 pkg install -y \
+  bash \
   bazel \
   git \
+  openjdk21 \
+  python3 \
   wget \
   zip
 


### PR DESCRIPTION
Reworked to the script alone, following the comment above: the platform
entry is gone, and what is left is a fix to a file already in the
repository.

buildkite/setup-freebsd.sh has been here since 2017 and no platform
refers to it, so nothing has run it in that time. It installs bazel, git,
wget and zip. Building Bazel from source also needs bash, which is not in
the FreeBSD base system and which every bootstrap script names in its
shebang; a JDK; and python3, since rules_python ships no CPython for
FreeBSD and the build falls back to the system interpreter. This adds the
three.

Checked on a stock FreeBSD 15.1 (Vultr's image): before the script bash,
javac and bazel are absent; after it, all three are on the path.

One thing this does not cover, because it is not this repository's: with
JAVA_HOME unset, Bazel's own buildenv.sh defaults to /usr/local/openjdk11
on FreeBSD, which is exactly what the bazel package installs, and that is
too old to build Bazel. That is a change for bazelbuild/bazel,
bazelbuild/bazel#31051.
