### PR TITLE
Stop building ubuntu 18 and 20

### DIFF
--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3506,7 +3506,7 @@ def print_project_pipeline(
             create_step(
                 label=":warning: WARNING: EOL platform detected!",
                 commands=[
-                    f"buildkite-agent annotate --style=warning --context 'eol-platform' 'WARNING!! You are using end-of-life platforms: {eol_platforms_fmt}'. We will stop supporting the platforms soon. If the platforms are business-critical, please file an issue at github.com/bazelbuild/continuous-integration.'",
+                    f"buildkite-agent annotate --style=warning --context 'eol-platform' 'WARNING!! You are using end-of-life platforms: {eol_platforms_fmt}. We will stop supporting the platforms soon. If the platforms are business-critical, please file an issue at github.com/bazelbuild/continuous-integration.'",
                 ],
                 platform=DEFAULT_PLATFORM,
             )

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -328,6 +328,22 @@ DOCKER_REGISTRY_PREFIX = {
     "bazel": "bazel-public",
 }[BUILDKITE_ORG]
 
+
+# Platforms we no longer support, but still exist in the artifact registry.
+# NOTE: These names are the ones use din the PLATFORMS dict, not the
+# IMAGE_HASHES dict.
+EOL_PLATFORMS = frozenset(
+    [
+        "ubuntu1604",
+        "ubuntu1804",
+        "ubuntu1804_java11",
+        "ubuntu2004",
+        "ubuntu2004_arm64",
+        "ubuntu2004_java11",
+        "kythe_ubuntu2004",
+    ]
+)
+
 IMAGE_HASHES = {
     "rockylinux8": {
         "amd64": "sha256:1302e131f7db6d98fffc75f08b900b261d3bc122abeb875b294d43117e2a2466",
@@ -3476,7 +3492,28 @@ def print_project_pipeline(
             )
         )
 
+    # Inform user of EOL platforms
+    eol_platforms_used = sorted(
+        [
+            get_platform_for_task(t, tc)
+            for t, tc in task_configs.items()
+            if get_platform_for_task(t, tc) in EOL_PLATFORMS
+        ]
+    )
+    eol_platforms_fmt = ", ".join(eol_platforms_used)
+    if eol_platforms_used:
+        pipeline_steps.append(
+            create_step(
+                label=":warning: WARNING: EOL platform detected!",
+                commands=[
+                    f"buildkite-agent annotate --style=warning --context 'eol-platform' 'WARNING!! You are using end-of-life platforms: {eol_platforms_fmt}'. We will stop supporting the platform(s) soon. If the platform(s) is/are business-critical, please file an issue at github.com/bazelbuild/continuous-integration.",
+                ],
+                platform=DEFAULT_PLATFORM,
+            )
+        )
+
     print_pipeline_steps(pipeline_steps, handle_emergencies=not is_downstream_pipeline())
+    return pipeline_steps
 
 
 def create_initial_steps():

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3505,7 +3505,13 @@ def print_project_pipeline(
             create_step(
                 label=":warning: WARNING: EOL platform detected!",
                 commands=[
-                    f"buildkite-agent annotate --style=warning --context 'eol-platform' 'WARNING!! You are using end-of-life platforms: {eol_platforms_fmt}. We will stop supporting the platforms soon. If the platforms are business-critical, please file an issue at github.com/bazelbuild/continuous-integration.'",
+                    (
+                        "buildkite-agent annotate --style=warning --context 'eol-platform' "
+                        f"'WARNING!! You are using end-of-life platforms: {eol_platforms_fmt}. "
+                        "We will stop supporting the platforms soon. "
+                        "If the platforms are business-critical, please file an issue at "
+                        "https://github.com/bazelbuild/continuous-integration.'"
+                    ),
                 ],
                 platform=DEFAULT_PLATFORM,
             )

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3506,7 +3506,7 @@ def print_project_pipeline(
             create_step(
                 label=":warning: WARNING: EOL platform detected!",
                 commands=[
-                    f"buildkite-agent annotate --style=warning --context 'eol-platform' 'WARNING!! You are using end-of-life platforms: {eol_platforms_fmt}'. We will stop supporting the platform(s) soon. If the platform(s) is/are business-critical, please file an issue at github.com/bazelbuild/continuous-integration.'",
+                    f"buildkite-agent annotate --style=warning --context 'eol-platform' 'WARNING!! You are using end-of-life platforms: {eol_platforms_fmt}'. We will stop supporting the platforms soon. If the platforms are business-critical, please file an issue at github.com/bazelbuild/continuous-integration.'",
                 ],
                 platform=DEFAULT_PLATFORM,
             )

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -3506,7 +3506,7 @@ def print_project_pipeline(
             create_step(
                 label=":warning: WARNING: EOL platform detected!",
                 commands=[
-                    f"buildkite-agent annotate --style=warning --context 'eol-platform' 'WARNING!! You are using end-of-life platforms: {eol_platforms_fmt}'. We will stop supporting the platform(s) soon. If the platform(s) is/are business-critical, please file an issue at github.com/bazelbuild/continuous-integration.",
+                    f"buildkite-agent annotate --style=warning --context 'eol-platform' 'WARNING!! You are using end-of-life platforms: {eol_platforms_fmt}'. We will stop supporting the platform(s) soon. If the platform(s) is/are business-critical, please file an issue at github.com/bazelbuild/continuous-integration.'",
                 ],
                 platform=DEFAULT_PLATFORM,
             )

--- a/buildkite/bazelci.py
+++ b/buildkite/bazelci.py
@@ -336,7 +336,6 @@ EOL_PLATFORMS = frozenset(
     [
         "ubuntu1604",
         "ubuntu1804",
-        "ubuntu1804_java11",
         "ubuntu2004",
         "ubuntu2004_arm64",
         "ubuntu2004_java11",
@@ -679,7 +678,7 @@ BUILDIFIER_DOCKER_IMAGE = "gcr.io/bazel-public/buildifier"
 MINTLIFY_DOCKER_IMAGE = "gcr.io/bazel-public/{}mintlify".format("testing/" if THIS_IS_TESTING else "")
 
 # The platform used for various steps (e.g. stuff that formerly ran on the "pipeline" workers).
-DEFAULT_PLATFORM = "ubuntu1804"
+DEFAULT_PLATFORM = "ubuntu2404"
 
 # In order to test that "the one Linux binary" that we build for our official releases actually
 # works on all Linux distributions that we test on, we use the Linux binary built on our official

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -766,6 +766,38 @@ class ExecuteCommandTimeout(unittest.TestCase):
             bazelci.upload_test_logs_from_bep("bep.json", "/tmp", monitor_flaky_tests=False)
 
 
+class EolPlatforms(unittest.TestCase):
+    _PLATFORM_FOR_TEST = list(bazelci.EOL_PLATFORMS)[0]
+    _CONFIG = yaml.safe_load(
+        f"""
+tasks:
+    foobar:
+        platform: {_PLATFORM_FOR_TEST}
+"""
+    )
+    def test_eol_platform_has_warning(self):
+        with mock.patch("bazelci.runner_step", return_value=dict({"label": "dummystep"})):
+            steps = bazelci.print_project_pipeline(
+                configs=self._CONFIG,
+                project_name="foobar_project",
+                http_config=None,
+                file_config=None,
+                git_repository=None,
+                git_commit=None,
+                monitor_flaky_tests=None,
+                notify=False,
+                print_shard_summary=False,
+            )
+            # Find all steps that contain the EOL warning
+            warning_steps = list(filter(lambda s: "WARNING: EOL platform detected" in s["label"], steps))
+            # There should only be 1 warning step.
+            self.assertEqual(1, len(warning_steps))
+            # The step should only have 1 command.
+            self.assertEqual(1, len(warning_steps[0]["command"]))
+            # The warning message should be specific to the EOL platform.
+            self.assertTrue(self._PLATFORM_FOR_TEST in warning_steps[0]["command"][0])
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -767,18 +767,28 @@ class ExecuteCommandTimeout(unittest.TestCase):
 
 
 class EolPlatforms(unittest.TestCase):
-    _PLATFORM_FOR_TEST = list(bazelci.EOL_PLATFORMS)[0]
-    _CONFIG = yaml.safe_load(
+    _EOL_PLATFORM_FOR_TEST = sorted(bazelci.EOL_PLATFORMS)[0]
+    _SUPPORTED_PLATFORM_FOR_TEST = sorted(set(bazelci.PLATFORMS.keys()) - bazelci.EOL_PLATFORMS)[0]
+    _CONFIG_WITH_EOL_PLATFORM = yaml.safe_load(
         f"""
 tasks:
-    foobar:
-        platform: {_PLATFORM_FOR_TEST}
+    foobar_eol:
+        platform: {_EOL_PLATFORM_FOR_TEST}
 """
     )
-    def test_eol_platform_has_warning(self):
-        with mock.patch("bazelci.runner_step", return_value=dict({"label": "dummystep"})):
+    _CONFIG_WITH_SUPPORTED_PLATFORM = yaml.safe_load(
+        f"""
+tasks:
+    foobar_supported:
+        platform: {_SUPPORTED_PLATFORM_FOR_TEST}
+"""
+    )
+
+    def get_steps_no_stdout(self, config):
+        # Silence stdout to avoid polluting console when running unit test
+        with mock.patch("sys.stdout") as _:
             steps = bazelci.print_project_pipeline(
-                configs=self._CONFIG,
+                configs=config,
                 project_name="foobar_project",
                 http_config=None,
                 file_config=None,
@@ -788,14 +798,26 @@ tasks:
                 notify=False,
                 print_shard_summary=False,
             )
-            # Find all steps that contain the EOL warning
-            warning_steps = list(filter(lambda s: "WARNING: EOL platform detected" in s["label"], steps))
-            # There should only be 1 warning step.
-            self.assertEqual(1, len(warning_steps))
-            # The step should only have 1 command.
-            self.assertEqual(1, len(warning_steps[0]["command"]))
-            # The warning message should be specific to the EOL platform.
-            self.assertTrue(self._PLATFORM_FOR_TEST in warning_steps[0]["command"][0])
+            return steps
+
+    def test_eol_platform_has_warning(self):
+        steps = self.get_steps_no_stdout(self._CONFIG_WITH_EOL_PLATFORM)
+        # Find all steps that contain the EOL warning
+        warning_steps = list(filter(lambda s: "WARNING: EOL platform detected" in s["label"], steps))
+        # There should only be 1 warning step.
+        self.assertEqual(1, len(warning_steps))
+        # The step should only have 1 command.
+        self.assertEqual(1, len(warning_steps[0]["command"]))
+        # The warning message should be specific to the EOL platform.
+        self.assertTrue(self._EOL_PLATFORM_FOR_TEST in warning_steps[0]["command"][0])
+
+    def test_supported_platform_has_no_warning(self):
+        steps = self.get_steps_no_stdout(self._CONFIG_WITH_SUPPORTED_PLATFORM)
+        # Find all steps that contain the EOL warning (there should be none)
+        warning_steps = list(filter(lambda s: "WARNING: EOL platform detected" in s["label"], steps))
+        # There should be no warning steps.
+        self.assertEqual(0, len(warning_steps))
+
 
 
 if __name__ == "__main__":

--- a/buildkite/bazelci_test.py
+++ b/buildkite/bazelci_test.py
@@ -769,20 +769,16 @@ class ExecuteCommandTimeout(unittest.TestCase):
 class EolPlatforms(unittest.TestCase):
     _EOL_PLATFORM_FOR_TEST = sorted(bazelci.EOL_PLATFORMS)[0]
     _SUPPORTED_PLATFORM_FOR_TEST = sorted(set(bazelci.PLATFORMS.keys()) - bazelci.EOL_PLATFORMS)[0]
-    _CONFIG_WITH_EOL_PLATFORM = yaml.safe_load(
-        f"""
+    _CONFIG_WITH_EOL_PLATFORM = yaml.safe_load(f"""
 tasks:
     foobar_eol:
         platform: {_EOL_PLATFORM_FOR_TEST}
-"""
-    )
-    _CONFIG_WITH_SUPPORTED_PLATFORM = yaml.safe_load(
-        f"""
+""")
+    _CONFIG_WITH_SUPPORTED_PLATFORM = yaml.safe_load(f"""
 tasks:
     foobar_supported:
         platform: {_SUPPORTED_PLATFORM_FOR_TEST}
-"""
-    )
+""")
 
     def get_steps_no_stdout(self, config):
         # Silence stdout to avoid polluting console when running unit test
@@ -803,7 +799,9 @@ tasks:
     def test_eol_platform_has_warning(self):
         steps = self.get_steps_no_stdout(self._CONFIG_WITH_EOL_PLATFORM)
         # Find all steps that contain the EOL warning
-        warning_steps = list(filter(lambda s: "WARNING: EOL platform detected" in s["label"], steps))
+        warning_steps = list(
+            filter(lambda s: "WARNING: EOL platform detected" in s["label"], steps)
+        )
         # There should only be 1 warning step.
         self.assertEqual(1, len(warning_steps))
         # The step should only have 1 command.
@@ -814,12 +812,12 @@ tasks:
     def test_supported_platform_has_no_warning(self):
         steps = self.get_steps_no_stdout(self._CONFIG_WITH_SUPPORTED_PLATFORM)
         # Find all steps that contain the EOL warning (there should be none)
-        warning_steps = list(filter(lambda s: "WARNING: EOL platform detected" in s["label"], steps))
+        warning_steps = list(
+            filter(lambda s: "WARNING: EOL platform detected" in s["label"], steps)
+        )
         # There should be no warning steps.
         self.assertEqual(0, len(warning_steps))
 
 
-
 if __name__ == "__main__":
     unittest.main()
-

--- a/buildkite/docker/build.sh
+++ b/buildkite/docker/build.sh
@@ -58,16 +58,13 @@ function docker_build() {
 }
 
 # Containers used by Bazel
-# For Rocky Linux & Ubuntu 20.04 we build multi-platform images.
+# For Rocky Linux & Ubuntu we build multi-platform images.
 pids=()
 docker_build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target rockylinux8 -t "gcr.io/$PREFIX/rockylinux8"  rockylinux8 & pids+=($!)
 docker_build -f debian10/Dockerfile   --target debian10-java11   -t "gcr.io/$PREFIX/debian10-java11" debian10 & pids+=($!)
 docker_build -f debian11/Dockerfile   --target debian11-java17   -t "gcr.io/$PREFIX/debian11-java17" debian11 & pids+=($!)
 docker_build -f debian12/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target debian12-java17   -t "gcr.io/$PREFIX/debian12" debian12 & pids+=($!)
 docker_build -f debian13/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target debian13-java21   -t "gcr.io/$PREFIX/debian13" debian13 & pids+=($!)
-docker_build -f ubuntu1804/Dockerfile --target ubuntu1804-java11 -t "gcr.io/$PREFIX/ubuntu1804-java11" ubuntu1804 & pids+=($!)
-docker_build -f ubuntu2004/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2004-java11 -t "gcr.io/$PREFIX/ubuntu2004-java11" ubuntu2004 & pids+=($!)
-docker_build -f ubuntu2004/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2004        -t "gcr.io/$PREFIX/ubuntu2004" ubuntu2004 & pids+=($!)
 docker_build -f ubuntu2204/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2204-java17 -t "gcr.io/$PREFIX/ubuntu2204-java17" ubuntu2204 & pids+=($!)
 docker_build -f ubuntu2204/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2204        -t "gcr.io/$PREFIX/ubuntu2204" ubuntu2204 & pids+=($!)
 docker_build -f ubuntu2404/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2404        -t "gcr.io/$PREFIX/ubuntu2404" ubuntu2404 & pids+=($!)
@@ -83,8 +80,6 @@ docker_build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=l
 docker_build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target rockylinux8-java11              -t "gcr.io/$PREFIX/rockylinux8-java11"                rockylinux8
 docker_build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target rockylinux8-java11-devtoolset10 -t "gcr.io/$PREFIX/rockylinux8-java11-devtoolset10"   rockylinux8
 docker_build -f rockylinux8/Dockerfile  --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target rockylinux8-releaser            -t "gcr.io/$PREFIX/rockylinux8-releaser"              rockylinux8
-docker_build -f ubuntu1804/Dockerfile --target ubuntu1804-bazel-java11     -t "gcr.io/$PREFIX/ubuntu1804-bazel-java11" ubuntu1804
-docker_build -f ubuntu2004/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2004-bazel-java11     -t "gcr.io/$PREFIX/ubuntu2004-bazel-java11" ubuntu2004
 docker_build -f ubuntu2204/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2204-kythe            -t "gcr.io/$PREFIX/ubuntu2204-kythe" ubuntu2204
 docker_build -f ubuntu2204/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2204-bazel-java17     -t "gcr.io/$PREFIX/ubuntu2204-bazel-java17" ubuntu2204
 docker_build -f ubuntu2404/Dockerfile   --builder mp-builder --load --platform=linux/amd64,linux/arm64 --target ubuntu2404-kythe            -t "gcr.io/$PREFIX/ubuntu2404-kythe" ubuntu2404

--- a/buildkite/docker/push.sh
+++ b/buildkite/docker/push.sh
@@ -24,11 +24,6 @@ docker push "gcr.io/$PREFIX/debian10-java11" &
 docker push "gcr.io/$PREFIX/debian11-java17" &
 docker push "gcr.io/$PREFIX/debian12" &
 docker push "gcr.io/$PREFIX/debian13" &
-docker push "gcr.io/$PREFIX/ubuntu1804-bazel-java11" &
-docker push "gcr.io/$PREFIX/ubuntu1804-java11" &
-docker push "gcr.io/$PREFIX/ubuntu2004-bazel-java11" &
-docker push "gcr.io/$PREFIX/ubuntu2004-java11" &
-docker push "gcr.io/$PREFIX/ubuntu2004" &
 docker push "gcr.io/$PREFIX/ubuntu2204-java17" &
 docker push "gcr.io/$PREFIX/ubuntu2204-kythe" &
 docker push "gcr.io/$PREFIX/ubuntu2204-bazel-java17" &


### PR DESCRIPTION
These platforms are far past EOL. We will stop building them. This PR also adds a warning in the buildkite UI for deprecated platforms, and adds a unit test asserting that the warning is correct.